### PR TITLE
Replace `MutableStateFlow` value assignments with atomic updates

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImpl.kt
@@ -37,6 +37,7 @@ import io.getstream.feeds.android.client.internal.utils.upsertSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * An observable state object that manages the activities list and handles real-time updates.
@@ -77,22 +78,24 @@ internal class ActivityListStateImpl(
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
         // Merge the new activities with the existing ones (keeping the sort order)
-        _activities.value =
-            _activities.value.mergeSorted(result.models, ActivityData::id, activitiesSorting)
+        _activities.update { current ->
+            current.mergeSorted(result.models, ActivityData::id, activitiesSorting)
+        }
     }
 
     override fun onActivityRemoved(activity: ActivityData) {
-        _activities.value = _activities.value.filter { it.id != activity.id }
+        _activities.update { current -> current.filter { it.id != activity.id } }
     }
 
     override fun onActivityUpdated(activity: ActivityData) {
-        _activities.value =
-            _activities.value.upsertSorted(activity, ActivityData::id, activitiesSorting)
+        _activities.update { current ->
+            current.upsertSorted(activity, ActivityData::id, activitiesSorting)
+        }
     }
 
     override fun onBookmarkAdded(bookmark: BookmarkData) {
-        _activities.value =
-            _activities.value.map { activity ->
+        _activities.update { current ->
+            current.map { activity ->
                 if (activity.id == bookmark.activity.id) {
                     // If the activity matches the bookmark, add the bookmark to it
                     activity.addBookmark(bookmark, currentUserId)
@@ -100,11 +103,12 @@ internal class ActivityListStateImpl(
                     activity
                 }
             }
+        }
     }
 
     override fun onBookmarkRemoved(bookmark: BookmarkData) {
-        _activities.value =
-            _activities.value.map { activity ->
+        _activities.update { current ->
+            current.map { activity ->
                 if (activity.id == bookmark.activity.id) {
                     // If the activity matches the bookmark, remove the bookmark from it
                     activity.deleteBookmark(bookmark, currentUserId)
@@ -112,33 +116,36 @@ internal class ActivityListStateImpl(
                     activity
                 }
             }
+        }
     }
 
     override fun onCommentAdded(comment: CommentData) {
-        _activities.value =
-            _activities.value.map { activity ->
+        _activities.update { current ->
+            current.map { activity ->
                 if (activity.id == comment.objectId) {
                     activity.addComment(comment)
                 } else {
                     activity
                 }
             }
+        }
     }
 
     override fun onCommentRemoved(comment: CommentData) {
-        _activities.value =
-            _activities.value.map { activity ->
+        _activities.update { current ->
+            current.map { activity ->
                 if (activity.id == comment.objectId) {
                     activity.removeComment(comment)
                 } else {
                     activity
                 }
             }
+        }
     }
 
     override fun onReactionAdded(reaction: FeedsReactionData) {
-        _activities.value =
-            _activities.value.map { activity ->
+        _activities.update { current ->
+            current.map { activity ->
                 if (activity.id == reaction.activityId) {
                     // Add the reaction to the activity
                     activity.addReaction(reaction, currentUserId)
@@ -146,11 +153,12 @@ internal class ActivityListStateImpl(
                     activity
                 }
             }
+        }
     }
 
     override fun onReactionRemoved(reaction: FeedsReactionData) {
-        _activities.value =
-            _activities.value.map { activity ->
+        _activities.update { current ->
+            current.map { activity ->
                 if (activity.id == reaction.activityId) {
                     // Remove the reaction from the activity
                     activity.removeReaction(reaction, currentUserId)
@@ -158,6 +166,7 @@ internal class ActivityListStateImpl(
                     activity
                 }
             }
+        }
     }
 }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListStateImpl.kt
@@ -69,8 +69,9 @@ internal class ActivityReactionListStateImpl(override val query: ActivityReactio
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
         // Merge the new reactions with the existing ones (keeping the sort order)
-        _reactions.value =
-            _reactions.value.mergeSorted(result.models, FeedsReactionData::id, reactionsSorting)
+        _reactions.update { current ->
+            current.mergeSorted(result.models, FeedsReactionData::id, reactionsSorting)
+        }
     }
 
     override fun onReactionAdded(reaction: FeedsReactionData) {
@@ -78,7 +79,7 @@ internal class ActivityReactionListStateImpl(override val query: ActivityReactio
     }
 
     override fun onReactionRemoved(reaction: FeedsReactionData) {
-        _reactions.value = _reactions.value.filter { it.id != reaction.id }
+        _reactions.update { current -> current.filter { it.id != reaction.id } }
     }
 }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityStateImpl.kt
@@ -66,8 +66,8 @@ internal class ActivityStateImpl(
         get() = _poll.asStateFlow()
 
     override fun onActivityUpdated(activity: ActivityData) {
-        _activity.value = activity
-        _poll.value = activity.poll
+        _activity.update { activity }
+        _poll.update { activity.poll }
     }
 
     override fun onReactionAdded(reaction: FeedsReactionData) {
@@ -88,54 +88,54 @@ internal class ActivityStateImpl(
 
     override fun onPollClosed(poll: PollData) {
         if (_poll.value?.id != poll.id) return
-        _poll.value = poll
+        _poll.update { poll }
     }
 
     override fun onPollDeleted(pollId: String) {
         if (_poll.value?.id != pollId) return
-        _poll.value = null
+        _poll.update { null }
     }
 
     override fun onPollUpdated(poll: PollData) {
         if (_poll.value?.id != poll.id) return
-        _poll.value = poll
+        _poll.update { poll }
     }
 
     override fun onOptionCreated(option: PollOptionData) {
-        _poll.value = _poll.value?.addOption(option)
+        _poll.update { current -> current?.addOption(option) }
     }
 
     override fun onOptionDeleted(optionId: String) {
-        _poll.value = _poll.value?.removeOption(optionId)
+        _poll.update { current -> current?.removeOption(optionId) }
     }
 
     override fun onOptionUpdated(option: PollOptionData) {
-        _poll.value = _poll.value?.updateOption(option)
+        _poll.update { current -> current?.updateOption(option) }
     }
 
     override fun onPollVoteCasted(vote: PollVoteData, poll: PollData) {
         if (_poll.value?.id != poll.id) return
-        _poll.value = poll
+        _poll.update { poll }
     }
 
     override fun onPollVoteCasted(vote: PollVoteData?) {
         if (vote == null) return
-        _poll.value = _poll.value?.castVote(vote, currentUserId)
+        _poll.update { current -> current?.castVote(vote, currentUserId) }
     }
 
     override fun onPollVoteChanged(vote: PollVoteData, poll: PollData) {
         if (_poll.value?.id != poll.id) return
-        _poll.value = poll
+        _poll.update { poll }
     }
 
     override fun onPollVoteRemoved(vote: PollVoteData, poll: PollData) {
         if (_poll.value?.id != poll.id) return
-        _poll.value = poll
+        _poll.update { poll }
     }
 
     override fun onPollVoteRemoved(vote: PollVoteData?) {
         if (vote == null) return
-        _poll.value = _poll.value?.removeVote(vote, currentUserId)
+        _poll.update { current -> current?.removeVote(vote, currentUserId) }
     }
 }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListStateImpl.kt
@@ -27,6 +27,7 @@ import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * An observable state object that manages the current state of a bookmark folder list.
@@ -65,17 +66,18 @@ internal class BookmarkFolderListStateImpl(override val query: BookmarkFoldersQu
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
         // Merge the new folders with the existing ones (keeping the sort order)
-        _folders.value =
-            _folders.value.mergeSorted(result.models, BookmarkFolderData::id, foldersSorting)
+        _folders.update { current ->
+            current.mergeSorted(result.models, BookmarkFolderData::id, foldersSorting)
+        }
     }
 
     override fun onBookmarkFolderRemoved(folderId: String) {
-        _folders.value = _folders.value.filter { it.id != folderId }
+        _folders.update { current -> current.filter { it.id != folderId } }
     }
 
     override fun onBookmarkFolderUpdated(folder: BookmarkFolderData) {
-        _folders.value =
-            _folders.value.map {
+        _folders.update { current ->
+            current.map {
                 if (it.id == folder.id) {
                     // Update the folder data
                     folder
@@ -83,6 +85,7 @@ internal class BookmarkFolderListStateImpl(override val query: BookmarkFoldersQu
                     it
                 }
             }
+        }
     }
 }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListStateImpl.kt
@@ -66,13 +66,14 @@ internal class BookmarkListStateImpl(override val query: BookmarksQuery) :
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
         // Merge the new bookmarks with the existing ones (keeping the sort order)
-        _bookmarks.value =
-            _bookmarks.value.mergeSorted(result.models, BookmarkData::id, bookmarksSorting)
+        _bookmarks.update { current ->
+            current.mergeSorted(result.models, BookmarkData::id, bookmarksSorting)
+        }
     }
 
     override fun onBookmarkFolderRemoved(folderId: String) {
-        _bookmarks.value =
-            _bookmarks.value.map {
+        _bookmarks.update { current ->
+            current.map {
                 if (it.folder?.id == folderId) {
                     // Remove the folder reference from the bookmark
                     it.copy(folder = null)
@@ -80,11 +81,12 @@ internal class BookmarkListStateImpl(override val query: BookmarksQuery) :
                     it
                 }
             }
+        }
     }
 
     override fun onBookmarkFolderUpdated(folder: BookmarkFolderData) {
-        _bookmarks.value =
-            _bookmarks.value.map { bookmark ->
+        _bookmarks.update { current ->
+            current.map { bookmark ->
                 if (bookmark.folder?.id == folder.id) {
                     // Update the folder reference in the bookmark
                     bookmark.copy(folder = folder)
@@ -92,11 +94,12 @@ internal class BookmarkListStateImpl(override val query: BookmarksQuery) :
                     bookmark
                 }
             }
+        }
     }
 
     override fun onBookmarkUpdated(bookmark: BookmarkData) {
-        _bookmarks.value =
-            _bookmarks.value.map {
+        _bookmarks.update { current ->
+            current.map {
                 if (it.id == bookmark.id) {
                     // Update the bookmark with the new data
                     bookmark
@@ -104,6 +107,7 @@ internal class BookmarkListStateImpl(override val query: BookmarksQuery) :
                     it
                 }
             }
+        }
     }
 
     override fun onBookmarkRemoved(bookmark: BookmarkData) {

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListStateImpl.kt
@@ -27,6 +27,7 @@ import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * An observable state object that manages the current state of a comment reaction list.
@@ -65,12 +66,13 @@ internal class CommentReactionListStateImpl(override val query: CommentReactions
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
         // Merge the new reactions with the existing ones (keeping the sort order)
-        _reactions.value =
-            _reactions.value.mergeSorted(result.models, FeedsReactionData::id, reactionsSorting)
+        _reactions.update { current ->
+            current.mergeSorted(result.models, FeedsReactionData::id, reactionsSorting)
+        }
     }
 
     override fun onReactionRemoved(reaction: FeedsReactionData) {
-        _reactions.value = _reactions.value.filter { it.id != reaction.id }
+        _reactions.update { current -> current.filter { it.id != reaction.id } }
     }
 }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListStateImpl.kt
@@ -57,14 +57,15 @@ internal class FeedListStateImpl(override val query: FeedsQuery) : FeedListMutab
         get() = _pagination
 
     override fun onFeedUpdated(feed: FeedData) {
-        _feeds.value =
-            _feeds.value.map {
+        _feeds.update { current ->
+            current.map {
                 if (it.fid == feed.fid) {
                     feed
                 } else {
                     it
                 }
             }
+        }
     }
 
     override fun onFeedRemoved(feedId: String) {
@@ -78,7 +79,9 @@ internal class FeedListStateImpl(override val query: FeedsQuery) : FeedListMutab
         _pagination = result.pagination
         this.queryConfig = queryConfig
         // Merge the new feeds with the existing ones (keeping the sort order)
-        _feeds.value = _feeds.value.mergeSorted(result.models, { it.fid.rawValue }, feedsSorting)
+        _feeds.update { current ->
+            current.mergeSorted(result.models, { it.fid.rawValue }, feedsSorting)
+        }
     }
 }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImpl.kt
@@ -61,18 +61,21 @@ internal class FollowListStateImpl(override val query: FollowsQuery) : FollowLis
         _pagination = result.pagination
         this.queryConfig = queryConfig
         // Merge the new follows with the existing ones (keeping the sort order)
-        _follows.value = _follows.value.mergeSorted(result.models, FollowData::id, followsSorting)
+        _follows.update { current ->
+            current.mergeSorted(result.models, FollowData::id, followsSorting)
+        }
     }
 
     override fun onFollowUpdated(follow: FollowData) {
-        _follows.value =
-            _follows.value.map {
+        _follows.update { current ->
+            current.map {
                 if (it.id == follow.id) {
                     follow
                 } else {
                     it
                 }
             }
+        }
     }
 
     override fun onFollowRemoved(follow: FollowData) {

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListStateImpl.kt
@@ -27,6 +27,7 @@ import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * An observable state object that manages the current state of a moderation config list.
@@ -62,8 +63,9 @@ internal class ModerationConfigListStateImpl(override val query: ModerationConfi
         _pagination = result.pagination
         this.queryConfig = queryConfig
         // Merge the new configs with the existing ones (keeping the sort order)
-        _configs.value =
-            _configs.value.mergeSorted(result.models, ModerationConfigData::id, configsSorting)
+        _configs.update { current ->
+            current.mergeSorted(result.models, ModerationConfigData::id, configsSorting)
+        }
     }
 }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListStateImpl.kt
@@ -27,6 +27,7 @@ import io.getstream.feeds.android.client.internal.utils.mergeSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 
 /**
  * An observable state object that manages the current state of a poll list.
@@ -62,12 +63,12 @@ internal class PollListStateImpl(override val query: PollsQuery) : PollListMutab
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
         // Merge the new polls with the existing ones (keeping the sort order)
-        _polls.value = _polls.value.mergeSorted(result.models, PollData::id, pollsSorting)
+        _polls.update { current -> current.mergeSorted(result.models, PollData::id, pollsSorting) }
     }
 
     override fun onPollUpdated(poll: PollData) {
-        _polls.value =
-            _polls.value.map {
+        _polls.update { current ->
+            current.map {
                 if (it.id == poll.id) {
                     // Update the existing poll with the new data
                     poll
@@ -75,6 +76,7 @@ internal class PollListStateImpl(override val query: PollsQuery) : PollListMutab
                     it
                 }
             }
+        }
     }
 }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListStateImpl.kt
@@ -62,7 +62,9 @@ internal class PollVoteListStateImpl(override val query: PollVotesQuery) :
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
         // Merge the new votes with the existing ones (keeping the sort order)
-        _votes.value = _votes.value.mergeSorted(result.models, PollVoteData::id, votesSorting)
+        _votes.update { current ->
+            current.mergeSorted(result.models, PollVoteData::id, votesSorting)
+        }
     }
 
     override fun pollVoteAdded(vote: PollVoteData) {
@@ -70,12 +72,12 @@ internal class PollVoteListStateImpl(override val query: PollVotesQuery) :
     }
 
     override fun pollVoteRemoved(voteId: String) {
-        _votes.value = _votes.value.filter { it.id != voteId }
+        _votes.update { current -> current.filter { it.id != voteId } }
     }
 
     override fun pollVoteUpdated(vote: PollVoteData) {
-        _votes.value =
-            _votes.value.map {
+        _votes.update { current ->
+            current.map {
                 if (it.id == vote.id) {
                     // Update the existing vote with the new data
                     vote
@@ -83,6 +85,7 @@ internal class PollVoteListStateImpl(override val query: PollVotesQuery) :
                     it
                 }
             }
+        }
     }
 }
 


### PR DESCRIPTION
### Goal

As the title says, we're using `flow.value =` and I'm replacing it with `flow.update` as it ensures the operation is atomic.

### Implementation

Replace `flow.value =` with `flow.update`.

### Testing

No behavior changes should be observed 

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
