### PR TITLE
Make public StateFlows read-only

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImpl.kt
@@ -14,6 +14,7 @@ import io.getstream.feeds.android.client.api.state.query.ActivityCommentsQuery
 import io.getstream.feeds.android.client.internal.utils.upsert
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * A class representing a paginated list of comments for a specific activity.
@@ -33,7 +34,7 @@ internal class ActivityCommentListStateImpl(
     private var _pagination: PaginationData? = null
 
     override val comments: StateFlow<List<ThreadedCommentData>>
-        get() = _comments
+        get() = _comments.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImpl.kt
@@ -13,13 +13,14 @@ import io.getstream.feeds.android.client.api.model.addReaction
 import io.getstream.feeds.android.client.api.model.deleteBookmark
 import io.getstream.feeds.android.client.api.model.removeComment
 import io.getstream.feeds.android.client.api.model.removeReaction
+import io.getstream.feeds.android.client.api.state.ActivityListState
 import io.getstream.feeds.android.client.api.state.query.ActivitiesQuery
 import io.getstream.feeds.android.client.api.state.query.ActivitiesSort
-import io.getstream.feeds.android.client.api.state.ActivityListState
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import io.getstream.feeds.android.client.internal.utils.upsertSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the activities list and handles real-time updates.
@@ -47,7 +48,7 @@ internal class ActivityListStateImpl(
         get() = query.sort ?: ActivitiesSort.Default
 
     override val activities: StateFlow<List<ActivityData>>
-        get() = _activities
+        get() = _activities.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListStateImpl.kt
@@ -10,6 +10,7 @@ import io.getstream.feeds.android.client.api.state.query.ActivityReactionsSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of an activity reaction list.
@@ -35,7 +36,7 @@ internal class ActivityReactionListStateImpl(
         get() = query.sort ?: ActivityReactionsSort.Default
 
     override val reactions: StateFlow<List<FeedsReactionData>>
-        get() = _reactions
+        get() = _reactions.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityStateImpl.kt
@@ -14,6 +14,7 @@ import io.getstream.feeds.android.client.api.state.ActivityCommentListState
 import io.getstream.feeds.android.client.api.state.ActivityState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable object representing the current state of an activity.
@@ -35,13 +36,13 @@ internal class ActivityStateImpl(
     private val _poll: MutableStateFlow<PollData?> = MutableStateFlow(null)
 
     override val activity: StateFlow<ActivityData?>
-        get() = _activity
+        get() = _activity.asStateFlow()
 
     override val comments: StateFlow<List<ThreadedCommentData>>
         get() = activityCommentListState.comments
 
     override val poll: StateFlow<PollData?>
-        get() = _poll
+        get() = _poll.asStateFlow()
 
     override fun onActivityUpdated(activity: ActivityData) {
         _activity.value = activity

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListStateImpl.kt
@@ -10,6 +10,7 @@ import io.getstream.feeds.android.client.api.state.query.BookmarkFoldersSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a bookmark folder list.
@@ -35,7 +36,7 @@ internal class BookmarkFolderListStateImpl(
         get() = query.sort ?: BookmarkFoldersSort.Default
 
     override val folders: StateFlow<List<BookmarkFolderData>>
-        get() = _folders
+        get() = _folders.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListStateImpl.kt
@@ -11,6 +11,7 @@ import io.getstream.feeds.android.client.api.state.query.BookmarksSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a bookmark list.
@@ -36,7 +37,7 @@ internal class BookmarkListStateImpl(
         get() = query.sort ?: BookmarksSort.Default
 
     override val bookmarks: StateFlow<List<BookmarkData>>
-        get() = _bookmarks
+        get() = _bookmarks.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImpl.kt
@@ -9,6 +9,7 @@ import io.getstream.feeds.android.client.api.state.query.CommentsQuery
 import io.getstream.feeds.android.client.api.state.query.CommentsSort
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a comment list.
@@ -41,7 +42,7 @@ internal class CommentListStateImpl(
     private var _pagination: PaginationData? = null
 
     override val comments: StateFlow<List<CommentData>>
-        get() = _comments
+        get() = _comments.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListStateImpl.kt
@@ -10,6 +10,7 @@ import io.getstream.feeds.android.client.api.state.query.CommentReactionsSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a comment reaction list.
@@ -33,7 +34,7 @@ internal class CommentReactionListStateImpl(
         get() = query.sort ?: CommentReactionsSort.Default
 
     override val reactions: StateFlow<List<FeedsReactionData>>
-        get() = _reactions
+        get() = _reactions.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListStateImpl.kt
@@ -13,6 +13,7 @@ import io.getstream.feeds.android.client.api.state.CommentReplyListState
 import io.getstream.feeds.android.client.api.state.query.CommentRepliesQuery
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable object representing the current state of a comment's reply list.
@@ -34,7 +35,7 @@ internal class CommentReplyListStateImpl(
     private var _pagination: PaginationData? = null
 
     override val replies: StateFlow<List<ThreadedCommentData>>
-        get() = _replies
+        get() = _replies.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListStateImpl.kt
@@ -10,6 +10,7 @@ import io.getstream.feeds.android.client.api.state.query.FeedsSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a feed list.
@@ -35,7 +36,7 @@ internal class FeedListStateImpl(
         get() = queryConfig?.sort ?: FeedsSort.Default
 
     override val feeds: StateFlow<List<FeedData>>
-        get() = _feeds
+        get() = _feeds.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedStateImpl.kt
@@ -19,9 +19,9 @@ import io.getstream.feeds.android.client.api.model.addReaction
 import io.getstream.feeds.android.client.api.model.deleteBookmark
 import io.getstream.feeds.android.client.api.model.removeComment
 import io.getstream.feeds.android.client.api.model.removeReaction
+import io.getstream.feeds.android.client.api.state.FeedState
 import io.getstream.feeds.android.client.api.state.query.ActivitiesSort
 import io.getstream.feeds.android.client.api.state.query.FeedQuery
-import io.getstream.feeds.android.client.api.state.FeedState
 import io.getstream.feeds.android.client.internal.repository.GetOrCreateInfo
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import io.getstream.feeds.android.client.internal.utils.upsert
@@ -29,6 +29,7 @@ import io.getstream.feeds.android.client.internal.utils.upsertSorted
 import io.getstream.feeds.android.core.generated.models.FeedOwnCapability
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Default implementation of [FeedState].
@@ -68,28 +69,28 @@ internal class FeedStateImpl(
         get() = feedQuery.fid
 
     override val activities: StateFlow<List<ActivityData>>
-        get() = _activities
+        get() = _activities.asStateFlow()
 
     override val feed: StateFlow<FeedData?>
-        get() = _feed
+        get() = _feed.asStateFlow()
 
     override val followers: StateFlow<List<FollowData>>
-        get() = _followers
+        get() = _followers.asStateFlow()
 
     override val following: StateFlow<List<FollowData>>
-        get() = _following
+        get() = _following.asStateFlow()
 
     override val followRequests: StateFlow<List<FollowData>>
-        get() = _followRequests
+        get() = _followRequests.asStateFlow()
 
     override val members: StateFlow<List<FeedMemberData>>
         get() = memberListState.members
 
     override val ownCapabilities: StateFlow<List<FeedOwnCapability>>
-        get() = _ownCapabilities
+        get() = _ownCapabilities.asStateFlow()
 
     override val pinnedActivities: StateFlow<List<ActivityPinData>>
-        get() = _pinnedActivities
+        get() = _pinnedActivities.asStateFlow()
 
     override val activitiesPagination: PaginationData?
         get() = _activitiesPagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImpl.kt
@@ -10,6 +10,7 @@ import io.getstream.feeds.android.client.api.state.query.FollowsSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a follow list.
@@ -33,7 +34,7 @@ internal class FollowListStateImpl(
         get() = queryConfig?.sort ?: FollowsSort.Default
 
     override val follows: StateFlow<List<FollowData>>
-        get() = _follows
+        get() = _follows.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListStateImpl.kt
@@ -12,6 +12,7 @@ import io.getstream.feeds.android.client.api.state.query.MembersSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a member list.
@@ -35,7 +36,7 @@ internal class MemberListStateImpl(
         get() = queryConfig?.sort ?: MembersSort.Default
 
     override val members: StateFlow<List<FeedMemberData>>
-        get() = _members
+        get() = _members.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListStateImpl.kt
@@ -10,6 +10,7 @@ import io.getstream.feeds.android.client.api.state.query.ModerationConfigsQuery
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a moderation config list.
@@ -33,7 +34,7 @@ internal class ModerationConfigListStateImpl(
 
 
     override val configs: StateFlow<List<ModerationConfigData>>
-        get() = _configs
+        get() = _configs.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListStateImpl.kt
@@ -10,6 +10,7 @@ import io.getstream.feeds.android.client.api.state.query.PollsSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a poll list.
@@ -34,7 +35,7 @@ internal class PollListStateImpl(
         get() = query.sort ?: PollsSort.Default
 
     override val polls: StateFlow<List<PollData>>
-        get() = _polls
+        get() = _polls.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListStateImpl.kt
@@ -10,6 +10,7 @@ import io.getstream.feeds.android.client.api.state.query.PollVotesSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * An observable state object that manages the current state of a poll vote list.
@@ -31,7 +32,7 @@ internal class PollVoteListStateImpl(
         get() = query.sort ?: PollVotesSort.Default
 
     override val votes: StateFlow<List<PollVoteData>>
-        get() = _votes
+        get() = _votes.asStateFlow()
 
     override val pagination: PaginationData?
         get() = _pagination

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/MainViewModel.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/MainViewModel.kt
@@ -13,13 +13,14 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class MainViewModel: ViewModel() {
 
     private val _viewState: MutableStateFlow<ViewState> = MutableStateFlow(ViewState.LoggedOut)
     val viewState: StateFlow<ViewState>
-        get() = _viewState
+        get() = _viewState.asStateFlow()
 
     private val _errorEvent: MutableSharedFlow<String> = MutableSharedFlow(extraBufferCapacity = 1)
     val errorEvent: SharedFlow<String>

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/login/ProfileViewModel.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/login/ProfileViewModel.kt
@@ -11,6 +11,7 @@ import io.getstream.feeds.android.client.api.state.Feed
 import io.getstream.feeds.android.client.api.state.FeedState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
 class ProfileViewModel(
@@ -22,7 +23,7 @@ class ProfileViewModel(
     public val state: FeedState = feed.state
 
     private val _followSuggestions: MutableStateFlow<List<FeedData>> = MutableStateFlow(emptyList())
-    public val followSuggestions: StateFlow<List<FeedData>> = _followSuggestions
+    public val followSuggestions: StateFlow<List<FeedData>> = _followSuggestions.asStateFlow()
 
     init {
         viewModelScope.launch {


### PR DESCRIPTION
Follow up from the comments in #1.

This PR makes public `StateFlow`s read-only so they can't be cast to their mutable counterpart.