### PR TITLE
Display image attachments in comments

### DIFF
--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CommentsBottomSheet.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CommentsBottomSheet.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.defaultMinSize
@@ -30,7 +29,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -163,6 +161,7 @@ private fun ColumnScope.CommentsBottomSheetContent(
         CreateContentBottomSheet(
             title = "Add comment",
             onDismiss = { createCommentData = null },
+            requireText = true,
             onPost = { text, attachments ->
                 onPostComment(text, createCommentData?.replyParentId, attachments)
                 createCommentData = null
@@ -182,7 +181,7 @@ private fun Comment(
 ) {
     var expandedCommentId: String? by remember { mutableStateOf(null) }
 
-    Column(modifier.width(IntrinsicSize.Max)) {
+    Column(modifier.fillMaxWidth()) {
         Column(
             Modifier.background(
                     MaterialTheme.colorScheme.secondaryContainer,
@@ -194,6 +193,7 @@ private fun Comment(
         ) {
             Text(data.user.name.orEmpty(), fontWeight = FontWeight.SemiBold)
             Text(data.text.orEmpty())
+            ImageAttachmentsSection(data.attachments.orEmpty())
         }
 
         Row(

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CommentsSheetViewModel.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CommentsSheetViewModel.kt
@@ -48,7 +48,7 @@ import kotlinx.coroutines.flow.stateIn
 class CommentsSheetViewModel
 @Inject
 constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
     loginManager: LoginManager,
     savedStateHandle: SavedStateHandle,
 ) : ViewModel() {

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CreateContentBottomSheet.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CreateContentBottomSheet.kt
@@ -55,6 +55,7 @@ fun CreateContentBottomSheet(
     title: String,
     onDismiss: () -> Unit,
     onPost: (text: String, attachments: List<Uri>) -> Unit,
+    requireText: Boolean,
     extraActions: @Composable RowScope.() -> Unit = {},
 ) {
     var postText by remember { mutableStateOf("") }
@@ -75,7 +76,7 @@ fun CreateContentBottomSheet(
             ) {
                 Text(text = title, fontSize = 18.sp, fontWeight = FontWeight.Companion.Bold)
 
-                val canPost = attachments.isNotEmpty() || postText.isNotBlank()
+                val canPost = attachments.isNotEmpty() && !requireText || postText.isNotBlank()
                 TextButton(onClick = { onPost(postText, attachments) }, enabled = canPost) {
                     Text(text = "Submit", fontWeight = FontWeight.Companion.Medium)
                 }

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
@@ -25,16 +25,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -59,7 +56,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontStyle
@@ -69,7 +65,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
 import com.ramcosta.composedestinations.annotation.Destination
 import com.ramcosta.composedestinations.annotation.RootGraph
 import com.ramcosta.composedestinations.generated.NavGraphs
@@ -252,6 +247,7 @@ private fun FeedsScreenContent(
                         showCreatePostBottomSheet = false
                         viewModel.onCreatePost(postText, attachments)
                     },
+                    requireText = false,
                     extraActions = {
                         CreatePollButton { formData ->
                             showCreatePostBottomSheet = false
@@ -414,7 +410,7 @@ fun ActivityContent(
         }
 
         // Attachments - show below the content for better visual hierarchy
-        AttachmentsSection(attachments)
+        ImageAttachmentsSection(attachments)
 
         // Action buttons row
         ActivityActions(
@@ -470,36 +466,6 @@ fun ActivityContent(
             color = Color.Gray.copy(alpha = 0.2f),
             thickness = 1.dp,
         )
-    }
-}
-
-@Composable
-private fun AttachmentsSection(attachments: List<Attachment>) {
-    if (attachments.size == 1) {
-        AsyncImage(
-            modifier =
-                Modifier.fillMaxWidth()
-                    .height(240.dp)
-                    .padding(top = 8.dp)
-                    .clip(RoundedCornerShape(12.dp)),
-            model = attachments.first().assetUrl,
-            contentDescription = "Activity image",
-            contentScale = ContentScale.Crop,
-        )
-    } else if (attachments.size > 1) {
-        LazyRow(
-            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
-            horizontalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            items(attachments) { attachment ->
-                AsyncImage(
-                    modifier = Modifier.size(160.dp).clip(RoundedCornerShape(12.dp)),
-                    model = attachment.assetUrl,
-                    contentDescription = "Activity image",
-                    contentScale = ContentScale.Crop,
-                )
-            }
-        }
     }
 }
 

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/ImageAttachmentsSection.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/ImageAttachmentsSection.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.feeds.android.sample.feed
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import io.getstream.feeds.android.network.models.Attachment
+
+@Composable
+fun ImageAttachmentsSection(attachments: List<Attachment>) {
+    if (attachments.size == 1) {
+        AsyncImage(
+            modifier =
+                Modifier.fillMaxWidth()
+                    .height(240.dp)
+                    .padding(top = 8.dp)
+                    .clip(RoundedCornerShape(12.dp)),
+            model = attachments.first().assetUrl,
+            contentDescription = "Activity image",
+            contentScale = ContentScale.Crop,
+        )
+    } else if (attachments.size > 1) {
+        LazyRow(
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            items(attachments) { attachment ->
+                AsyncImage(
+                    modifier = Modifier.size(160.dp).clip(RoundedCornerShape(12.dp)),
+                    model = attachment.assetUrl,
+                    contentDescription = "Activity image",
+                    contentScale = ContentScale.Crop,
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Goal

We already allow to attach images to comments, so we should also display them.

### Implementation

- Add a section to the comment view to show attachments
- Update `CreateContentBottomSheet` to allow specifying if adding some text is required or not, because it's not required for posts, but it's for comments

### Testing

- Add a comment with an image to any activity
- Verify that the image is displayed in the comment

<img width="320" alt="a" src="https://github.com/user-attachments/assets/41ce3d7f-89ba-4343-afa4-72cc4e785316" />


### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
