### PR TITLE
Add workflow to clean stale PRs

### DIFF
--- a/.github/workflows/pr-clean-stale.yaml
+++ b/.github/workflows/pr-clean-stale.yaml
@@ -1,0 +1,11 @@
+name: PR cleanup
+
+on:
+  schedule:
+    - cron: "0 7 * * 1"  # every Monday 07:00 UTC (08:00 CET / 09:00 CEST)
+  workflow_dispatch:
+
+jobs:
+  pr-clean-stale:
+    uses: GetStream/android-ci-actions/.github/workflows/pr-clean-stale.yaml@main
+    secrets: inherit


### PR DESCRIPTION
### Goal

Introduce weekly check for cleaning stale PRs

### Implementation

Add workflow invoking the corresponding one in `android-ci-actions`.

### Testing

Open a PR, let it go stale, verify that is properly addressed.

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
