### PR TITLE
Show progress indicator while posting content

### DIFF
--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CreatePollButton.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/CreatePollButton.kt
@@ -60,10 +60,10 @@ import io.getstream.feeds.android.sample.R
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CreatePollButton(onCreatePoll: (PollFormData) -> Unit) {
+fun CreatePollButton(onCreatePoll: (PollFormData) -> Unit, enabled: Boolean) {
     var showPollBottomSheet by remember { mutableStateOf(false) }
 
-    IconButton(onClick = { showPollBottomSheet = true }) {
+    IconButton(onClick = { showPollBottomSheet = true }, enabled = enabled) {
         Icon(
             painter = painterResource(R.drawable.poll),
             contentDescription = "Create Poll",

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
@@ -140,7 +140,7 @@ private fun FeedsScreenContent(
     viewModel: FeedViewModel,
     modifier: Modifier,
 ) {
-    var showCreatePostBottomSheet by remember { mutableStateOf(false) }
+    val createContentState by viewModel.createContentState.collectAsStateWithLifecycle()
 
     Column(modifier = modifier.fillMaxSize()) {
         Box(modifier = Modifier.fillMaxSize()) {
@@ -209,7 +209,7 @@ private fun FeedsScreenContent(
             }
 
             FloatingActionButton(
-                onClick = { showCreatePostBottomSheet = true },
+                onClick = viewModel::onCreateClick,
                 modifier = Modifier.align(Alignment.BottomEnd).padding(16.dp),
                 shape = CircleShape,
             ) {
@@ -221,23 +221,14 @@ private fun FeedsScreenContent(
             }
 
             // Create Post Bottom Sheet
-            if (showCreatePostBottomSheet) {
-                CreateContentBottomSheet(
-                    title = "Create post",
-                    onDismiss = { showCreatePostBottomSheet = false },
-                    onPost = { postText, attachments ->
-                        showCreatePostBottomSheet = false
-                        viewModel.onCreatePost(postText, attachments)
-                    },
-                    requireText = false,
-                    extraActions = {
-                        CreatePollButton { formData ->
-                            showCreatePostBottomSheet = false
-                            viewModel.onCreatePoll(formData)
-                        }
-                    },
-                )
-            }
+            CreateContentBottomSheet(
+                state = createContentState,
+                title = "Create post",
+                onDismiss = viewModel::onContentCreateDismiss,
+                onPost = viewModel::onCreatePost,
+                requireText = false,
+                extraActions = { enabled -> CreatePollButton(viewModel::onCreatePoll, enabled) },
+            )
         }
     }
 }


### PR DESCRIPTION
### Goal

At the moment, when posting a comment in the demo app we just close the "create content" bottom sheet and post it. However, the operation can take long, especially when uploading attachments without any feedback until done. So we should show a loading indicator instead.

### Implementation

Move the visibility state of the "create content" sheet to the VM and, while posting, we now disable input and show a loading indicator. 

### Testing

Try posting something in the demo app and verify that the loading indicator is shown instead of the submit button.

<img width="300" alt="Screenshot_20250905_093210" src="https://github.com/user-attachments/assets/b9c9c571-8d0a-490e-854e-e914d2e2ac55" />

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
