### PR TITLE
Avoid catching CancellationException

### DIFF
--- a/stream-android-core/src/main/kotlin/io/getstream/android/core/http/XStreamClient.kt
+++ b/stream-android-core/src/main/kotlin/io/getstream/android/core/http/XStreamClient.kt
@@ -2,6 +2,7 @@ package io.getstream.android.core.http
 
 import android.content.Context
 import android.os.Build
+import io.getstream.android.core.result.runSafely
 import io.getstream.kotlin.base.annotation.marker.StreamInternalApi
 
 /**
@@ -96,9 +97,9 @@ public class XStreamClient private constructor(public val value: String) {
          * @return The version name (e.g., "1.2.3") or `"nameNotFound"` if retrieval fails.
          */
         private fun getAppVersion(context: Context): String {
-            return runCatching {
+            return runSafely {
                 context.packageManager
-                    ?.getPackageInfo(context.packageName ?: return@runCatching null, 0)
+                    ?.getPackageInfo(context.packageName ?: return@runSafely null, 0)
                     ?.versionName
             }.getOrNull() ?: "nameNotFound"
         }

--- a/stream-android-core/src/main/kotlin/io/getstream/android/core/network/NetworkStateProvider.kt
+++ b/stream-android-core/src/main/kotlin/io/getstream/android/core/network/NetworkStateProvider.kt
@@ -5,6 +5,7 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
 import android.os.Build
+import io.getstream.android.core.result.runSafely
 import io.getstream.kotlin.base.annotation.marker.StreamInternalApi
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -81,7 +82,7 @@ public class NetworkStateProvider(
      */
     public fun isConnected(): Boolean {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            runCatching {
+            runSafely {
                 connectivityManager.run {
                     getNetworkCapabilities(activeNetwork)?.run {
                         hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) &&

--- a/stream-android-core/src/main/kotlin/io/getstream/android/core/result/ResultUtils.kt
+++ b/stream-android-core/src/main/kotlin/io/getstream/android/core/result/ResultUtils.kt
@@ -1,0 +1,23 @@
+package io.getstream.android.core.result
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Runs a block of code and returns a [Result] containing the outcome.
+ *
+ * If the block completes successfully, the result is a success with the value returned by the block.
+ * If an exception is thrown, it is caught and wrapped in a failure result.
+ * Cancellation exceptions are rethrown to allow coroutine cancellation to propagate.
+ *
+ * @param block The block of code to execute.
+ * @return A [Result] containing either the successful value or the exception.
+ */
+public inline fun <T> runSafely(block: () -> T): Result<T> {
+    return try {
+        Result.success(block())
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+}

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/common/StreamSubscriptionManager.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/common/StreamSubscriptionManager.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.common
 
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.subscribe.StreamSubscriber
 import io.getstream.feeds.android.client.api.subscribe.StreamSubscription
 import io.getstream.feeds.android.client.internal.log.provideLogger
@@ -51,7 +52,7 @@ internal class StreamSubscriptionManagerImpl<T : StreamSubscriber>(
 
     private val subscribers = ConcurrentHashMap<T, Unit>()
 
-    override fun subscribe(listener: T): Result<StreamSubscription> = runCatching {
+    override fun subscribe(listener: T): Result<StreamSubscription> = runSafely {
         if (subscribers.size >= maxSubscriptions) {
             logger.e {
                 """
@@ -70,12 +71,12 @@ internal class StreamSubscriptionManagerImpl<T : StreamSubscriber>(
         }
     }
 
-    override fun clear(): Result<Unit> = runCatching {
+    override fun clear(): Result<Unit> = runSafely {
         subscribers.clear()
         logger.v { "[clear] Cleared all subscribers" }
     }
 
-    override fun forEach(block: (T) -> Unit) = runCatching {
+    override fun forEach(block: (T) -> Unit) = runSafely {
         subscribers.keys.forEach(block)
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.repository
 
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.model.ActivityData
 import io.getstream.feeds.android.client.api.model.FeedId
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
@@ -30,35 +31,35 @@ internal class ActivitiesRepositoryImpl(
 ) : ActivitiesRepository {
 
     override suspend fun addActivity(request: AddActivityRequest): Result<ActivityData> =
-        runCatching {
+        runSafely {
             api.addActivity(request).activity.toModel()
         }
 
     override suspend fun deleteActivity(
         activityId: String,
         hardDelete: Boolean
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runSafely {
         api.deleteActivity(activityId, hardDelete)
     }
 
-    override suspend fun getActivity(activityId: String): Result<ActivityData> = runCatching {
+    override suspend fun getActivity(activityId: String): Result<ActivityData> = runSafely {
         api.getActivity(activityId).activity.toModel()
     }
 
     override suspend fun updateActivity(
         activityId: String,
         request: UpdateActivityRequest
-    ): Result<ActivityData> = runCatching {
+    ): Result<ActivityData> = runSafely {
         api.updateActivity(activityId, request).activity.toModel()
     }
 
     override suspend fun upsertActivities(activities: List<ActivityRequest>): Result<List<ActivityData>> =
-        runCatching {
+        runSafely {
             val request = UpsertActivitiesRequest(activities)
             api.upsertActivities(request).activities.map { it.toModel() }
         }
 
-    override suspend fun pin(activityId: String, fid: FeedId): Result<ActivityData> = runCatching {
+    override suspend fun pin(activityId: String, fid: FeedId): Result<ActivityData> = runSafely {
         api.pinActivity(
             feedGroupId = fid.group,
             feedId = fid.id,
@@ -69,7 +70,7 @@ internal class ActivitiesRepositoryImpl(
     override suspend fun unpin(
         activityId: String,
         fid: FeedId,
-    ): Result<ActivityData> = runCatching {
+    ): Result<ActivityData> = runSafely {
         api.unpinActivity(
             feedGroupId = fid.group,
             feedId = fid.id,
@@ -81,13 +82,13 @@ internal class ActivitiesRepositoryImpl(
         feedGroupId: String,
         feedId: String,
         request: MarkActivityRequest
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runSafely {
         api.markActivity(feedGroupId = feedGroupId, feedId = feedId, markActivityRequest = request)
     }
 
     override suspend fun queryActivities(
         query: ActivitiesQuery
-    ): Result<PaginationResult<ActivityData>> = runCatching {
+    ): Result<PaginationResult<ActivityData>> = runSafely {
         val request = query.toRequest()
         val response = api.queryActivities(request)
         PaginationResult(
@@ -99,21 +100,21 @@ internal class ActivitiesRepositoryImpl(
     override suspend fun addReaction(
         activityId: String,
         request: AddReactionRequest
-    ): Result<FeedsReactionData> = runCatching {
+    ): Result<FeedsReactionData> = runSafely {
         api.addReaction(activityId, request).reaction.toModel()
     }
 
     override suspend fun deleteReaction(
         activityId: String,
         type: String
-    ): Result<FeedsReactionData> = runCatching {
+    ): Result<FeedsReactionData> = runSafely {
         api.deleteActivityReaction(activityId = activityId, type = type).reaction.toModel()
     }
 
     override suspend fun queryActivityReactions(
         activityId: String,
         request: QueryActivityReactionsRequest
-    ): Result<PaginationResult<FeedsReactionData>> = runCatching {
+    ): Result<PaginationResult<FeedsReactionData>> = runSafely {
         val response = api.queryActivityReactions(activityId, request)
         PaginationResult(
             models = response.reactions.map { it.toModel() },

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/BookmarksRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/BookmarksRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.repository
 
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.model.BookmarkData
 import io.getstream.feeds.android.client.api.model.BookmarkFolderData
 import io.getstream.feeds.android.client.api.model.PaginationData
@@ -23,7 +24,7 @@ internal class BookmarksRepositoryImpl(private val api: ApiService) : BookmarksR
 
     override suspend fun queryBookmarks(
         query: BookmarksQuery
-    ): Result<PaginationResult<BookmarkData>> = runCatching {
+    ): Result<PaginationResult<BookmarkData>> = runSafely {
         val response = api.queryBookmarks(query.toRequest())
         PaginationResult(
             models = response.bookmarks.map { it.toModel() },
@@ -34,27 +35,27 @@ internal class BookmarksRepositoryImpl(private val api: ApiService) : BookmarksR
     override suspend fun addBookmark(
         activityId: String,
         request: AddBookmarkRequest
-    ): Result<BookmarkData> = runCatching {
+    ): Result<BookmarkData> = runSafely {
         api.addBookmark(activityId, request).bookmark.toModel()
     }
 
     override suspend fun deleteBookmark(
         activityId: String,
         folderId: String?
-    ): Result<BookmarkData> = runCatching {
+    ): Result<BookmarkData> = runSafely {
         api.deleteBookmark(activityId, folderId).bookmark.toModel()
     }
 
     override suspend fun updateBookmark(
         activityId: String,
         request: UpdateBookmarkRequest
-    ): Result<BookmarkData> = runCatching {
+    ): Result<BookmarkData> = runSafely {
         api.updateBookmark(activityId, request).bookmark.toModel()
     }
 
     override suspend fun queryBookmarkFolders(
         query: BookmarkFoldersQuery
-    ): Result<PaginationResult<BookmarkFolderData>> = runCatching {
+    ): Result<PaginationResult<BookmarkFolderData>> = runSafely {
         val response = api.queryBookmarkFolders(query.toRequest())
         PaginationResult(
             models = response.bookmarkFolders.map { it.toModel() },

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.repository
 
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.model.CommentData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.PaginationData
@@ -28,7 +29,7 @@ internal class CommentsRepositoryImpl(private val api: ApiService) : CommentsRep
 
     override suspend fun queryComments(
         query: CommentsQuery,
-    ): Result<PaginationResult<CommentData>> = runCatching {
+    ): Result<PaginationResult<CommentData>> = runSafely {
         val response = api.queryComments(query.toRequest())
         PaginationResult(
             models = response.comments.map { it.toModel() },
@@ -38,7 +39,7 @@ internal class CommentsRepositoryImpl(private val api: ApiService) : CommentsRep
 
     override suspend fun getComments(
         query: ActivityCommentsQuery,
-    ): Result<PaginationResult<ThreadedCommentData>> = runCatching {
+    ): Result<PaginationResult<ThreadedCommentData>> = runSafely {
         val response = api.getComments(
             objectId = query.objectId,
             objectType = query.objectType,
@@ -54,35 +55,35 @@ internal class CommentsRepositoryImpl(private val api: ApiService) : CommentsRep
         )
     }
 
-    override suspend fun addComment(request: AddCommentRequest): Result<CommentData> = runCatching {
+    override suspend fun addComment(request: AddCommentRequest): Result<CommentData> = runSafely {
         api.addComment(request).comment.toModel()
     }
 
     override suspend fun addCommentsBatch(
         request: AddCommentsBatchRequest,
-    ): Result<List<CommentData>> = runCatching {
+    ): Result<List<CommentData>> = runSafely {
         api.addCommentsBatch(request).comments.map { it.toModel() }
     }
 
-    override suspend fun deleteComment(commentId: String): Result<Unit> = runCatching {
+    override suspend fun deleteComment(commentId: String): Result<Unit> = runSafely {
         api.deleteComment(commentId)
     }
 
-    override suspend fun getComment(commentId: String): Result<CommentData> = runCatching {
+    override suspend fun getComment(commentId: String): Result<CommentData> = runSafely {
         api.getComment(commentId).comment.toModel()
     }
 
     override suspend fun updateComment(
         commentId: String,
         request: UpdateCommentRequest,
-    ): Result<CommentData> = runCatching {
+    ): Result<CommentData> = runSafely {
         api.updateComment(commentId, request).comment.toModel()
     }
 
     override suspend fun addCommentReaction(
         commentId: String,
         request: AddCommentReactionRequest,
-    ): Result<Pair<FeedsReactionData, String>> = runCatching {
+    ): Result<Pair<FeedsReactionData, String>> = runSafely {
         val response = api.addCommentReaction(commentId, request)
         Pair(response.reaction.toModel(), response.comment.id)
     }
@@ -90,7 +91,7 @@ internal class CommentsRepositoryImpl(private val api: ApiService) : CommentsRep
     override suspend fun deleteCommentReaction(
         commentId: String,
         type: String,
-    ): Result<Pair<FeedsReactionData, String>> = runCatching {
+    ): Result<Pair<FeedsReactionData, String>> = runSafely {
         val response = api.deleteCommentReaction(commentId = commentId, type = type)
         Pair(response.reaction.toModel(), response.comment.id)
     }
@@ -98,7 +99,7 @@ internal class CommentsRepositoryImpl(private val api: ApiService) : CommentsRep
     override suspend fun queryCommentReactions(
         commentId: String,
         query: CommentReactionsQuery,
-    ): Result<PaginationResult<FeedsReactionData>> = runCatching {
+    ): Result<PaginationResult<FeedsReactionData>> = runSafely {
         val response = api.queryCommentReactions(commentId, query.toRequest())
         PaginationResult(
             models = response.reactions.map { it.toModel() },
@@ -108,7 +109,7 @@ internal class CommentsRepositoryImpl(private val api: ApiService) : CommentsRep
 
     override suspend fun getCommentReplies(
         query: CommentRepliesQuery,
-    ): Result<PaginationResult<ThreadedCommentData>> = runCatching {
+    ): Result<PaginationResult<ThreadedCommentData>> = runSafely {
         val response = api.getCommentReplies(
             commentId = query.commentId,
             depth = query.depth,

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package io.getstream.feeds.android.client.internal.repository
 
 import io.getstream.android.core.query.sortedWith
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.model.FeedData
 import io.getstream.feeds.android.client.api.model.FeedId
 import io.getstream.feeds.android.client.api.model.FeedMemberData
@@ -32,7 +33,7 @@ import io.getstream.feeds.android.core.generated.models.UpdateFeedRequest
  */
 internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepository {
 
-    override suspend fun getOrCreateFeed(query: FeedQuery): Result<GetOrCreateInfo> = runCatching {
+    override suspend fun getOrCreateFeed(query: FeedQuery): Result<GetOrCreateInfo> = runSafely {
         val fid = query.fid
         val request = query.toRequest()
         val response = api.getOrCreateFeed(
@@ -68,7 +69,7 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
         )
     }
 
-    override suspend fun stopWatching(groupId: String, feedId: String): Result<Unit> = runCatching {
+    override suspend fun stopWatching(groupId: String, feedId: String): Result<Unit> = runSafely {
         api.stopWatchingFeed(feedGroupId = groupId, feedId = feedId)
     }
 
@@ -76,7 +77,7 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
         feedGroupId: String,
         feedId: String,
         hardDelete: Boolean
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runSafely {
         api.deleteFeed(feedGroupId = feedGroupId, feedId = feedId, hardDelete = hardDelete)
     }
 
@@ -84,7 +85,7 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
         feedGroupId: String,
         feedId: String,
         request: UpdateFeedRequest
-    ): Result<FeedData> = runCatching {
+    ): Result<FeedData> = runSafely {
         api.updateFeed(
             feedGroupId = feedGroupId,
             feedId = feedId,
@@ -93,7 +94,7 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
     }
 
     override suspend fun queryFeeds(query: FeedsQuery): Result<PaginationResult<FeedData>> =
-        runCatching {
+        runSafely {
             val request = query.toRequest()
             val response = api.feedsQueryFeeds(queryFeedsRequest = request)
             val feeds = response.feeds.map { it.toModel() }
@@ -104,7 +105,7 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
     override suspend fun queryFollowSuggestions(
         feedGroupId: String,
         limit: Int?
-    ): Result<List<FeedData>> = runCatching {
+    ): Result<List<FeedData>> = runSafely {
         api.getFollowSuggestions(feedGroupId = feedGroupId, limit = limit)
             .suggestions
             .map { it.toModel() }
@@ -113,31 +114,31 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
     override suspend fun queryFollows(
         request: QueryFollowsRequest
     ): Result<PaginationResult<FollowData>> =
-        runCatching {
+        runSafely {
             val response = api.queryFollows(request)
             val follows = response.follows.map { it.toModel() }
             val pagination = PaginationData(next = response.next, previous = response.prev)
             PaginationResult(follows, pagination)
         }
 
-    override suspend fun follow(request: SingleFollowRequest): Result<FollowData> = runCatching {
+    override suspend fun follow(request: SingleFollowRequest): Result<FollowData> = runSafely {
         api.follow(request).follow.toModel()
     }
 
     override suspend fun unfollow(
         source: FeedId,
         target: FeedId
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runSafely {
         api.unfollow(source = source.rawValue, target = target.rawValue)
     }
 
     override suspend fun acceptFollow(request: AcceptFollowRequest): Result<FollowData> =
-        runCatching {
+        runSafely {
             api.acceptFollow(request).follow.toModel()
         }
 
     override suspend fun rejectFollow(request: RejectFollowRequest): Result<FollowData> =
-        runCatching {
+        runSafely {
             api.rejectFollow(request).follow.toModel()
         }
 
@@ -145,7 +146,7 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
         feedGroupId: String,
         feedId: String,
         request: UpdateFeedMembersRequest
-    ): Result<ModelUpdates<FeedMemberData>> = runCatching {
+    ): Result<ModelUpdates<FeedMemberData>> = runSafely {
         val response = api.updateFeedMembers(
             feedGroupId = feedGroupId,
             feedId = feedId,
@@ -160,14 +161,14 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
     override suspend fun acceptFeedMember(
         feedGroupId: String,
         feedId: String
-    ): Result<FeedMemberData> = runCatching {
+    ): Result<FeedMemberData> = runSafely {
         api.acceptFeedMemberInvite(feedGroupId = feedGroupId, feedId = feedId).member.toModel()
     }
 
     override suspend fun rejectFeedMember(
         feedGroupId: String,
         feedId: String
-    ): Result<FeedMemberData> = runCatching {
+    ): Result<FeedMemberData> = runSafely {
         api.rejectFeedMemberInvite(feedGroupId = feedGroupId, feedId = feedId).member.toModel()
     }
 
@@ -175,7 +176,7 @@ internal class FeedsRepositoryImpl(private val api: ApiService) : FeedsRepositor
         feedGroupId: String,
         feedId: String,
         request: QueryFeedMembersRequest
-    ): Result<PaginationResult<FeedMemberData>> = runCatching {
+    ): Result<PaginationResult<FeedMemberData>> = runSafely {
         val response = api.queryFeedMembers(
             feedGroupId = feedGroupId,
             feedId = feedId,

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ModerationRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ModerationRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.repository
 
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.model.ModerationConfigData
 import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
@@ -39,7 +40,7 @@ internal class ModerationRepositoryImpl(private val api: ApiService) : Moderatio
 
     override suspend fun queryModerationConfigs(
         query: ModerationConfigsQuery,
-    ): Result<PaginationResult<ModerationConfigData>> = runCatching {
+    ): Result<PaginationResult<ModerationConfigData>> = runSafely {
         val response = api.queryModerationConfigs(query.toRequest())
         PaginationResult(
             models = response.configs.map { it.toModel() },
@@ -47,69 +48,69 @@ internal class ModerationRepositoryImpl(private val api: ApiService) : Moderatio
         )
     }
 
-    override suspend fun ban(banRequest: BanRequest): Result<BanResponse> = runCatching {
+    override suspend fun ban(banRequest: BanRequest): Result<BanResponse> = runSafely {
         api.ban(banRequest)
     }
 
-    override suspend fun mute(muteRequest: MuteRequest): Result<MuteResponse> = runCatching {
+    override suspend fun mute(muteRequest: MuteRequest): Result<MuteResponse> = runSafely {
         api.mute(muteRequest)
     }
 
     override suspend fun blockUser(
         blockUserRequest: BlockUsersRequest,
-    ): Result<BlockUsersResponse> = runCatching {
+    ): Result<BlockUsersResponse> = runSafely {
         api.blockUsers(blockUserRequest)
     }
 
     override suspend fun unblockUser(
         unblockUserRequest: UnblockUsersRequest,
-    ): Result<UnblockUsersResponse> = runCatching {
+    ): Result<UnblockUsersResponse> = runSafely {
         api.unblockUsers(unblockUserRequest)
     }
 
-    override suspend fun getBlockedUsers(): Result<GetBlockedUsersResponse> = runCatching {
+    override suspend fun getBlockedUsers(): Result<GetBlockedUsersResponse> = runSafely {
         api.getBlockedUsers()
     }
 
-    override suspend fun flag(flagRequest: FlagRequest): Result<FlagResponse> = runCatching {
+    override suspend fun flag(flagRequest: FlagRequest): Result<FlagResponse> = runSafely {
         api.flag(flagRequest)
     }
 
     override suspend fun submitAction(
         submitActionRequest: SubmitActionRequest,
-    ): Result<SubmitActionResponse> = runCatching {
+    ): Result<SubmitActionResponse> = runSafely {
         api.submitAction(submitActionRequest)
     }
 
     override suspend fun queryReviewQueue(
         queryReviewQueueRequest: QueryReviewQueueRequest,
-    ): Result<QueryReviewQueueResponse> = runCatching {
+    ): Result<QueryReviewQueueResponse> = runSafely {
         api.queryReviewQueue(queryReviewQueueRequest)
     }
 
     override suspend fun upsertConfig(
         upsertConfigRequest: UpsertConfigRequest,
-    ): Result<UpsertConfigResponse> = runCatching {
+    ): Result<UpsertConfigResponse> = runSafely {
         api.upsertConfig(upsertConfigRequest)
     }
 
     override suspend fun deleteConfig(
         key: String,
         team: String?
-    ): Result<DeleteModerationConfigResponse> = runCatching {
+    ): Result<DeleteModerationConfigResponse> = runSafely {
         api.deleteConfig(key = key, team = team)
     }
 
     override suspend fun getConfig(
         key: String,
         team: String?
-    ): Result<GetConfigResponse> = runCatching {
+    ): Result<GetConfigResponse> = runSafely {
         api.getConfig(key = key, team = team)
     }
 
     override suspend fun queryModerationConfigs(
         queryModerationConfigsRequest: QueryModerationConfigsRequest,
-    ): Result<QueryModerationConfigsResponse> = runCatching {
+    ): Result<QueryModerationConfigsResponse> = runSafely {
         api.queryModerationConfigs(queryModerationConfigsRequest)
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/PollsRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/PollsRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.repository
 
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.model.PollData
@@ -26,44 +27,44 @@ import io.getstream.feeds.android.core.generated.models.UpdatePollRequest
  */
 internal class PollsRepositoryImpl(private val api: ApiService) : PollsRepository {
 
-    override suspend fun closePoll(pollId: String): Result<PollData> = runCatching {
+    override suspend fun closePoll(pollId: String): Result<PollData> = runSafely {
         val request = UpdatePollPartialRequest(set = mapOf("is_closed" to true))
         api.updatePollPartial(pollId, request).poll.toModel()
     }
 
-    override suspend fun createPoll(request: CreatePollRequest): Result<PollData> = runCatching {
+    override suspend fun createPoll(request: CreatePollRequest): Result<PollData> = runSafely {
         api.createPoll(request).poll.toModel()
     }
 
     override suspend fun deletePoll(
         pollId: String,
         userId: String?
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runSafely {
         api.deletePoll(pollId = pollId, userId = userId)
     }
 
     override suspend fun getPoll(
         pollId: String,
         userId: String?
-    ): Result<PollData> = runCatching {
+    ): Result<PollData> = runSafely {
         api.getPoll(pollId = pollId, userId = userId).poll.toModel()
     }
 
     override suspend fun updatePollPartial(
         pollId: String,
         request: UpdatePollPartialRequest
-    ): Result<PollData> = runCatching {
+    ): Result<PollData> = runSafely {
         api.updatePollPartial(pollId, request).poll.toModel()
     }
 
-    override suspend fun updatePoll(request: UpdatePollRequest): Result<PollData> = runCatching {
+    override suspend fun updatePoll(request: UpdatePollRequest): Result<PollData> = runSafely {
         api.updatePoll(request).poll.toModel()
     }
 
     override suspend fun createPollOption(
         pollId: String,
         request: CreatePollOptionRequest
-    ): Result<PollOptionData> = runCatching {
+    ): Result<PollOptionData> = runSafely {
         api.createPollOption(pollId, request).pollOption.toModel()
     }
 
@@ -71,7 +72,7 @@ internal class PollsRepositoryImpl(private val api: ApiService) : PollsRepositor
         pollId: String,
         optionId: String,
         userId: String?
-    ): Result<Unit> = runCatching {
+    ): Result<Unit> = runSafely {
         api.deletePollOption(pollId = pollId, optionId = optionId, userId = userId)
     }
 
@@ -79,7 +80,7 @@ internal class PollsRepositoryImpl(private val api: ApiService) : PollsRepositor
         pollId: String,
         optionId: String,
         userId: String?
-    ): Result<PollOptionData> = runCatching {
+    ): Result<PollOptionData> = runSafely {
         api.getPollOption(
             pollId = pollId,
             optionId = optionId,
@@ -90,13 +91,13 @@ internal class PollsRepositoryImpl(private val api: ApiService) : PollsRepositor
     override suspend fun updatePollOption(
         pollId: String,
         request: UpdatePollOptionRequest
-    ): Result<PollOptionData> = runCatching {
+    ): Result<PollOptionData> = runSafely {
         api.updatePollOption(pollId, request).pollOption.toModel()
     }
 
     override suspend fun queryPolls(
         query: PollsQuery,
-    ): Result<PaginationResult<PollData>> = runCatching {
+    ): Result<PaginationResult<PollData>> = runSafely {
         val response = api.queryPolls(
             userId = null,
             queryPollsRequest = query.toRequest(),
@@ -111,7 +112,7 @@ internal class PollsRepositoryImpl(private val api: ApiService) : PollsRepositor
         activityId: String,
         pollId: String,
         request: CastPollVoteRequest
-    ): Result<PollVoteData?> = runCatching {
+    ): Result<PollVoteData?> = runSafely {
         api.castPollVote(
             activityId = activityId,
             pollId = pollId,
@@ -121,7 +122,7 @@ internal class PollsRepositoryImpl(private val api: ApiService) : PollsRepositor
 
     override suspend fun queryPollVotes(
         query: PollVotesQuery,
-    ): Result<PaginationResult<PollVoteData>> = runCatching {
+    ): Result<PaginationResult<PollVoteData>> = runSafely {
         val response = api.queryPollVotes(
             pollId = query.pollId,
             userId = query.userId,
@@ -138,7 +139,7 @@ internal class PollsRepositoryImpl(private val api: ApiService) : PollsRepositor
         pollId: String,
         voteId: String,
         userId: String?
-    ): Result<PollVoteData?> = runCatching {
+    ): Result<PollVoteData?> = runSafely {
         api.deletePollVote(
             activityId = activityId,
             pollId = pollId,

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/socket/common/StreamWebSocket.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/socket/common/StreamWebSocket.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.socket.common
 
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.subscribe.StreamSubscription
 import io.getstream.feeds.android.client.internal.common.StreamSubscriptionManager
 import io.getstream.feeds.android.client.internal.log.provideLogger
@@ -61,7 +62,7 @@ internal open class StreamWebSocketImpl<T : StreamWebSocketListener>(
 
     private lateinit var socket: WebSocket
 
-    override fun open(config: StreamSocketConfig): Result<Unit> = runCatching {
+    override fun open(config: StreamSocketConfig): Result<Unit> = runSafely {
         socket = socketFactory.createSocket(config, this).onFailure {
             logger.e { "[open] SocketFactory failed to create socket. ${it.message}" }
         }.getOrThrow()
@@ -160,7 +161,7 @@ internal open class StreamWebSocketImpl<T : StreamWebSocketListener>(
     override fun forEach(block: (T) -> Unit): Result<Unit> =
         subscriptionManager.forEach(block)
 
-    private inline fun <V> catchingWithSocket(block: (WebSocket) -> V) = runCatching {
+    private inline fun <V> catchingWithSocket(block: (WebSocket) -> V) = runSafely {
         if (::socket.isInitialized) {
             block(socket)
         } else {

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/socket/common/debounce/DebounceProcessor.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/socket/common/debounce/DebounceProcessor.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.socket.common.debounce
 
+import io.getstream.android.core.result.runSafely
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.ObsoleteCoroutinesApi
@@ -34,7 +35,7 @@ internal class DebounceProcessor<T>(
      * Starts the debounce processor.
      */
     @OptIn(ObsoleteCoroutinesApi::class)
-    fun start() = runCatching {
+    fun start() = runSafely {
         actor = scope.actor(capacity = Channel.UNLIMITED) {
             batchingLoop()
         }
@@ -44,7 +45,7 @@ internal class DebounceProcessor<T>(
      * Stops the debounce processor.
      */
     @OptIn(DelicateCoroutinesApi::class)
-    fun stop() = runCatching {
+    fun stop() = runSafely {
         if (actor?.isClosedForSend == false) {
             actor?.close()
         }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/socket/common/factory/StreamWebSocketFactory.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/socket/common/factory/StreamWebSocketFactory.kt
@@ -1,5 +1,6 @@
 package io.getstream.feeds.android.client.internal.socket.common.factory
 
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.internal.log.provideLogger
 import io.getstream.log.TaggedLogger
 import okhttp3.OkHttpClient
@@ -20,7 +21,7 @@ internal class StreamWebSocketFactory(
     internal fun createSocket(
         config: StreamSocketConfig,
         listener: WebSocketListener
-    ): Result<WebSocket> = runCatching {
+    ): Result<WebSocket> = runSafely {
         logger.v { "[createSocket] config: $config" }
         val request = buildRequest(config)
         okHttpClient.newWebSocket(request, listener)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/socket/common/parser/FeedsSocketParser.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/socket/common/parser/FeedsSocketParser.kt
@@ -1,6 +1,7 @@
 package io.getstream.feeds.android.client.internal.socket.common.parser
 
 import io.getstream.android.core.parser.JsonParser
+import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.internal.socket.events.ConnectedEvent
 import io.getstream.feeds.android.client.internal.socket.events.ConnectionErrorEvent
 import io.getstream.feeds.android.client.internal.socket.events.EVENT_TYPE_CONNECTION_ERROR
@@ -15,11 +16,11 @@ import io.getstream.feeds.android.core.generated.models.WSEvent
  */
 internal class FeedsEventParser(private val jsonParser: JsonParser) : GenericParser<Any, WSEvent> {
 
-    override fun encode(event: Any): Result<String> = runCatching {
+    override fun encode(event: Any): Result<String> = runSafely {
         jsonParser.toJson(event)
     }
 
-    override fun decode(raw: String): Result<WSEvent> = runCatching {
+    override fun decode(raw: String): Result<WSEvent> = runSafely {
         val event = jsonParser.fromJson(raw, WSEvent::class.java)
         if (event is UnsupportedWSEvent) {
             parseUnsupportedEvent(raw, event)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/android/core/result/ResultUtilsTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/android/core/result/ResultUtilsTest.kt
@@ -1,0 +1,27 @@
+package io.getstream.android.core.result
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import kotlin.coroutines.cancellation.CancellationException
+
+internal class ResultUtilsTest {
+    @Test
+    fun `runSafely, when no error occurs, then return success`() {
+        val result = runSafely { "Success" }
+
+        assertEquals(Result.success("Success"), result)
+    }
+
+    @Test
+    fun `runSafely, when an exception occurs, then return failure`() {
+        val exception = RuntimeException("Test Exception")
+        val result = runSafely { throw exception }
+
+        assertEquals(Result.failure<String>(exception), result)
+    }
+
+    @Test(expected = CancellationException::class)
+    fun `runSafely, when a CancellationException occurs, then rethrow it`() {
+        runSafely { throw CancellationException("Cancellation") }
+    }
+}


### PR DESCRIPTION
Follow up from the comments in #1.

`runCatching` catches everything, including `CancellationException`. However, when the latter is caught, we are interfering with coroutine cancellation propagation so we should avoid that. So, with this PR, I'm introducing a function that only catches `Exception`, excluding `CancellationException`.