### PR TITLE
Rewatch feeds on socket reconnection

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
@@ -48,6 +48,7 @@ import io.getstream.feeds.android.client.api.model.FeedsConfig
 import io.getstream.feeds.android.client.api.model.User
 import io.getstream.feeds.android.client.internal.client.reconnect.ConnectionRecoveryHandler
 import io.getstream.feeds.android.client.internal.client.reconnect.DefaultRetryStrategy
+import io.getstream.feeds.android.client.internal.client.reconnect.FeedWatchHandler
 import io.getstream.feeds.android.client.internal.client.reconnect.lifecycle.StreamLifecycleObserver
 import io.getstream.feeds.android.client.internal.file.StreamFeedUploader
 import io.getstream.feeds.android.client.internal.http.FeedsSingleFlightApi
@@ -248,6 +249,13 @@ internal fun createFeedsClient(
 
     val moderation = ModerationImpl(moderationRepository)
 
+    val feedWatchHandler =
+        FeedWatchHandler(
+            connectedEvents = client.connectionState,
+            feedsRepository = feedsRepository,
+            scope = clientScope,
+        )
+
     // Build client
     return FeedsClientImpl(
         apiKey = apiKey,
@@ -271,6 +279,7 @@ internal fun createFeedsClient(
                 maxStrongSubscriptions = Integer.MAX_VALUE,
                 maxWeakSubscriptions = Integer.MAX_VALUE,
             ),
+        feedWatchHandler = feedWatchHandler,
         logger = logger,
     )
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
@@ -253,6 +253,7 @@ internal fun createFeedsClient(
         FeedWatchHandler(
             connectionState = client.connectionState,
             feedsRepository = feedsRepository,
+            retryProcessor = StreamRetryProcessor(logProvider.taggedLogger("WatchHandler")),
             scope = clientScope,
         )
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
@@ -26,6 +26,7 @@ import io.getstream.android.core.api.log.StreamLogger
 import io.getstream.android.core.api.log.StreamLoggerProvider
 import io.getstream.android.core.api.model.config.StreamClientSerializationConfig
 import io.getstream.android.core.api.model.config.StreamHttpConfig
+import io.getstream.android.core.api.model.exceptions.StreamClientException
 import io.getstream.android.core.api.model.value.StreamApiKey
 import io.getstream.android.core.api.model.value.StreamHttpClientInfoHeader
 import io.getstream.android.core.api.model.value.StreamUserId
@@ -69,6 +70,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.plus
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
@@ -248,12 +250,14 @@ internal fun createFeedsClient(
     val pollsRepository = PollsRepositoryImpl(feedsApi)
 
     val moderation = ModerationImpl(moderationRepository)
+    val errorBus = MutableSharedFlow<StreamClientException>(extraBufferCapacity = 100)
 
     val feedWatchHandler =
         FeedWatchHandler(
             connectionState = client.connectionState,
             feedsRepository = feedsRepository,
             retryProcessor = StreamRetryProcessor(logProvider.taggedLogger("WatchHandler")),
+            errorBus = errorBus,
             scope = clientScope,
         )
 
@@ -281,6 +285,8 @@ internal fun createFeedsClient(
                 maxWeakSubscriptions = Integer.MAX_VALUE,
             ),
         feedWatchHandler = feedWatchHandler,
+        errorBus = errorBus,
+        scope = clientScope,
         logger = logger,
     )
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
@@ -251,7 +251,7 @@ internal fun createFeedsClient(
 
     val feedWatchHandler =
         FeedWatchHandler(
-            connectedEvents = client.connectionState,
+            connectionState = client.connectionState,
             feedsRepository = feedsRepository,
             scope = clientScope,
         )

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -63,6 +63,7 @@ import io.getstream.feeds.android.client.api.state.query.ModerationConfigsQuery
 import io.getstream.feeds.android.client.api.state.query.PollVotesQuery
 import io.getstream.feeds.android.client.api.state.query.PollsQuery
 import io.getstream.feeds.android.client.internal.client.reconnect.ConnectionRecoveryHandler
+import io.getstream.feeds.android.client.internal.client.reconnect.FeedWatchHandler
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
 import io.getstream.feeds.android.client.internal.repository.AppRepository
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepository
@@ -118,6 +119,7 @@ internal class FeedsClientImpl(
     private val pollsRepository: PollsRepository,
     override val uploader: FeedUploader,
     override val moderation: Moderation,
+    private val feedWatchHandler: FeedWatchHandler,
     private val logger: StreamLogger,
 ) : FeedsClient {
 
@@ -153,6 +155,7 @@ internal class FeedsClientImpl(
             return Result.failure(IllegalArgumentException("Anonymous users cannot connect."))
         }
         coreClient.subscribe(clientSubscription)
+        connectionRecoveryHandler.start()
         return coreClient.connect()
     }
 
@@ -175,6 +178,7 @@ internal class FeedsClientImpl(
             feedsRepository = feedsRepository,
             pollsRepository = pollsRepository,
             subscriptionManager = feedsEventsSubscriptionManager,
+            feedWatchHandler = feedWatchHandler,
         )
 
     override fun feedList(query: FeedsQuery): FeedList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/reconnect/FeedWatchHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/reconnect/FeedWatchHandler.kt
@@ -15,16 +15,16 @@
  */
 package io.getstream.feeds.android.client.internal.client.reconnect
 
+import io.getstream.android.core.api.filter.`in`
 import io.getstream.android.core.api.model.connection.StreamConnectionState
 import io.getstream.feeds.android.client.api.model.FeedId
-import io.getstream.feeds.android.client.api.state.query.FeedQuery
+import io.getstream.feeds.android.client.api.state.query.FeedsFilterField
+import io.getstream.feeds.android.client.api.state.query.FeedsQuery
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
 import java.util.concurrent.ConcurrentHashMap
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterIsInstance
-import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 
 /**
@@ -62,10 +62,9 @@ internal class FeedWatchHandler(
     }
 
     private suspend fun rewatchAll() {
-        coroutineScope {
-            watched
-                .map { launch { feedsRepository.getOrCreateFeed(FeedQuery(it.key, watch = true)) } }
-                .joinAll()
+        val toRewatch = watched.keys.mapTo(mutableListOf(), FeedId::rawValue)
+        if (toRewatch.isNotEmpty()) {
+            feedsRepository.queryFeeds(FeedsQuery(FeedsFilterField.feed.`in`(toRewatch)))
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/reconnect/FeedWatchHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/reconnect/FeedWatchHandler.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.feeds.android.client.internal.client.reconnect
+
+import io.getstream.android.core.api.model.connection.StreamConnectionState
+import io.getstream.feeds.android.client.api.model.FeedId
+import io.getstream.feeds.android.client.api.state.query.FeedQuery
+import io.getstream.feeds.android.client.internal.repository.FeedsRepository
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+
+/**
+ * Handles re-watching feeds upon reconnection.
+ *
+ * Keeps track of feeds that are being watched and re-subscribes to them when the connection is
+ * re-established.
+ *
+ * @property connectedEvents A [Flow] that emits events when the connection state changes to
+ *   [StreamConnectionState.Connected].
+ * @property feedsRepository The [FeedsRepository] used to rewatch feeds on connection.
+ * @property scope The [CoroutineScope] in which to launch coroutines for re-watching feeds.
+ */
+internal class FeedWatchHandler(
+    private val connectedEvents: Flow<StreamConnectionState>,
+    private val feedsRepository: FeedsRepository,
+    scope: CoroutineScope,
+) {
+    private val watched = mutableSetOf<FeedId>()
+
+    init {
+        scope.launch {
+            connectedEvents.filterIsInstance<StreamConnectionState.Connected>().collect {
+                rewatchAll()
+            }
+        }
+    }
+
+    @Synchronized
+    fun onStartWatching(feedId: FeedId) {
+        watched += feedId
+    }
+
+    @Synchronized
+    fun onStopWatching(feedId: FeedId) {
+        watched -= feedId
+    }
+
+    private suspend fun rewatchAll() {
+        coroutineScope {
+            synchronized(this@FeedWatchHandler) { watched.toSet() }
+                .map { launch { feedsRepository.getOrCreateFeed(FeedQuery(it, watch = true)) } }
+                .joinAll()
+        }
+    }
+}

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImplTest.kt
@@ -27,6 +27,7 @@ import io.getstream.feeds.android.client.api.model.PushNotificationsProvider
 import io.getstream.feeds.android.client.api.model.User
 import io.getstream.feeds.android.client.api.model.UserAuthType
 import io.getstream.feeds.android.client.internal.client.reconnect.ConnectionRecoveryHandler
+import io.getstream.feeds.android.client.internal.client.reconnect.FeedWatchHandler
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
 import io.getstream.feeds.android.client.internal.repository.AppRepository
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepository
@@ -72,6 +73,7 @@ internal class FeedsClientImplTest {
     private val pollsRepository: PollsRepository = mockk(relaxed = true)
     private val uploader: FeedUploader = mockk(relaxed = true)
     private val moderation: Moderation = mockk(relaxed = true)
+    private val feedWatchHandler: FeedWatchHandler = mockk(relaxed = true)
     private val logger: StreamLogger = mockk(relaxed = true)
 
     private val feedsClient: FeedsClientImpl =
@@ -92,6 +94,7 @@ internal class FeedsClientImplTest {
             pollsRepository = pollsRepository,
             uploader = uploader,
             moderation = moderation,
+            feedWatchHandler = feedWatchHandler,
             logger = logger,
         )
 
@@ -136,6 +139,7 @@ internal class FeedsClientImplTest {
                 pollsRepository = pollsRepository,
                 uploader = uploader,
                 moderation = moderation,
+                feedWatchHandler = feedWatchHandler,
                 logger = logger,
             )
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImplTest.kt
@@ -19,6 +19,7 @@ import io.getstream.android.core.api.StreamClient
 import io.getstream.android.core.api.log.StreamLogger
 import io.getstream.android.core.api.model.connection.StreamConnectedUser
 import io.getstream.android.core.api.model.connection.StreamConnectionState
+import io.getstream.android.core.api.model.exceptions.StreamClientException
 import io.getstream.android.core.api.model.value.StreamApiKey
 import io.getstream.android.core.api.subscribe.StreamSubscriptionManager
 import io.getstream.feeds.android.client.api.Moderation
@@ -48,13 +49,19 @@ import io.getstream.feeds.android.network.models.ListDevicesResponse
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import java.util.Date
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 internal class FeedsClientImplTest {
     private val coreClient: StreamClient = mockk(relaxed = true)
     private val feedsEventsSubscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
@@ -75,6 +82,8 @@ internal class FeedsClientImplTest {
     private val moderation: Moderation = mockk(relaxed = true)
     private val feedWatchHandler: FeedWatchHandler = mockk(relaxed = true)
     private val logger: StreamLogger = mockk(relaxed = true)
+    private val scope = TestScope(UnconfinedTestDispatcher())
+    private val errorBus = MutableSharedFlow<StreamClientException>()
 
     private val feedsClient: FeedsClientImpl =
         FeedsClientImpl(
@@ -96,7 +105,18 @@ internal class FeedsClientImplTest {
             moderation = moderation,
             feedWatchHandler = feedWatchHandler,
             logger = logger,
+            scope = scope,
+            errorBus = errorBus,
         )
+
+    @Test
+    fun `on error bus event, then log it`() = runTest {
+        val exception = StreamClientException("error!")
+
+        errorBus.emit(exception)
+
+        verify { logger.e(exception, any()) }
+    }
 
     @Test
     fun `connect when user is regular, then subscribes to client and connects successfully`() =
@@ -141,6 +161,8 @@ internal class FeedsClientImplTest {
                 moderation = moderation,
                 feedWatchHandler = feedWatchHandler,
                 logger = logger,
+                scope = scope,
+                errorBus = errorBus,
             )
 
         val result = anonymousClient.connect()

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/client/reconnect/FeedWatchHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/client/reconnect/FeedWatchHandlerTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.feeds.android.client.internal.client.reconnect
+
+import io.getstream.android.core.api.model.connection.StreamConnectionState
+import io.getstream.feeds.android.client.api.model.FeedId
+import io.getstream.feeds.android.client.api.state.query.FeedQuery
+import io.getstream.feeds.android.client.internal.repository.FeedsRepository
+import io.mockk.called
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class FeedWatchHandlerTest {
+    private val connectionEvents = MutableSharedFlow<StreamConnectionState>()
+    private val feedsRepository: FeedsRepository = mockk()
+    private val scope = TestScope(UnconfinedTestDispatcher())
+
+    private val handler = FeedWatchHandler(connectionEvents, feedsRepository, scope)
+
+    @Test
+    fun `on connected event, get feeds that are still being watched`() = runTest {
+        coEvery { feedsRepository.getOrCreateFeed(any()) } returns Result.failure(Exception())
+        val id1 = FeedId("group", "id1")
+        val id2 = FeedId("group", "id2")
+        val id3 = FeedId("group", "id3")
+
+        handler.onStartWatching(id1)
+        handler.onStartWatching(id2)
+        handler.onStartWatching(id3)
+        handler.onStopWatching(id2)
+
+        connectionEvents.emit(StreamConnectionState.Connected(mockk(), "connection-id"))
+
+        coVerify {
+            feedsRepository.getOrCreateFeed(FeedQuery(id1))
+            feedsRepository.getOrCreateFeed(FeedQuery(id3))
+        }
+    }
+
+    @Test
+    fun `on non-connected event, do nothing`() = runTest {
+        val id1 = FeedId("group", "id1")
+        handler.onStartWatching(id1)
+
+        listOf(
+                StreamConnectionState.Idle,
+                StreamConnectionState.Connecting.Opening("user-id"),
+                StreamConnectionState.Connecting.Authenticating("user-id"),
+                StreamConnectionState.Disconnected(),
+            )
+            .forEach { connectionEvents.emit(it) }
+
+        verify { feedsRepository wasNot called }
+    }
+}

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
@@ -18,14 +18,26 @@ package io.getstream.feeds.android.client.internal.state
 import io.getstream.feeds.android.client.api.file.FeedUploadPayload
 import io.getstream.feeds.android.client.api.model.ActivityData
 import io.getstream.feeds.android.client.api.model.FeedAddActivityRequest
+import io.getstream.feeds.android.client.api.model.FeedData
+import io.getstream.feeds.android.client.api.model.FeedId
+import io.getstream.feeds.android.client.api.model.PaginationData
+import io.getstream.feeds.android.client.api.model.PaginationResult
+import io.getstream.feeds.android.client.api.model.QueryConfiguration
 import io.getstream.feeds.android.client.api.model.request.ActivityAddCommentRequest
+import io.getstream.feeds.android.client.api.state.query.ActivitiesSort
 import io.getstream.feeds.android.client.api.state.query.FeedQuery
+import io.getstream.feeds.android.client.internal.client.reconnect.FeedWatchHandler
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
+import io.getstream.feeds.android.client.internal.repository.FeedsRepository
+import io.getstream.feeds.android.client.internal.repository.GetOrCreateInfo
 import io.getstream.feeds.android.client.internal.test.TestData.commentData
+import io.getstream.feeds.android.client.internal.test.TestData.feedData
+import io.mockk.called
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -33,21 +45,53 @@ import org.junit.Test
 internal class FeedImplTest {
     private val activitiesRepository: ActivitiesRepository = mockk(relaxed = true)
     private val commentsRepository: CommentsRepository = mockk(relaxed = true)
+    private val feedsRepository: FeedsRepository = mockk(relaxed = true)
+    private val feedWatchHandler: FeedWatchHandler = mockk(relaxed = true)
 
-    private val feed =
-        FeedImpl(
-            query = FeedQuery(group = "group", id = "id"),
-            currentUserId = "user",
-            activitiesRepository = activitiesRepository,
-            bookmarksRepository = mockk(),
-            commentsRepository = commentsRepository,
-            feedsRepository = mockk(),
-            pollsRepository = mockk(),
-            subscriptionManager = mockk(relaxed = true),
-        )
+    @Test
+    fun `on getOrCreate with watch enabled, then call feedWatchHandler`() = runTest {
+        val feed = createFeed(watch = true)
+        val feedId = FeedId("group:id")
+        val testFeedData = feedData()
+        val feedInfo = getOrCreateInfo(testFeedData)
+        coEvery { feedsRepository.getOrCreateFeed(any()) } returns Result.success(feedInfo)
+
+        val result = feed.getOrCreate()
+
+        assertEquals(feedInfo.feed, result.getOrNull())
+        verify { feedWatchHandler.onStartWatching(feedId) }
+    }
+
+    @Test
+    fun `on getOrCreate with watch disabled, then do not call feedWatchHandler`() = runTest {
+        val feed = createFeed(watch = false)
+        val testFeedData = feedData()
+        val feedInfo = getOrCreateInfo(testFeedData)
+        coEvery { feedsRepository.getOrCreateFeed(any()) } returns Result.success(feedInfo)
+
+        val result = feed.getOrCreate()
+
+        assertEquals(feedInfo.feed, result.getOrNull())
+        verify { feedWatchHandler wasNot called }
+    }
+
+    @Test
+    fun `on stopWatching, then call feedWatchHandler`() = runTest {
+        val feed = createFeed()
+        val feedId = FeedId("group:id")
+        coEvery { feedsRepository.stopWatching(any(), any()) } returns Result.success(Unit)
+
+        feed.stopWatching()
+
+        coVerify {
+            feedWatchHandler.onStopWatching(feedId)
+            feedsRepository.stopWatching("group", "id")
+        }
+    }
 
     @Test
     fun `on addActivity, delegate to repository and notify state on success`() = runTest {
+        val feed = createFeed()
         val request = FeedAddActivityRequest(type = "post", text = "Nice post")
         val attachmentUploadProgress: (FeedUploadPayload, Double) -> Unit = { _, _ -> }
         val activityData = mockk<ActivityData>(relaxed = true)
@@ -62,6 +106,7 @@ internal class FeedImplTest {
 
     @Test
     fun `on addComment, delegate to repository`() = runTest {
+        val feed = createFeed()
         val request = ActivityAddCommentRequest(activityId = "activityId", comment = "Comment")
         val progress = { _: FeedUploadPayload, _: Double -> }
         val commentData = commentData("id")
@@ -71,4 +116,33 @@ internal class FeedImplTest {
 
         coVerify { commentsRepository.addComment(request, progress) }
     }
+
+    private fun createFeed(watch: Boolean = false) =
+        FeedImpl(
+            query = FeedQuery(group = "group", id = "id", watch = watch),
+            currentUserId = "user",
+            activitiesRepository = activitiesRepository,
+            bookmarksRepository = mockk(),
+            commentsRepository = commentsRepository,
+            feedsRepository = feedsRepository,
+            pollsRepository = mockk(),
+            subscriptionManager = mockk(relaxed = true),
+            feedWatchHandler = feedWatchHandler,
+        )
+
+    private fun getOrCreateInfo(testFeedData: FeedData): GetOrCreateInfo =
+        GetOrCreateInfo(
+            activities = PaginationResult(models = emptyList(), pagination = PaginationData.EMPTY),
+            activitiesQueryConfig =
+                QueryConfiguration(filter = null, sort = ActivitiesSort.Default),
+            feed = testFeedData,
+            followers = emptyList(),
+            following = emptyList(),
+            followRequests = emptyList(),
+            members = PaginationResult(models = emptyList(), pagination = PaginationData.EMPTY),
+            ownCapabilities = emptyList(),
+            pinnedActivities = emptyList(),
+            aggregatedActivities = emptyList(),
+            notificationStatus = null,
+        )
 }


### PR DESCRIPTION
### Goal

Make sure that feeds that the client started watching, are re-watched on socket reconnection.

### Implementation

Introduce a `FeedWatchHandler` class that keeps track of watched feeds and re-watch them when the socket state becomes connected

### Testing

- Unit tests covering the new code pass
- Run the sample and cause a socket disconnection & reconnection. Then validate that the events are still received. E.g. disconnect because of network down & then reconnect by moving the app to background & foreground.