### PR TITLE
Allow editing and deleting comments

### DIFF
--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CommentsBottomSheet.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CommentsBottomSheet.kt
@@ -67,6 +67,7 @@ import io.getstream.feeds.android.sample.R
 import io.getstream.feeds.android.sample.components.LoadingScreen
 import io.getstream.feeds.android.sample.feed.CommentsSheetViewModel.Event
 import io.getstream.feeds.android.sample.ui.util.ScrolledToBottomEffect
+import io.getstream.feeds.android.sample.ui.util.conditional
 import io.getstream.feeds.android.sample.ui.util.rippleClickable
 import io.getstream.feeds.android.sample.util.AsyncResource
 
@@ -195,18 +196,17 @@ private fun Comment(
                     MaterialTheme.colorScheme.secondaryContainer,
                     shape = RoundedCornerShape(16.dp),
                 )
-                .combinedClickable(
-                    indication = null,
-                    interactionSource = null,
-                    onClick = {},
-                    onLongClick =
-                        if (data.user.id == currentUserId) {
-                            {
-                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                showContextMenu = true
-                            }
-                        } else null,
-                )
+                .conditional(data.user.id == currentUserId) {
+                    combinedClickable(
+                        indication = null,
+                        interactionSource = null,
+                        onClick = {},
+                        onLongClick = {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                            showContextMenu = true
+                        },
+                    )
+                }
                 .padding(16.dp)
                 .fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(4.dp),

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/ContentContextMenuDialog.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/ContentContextMenuDialog.kt
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.feeds.android.sample.feed
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.getstream.feeds.android.sample.R
+
+@Composable
+fun ContentContextMenuDialog(
+    title: String,
+    showEdit: Boolean,
+    onDismiss: () -> Unit,
+    onEdit: () -> Unit,
+    onDelete: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = title, fontWeight = FontWeight.Bold, fontSize = 16.sp) },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                if (showEdit) {
+                    MenuItemRow(iconRes = R.drawable.edit_24, text = "Edit", onClick = onEdit)
+
+                    // Divider between Edit and Delete
+                    HorizontalDivider(thickness = 1.dp)
+                }
+
+                MenuItemRow(
+                    iconRes = R.drawable.delete_24,
+                    text = "Delete",
+                    onClick = onDelete,
+                    tint = MaterialTheme.colorScheme.error,
+                    textColor = MaterialTheme.colorScheme.error,
+                )
+            }
+        },
+        confirmButton = {},
+        dismissButton = {},
+    )
+}
+
+@Composable
+private fun MenuItemRow(
+    iconRes: Int,
+    text: String,
+    onClick: () -> Unit,
+    tint: Color = Color.Unspecified,
+    textColor: Color = Color.Unspecified,
+) {
+    Row(
+        modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            painter = painterResource(iconRes),
+            contentDescription = text,
+            tint = tint,
+            modifier = Modifier.size(24.dp),
+        )
+        Text(
+            text = text,
+            fontSize = 16.sp,
+            color = textColor,
+            modifier = Modifier.padding(start = 16.dp),
+        )
+    }
+}

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/EditContentDialog.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/EditContentDialog.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.feeds.android.sample.feed
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun EditContentDialog(initialText: String, onDismiss: () -> Unit, onSave: (String) -> Unit) {
+    var editText by remember { mutableStateOf(initialText) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(text = "Edit", fontWeight = FontWeight.Bold, fontSize = 16.sp) },
+        text = {
+            OutlinedTextField(
+                value = editText,
+                onValueChange = { editText = it },
+                placeholder = { Text("What's on your mind?") },
+                modifier = Modifier.fillMaxWidth(),
+                maxLines = 5,
+                minLines = 3,
+            )
+        },
+        confirmButton = { Button(onClick = { onSave(editText) }) { Text("Save") } },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
+    )
+}

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
@@ -85,6 +85,7 @@ import io.getstream.feeds.android.sample.components.LoadingScreen
 import io.getstream.feeds.android.sample.components.UserAvatar
 import io.getstream.feeds.android.sample.notification.NotificationsScreenArgs
 import io.getstream.feeds.android.sample.ui.util.ScrolledToBottomEffect
+import io.getstream.feeds.android.sample.ui.util.conditional
 import io.getstream.feeds.android.sample.util.AsyncResource
 
 data class FeedsScreenArgs(val feedId: String, val avatarUrl: String?, val userId: String) {
@@ -376,18 +377,17 @@ fun ActivityContent(
     Column(
         modifier =
             Modifier.fillMaxWidth()
-                .combinedClickable(
-                    indication = null,
-                    interactionSource = null,
-                    onClick = { /* Regular click - do nothing */ },
-                    onLongClick =
-                        if (isCurrentUserAuthor) {
-                            {
-                                hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
-                                showContextMenu = true
-                            }
-                        } else null,
-                )
+                .conditional(isCurrentUserAuthor) {
+                    combinedClickable(
+                        indication = null,
+                        interactionSource = null,
+                        onClick = { /* Regular click - do nothing */ },
+                        onLongClick = {
+                            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                            showContextMenu = true
+                        },
+                    )
+                }
                 .padding(horizontal = 16.dp, vertical = 12.dp)
     ) {
         Row(modifier = Modifier.fillMaxWidth(), verticalAlignment = Alignment.Top) {

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
@@ -39,8 +39,6 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -441,7 +439,8 @@ fun ActivityContent(
 
         // Context menu dialog for long press
         if (showContextMenu) {
-            ActivityContextMenuDialog(
+            ContentContextMenuDialog(
+                title = "Post Options",
                 showEdit = data.parent == null && data.poll == null,
                 onDismiss = { showContextMenu = false },
                 onEdit = {
@@ -457,7 +456,7 @@ fun ActivityContent(
 
         // Edit dialog
         if (showEditDialog) {
-            EditPostDialog(
+            EditContentDialog(
                 initialText = text,
                 onDismiss = { showEditDialog = false },
                 onSave = { editedText ->
@@ -470,89 +469,6 @@ fun ActivityContent(
         // Add divider between activities for better separation
         HorizontalDivider(modifier = Modifier.fillMaxWidth().padding(top = 16.dp), thickness = 1.dp)
     }
-}
-
-@Composable
-fun ActivityContextMenuDialog(
-    showEdit: Boolean,
-    onDismiss: () -> Unit,
-    onEdit: () -> Unit,
-    onDelete: () -> Unit,
-) {
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(text = "Post Options", fontWeight = FontWeight.Bold, fontSize = 16.sp) },
-        text = {
-            Column(modifier = Modifier.fillMaxWidth()) {
-                if (showEdit) {
-                    Row(
-                        modifier =
-                            Modifier.fillMaxWidth()
-                                .clickable { onEdit() }
-                                .padding(vertical = 12.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Icon(
-                            painter = painterResource(R.drawable.edit_24),
-                            contentDescription = "Edit",
-                            modifier = Modifier.size(24.dp),
-                        )
-                        Text(
-                            text = "Edit Post",
-                            fontSize = 16.sp,
-                            modifier = Modifier.padding(start = 16.dp),
-                        )
-                    }
-
-                    // Divider between Edit and Delete
-                    HorizontalDivider(thickness = 1.dp)
-                }
-
-                Row(
-                    modifier =
-                        Modifier.fillMaxWidth().clickable { onDelete() }.padding(vertical = 12.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Icon(
-                        painter = painterResource(R.drawable.delete_24),
-                        contentDescription = "Delete",
-                        tint = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.size(24.dp),
-                    )
-                    Text(
-                        text = "Delete Post",
-                        fontSize = 16.sp,
-                        color = MaterialTheme.colorScheme.error,
-                        modifier = Modifier.padding(start = 16.dp),
-                    )
-                }
-            }
-        },
-        confirmButton = {},
-        dismissButton = {},
-    )
-}
-
-@Composable
-fun EditPostDialog(initialText: String, onDismiss: () -> Unit, onSave: (String) -> Unit) {
-    var editText by remember { mutableStateOf(initialText) }
-
-    AlertDialog(
-        onDismissRequest = onDismiss,
-        title = { Text(text = "Edit Post", fontWeight = FontWeight.Bold, fontSize = 16.sp) },
-        text = {
-            OutlinedTextField(
-                value = editText,
-                onValueChange = { editText = it },
-                placeholder = { Text("What's on your mind?") },
-                modifier = Modifier.fillMaxWidth(),
-                maxLines = 5,
-                minLines = 3,
-            )
-        },
-        confirmButton = { Button(onClick = { onSave(editText) }) { Text("Save") } },
-        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } },
-    )
 }
 
 @Composable

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/ui/util/ComposeExtensions.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/ui/util/ComposeExtensions.kt
@@ -52,3 +52,10 @@ fun Modifier.rippleClickable(enabled: Boolean = true, onClick: () -> Unit): Modi
         enabled = enabled,
         onClick = onClick,
     )
+
+inline fun Modifier.conditional(condition: Boolean, modifier: Modifier.() -> Modifier): Modifier =
+    if (condition) {
+        modifier()
+    } else {
+        this
+    }


### PR DESCRIPTION
### Goal

Users should be able to edit and delete their comments.

### Implementation

Similar to what we do for activities:
1. Show a dialog on long press on a comment
2. Show dialog to choose edit or delete
3. Delegate actual execution to the VM

I also refactored the VM to expose a single function for receiving events from the view, so we avoid passing one million lambdas around. 

### Testing

Open the feed, try to edit or delete any comment belonging to the logged in user, and verify that the action is carried out.

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
