### PR TITLE
Use returned activity to update state when deleting a comment

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepository.kt
@@ -16,6 +16,7 @@
 package io.getstream.feeds.android.client.internal.repository
 
 import io.getstream.feeds.android.client.api.file.FeedUploadPayload
+import io.getstream.feeds.android.client.api.model.ActivityData
 import io.getstream.feeds.android.client.api.model.CommentData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.PaginationResult
@@ -89,7 +90,10 @@ internal interface CommentsRepository {
      *   soft-deleted.
      * @return A [Result] indicating success or failure of the deletion operation.
      */
-    suspend fun deleteComment(commentId: String, hardDelete: Boolean?): Result<Unit>
+    suspend fun deleteComment(
+        commentId: String,
+        hardDelete: Boolean?,
+    ): Result<Pair<CommentData, ActivityData>>
 
     /**
      * Retrieves a specific comment by its identifier.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImpl.kt
@@ -18,6 +18,7 @@ package io.getstream.feeds.android.client.internal.repository
 import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.file.FeedUploadPayload
 import io.getstream.feeds.android.client.api.file.FeedUploader
+import io.getstream.feeds.android.client.api.model.ActivityData
 import io.getstream.feeds.android.client.api.model.CommentData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.PaginationData
@@ -122,10 +123,13 @@ internal class CommentsRepositoryImpl(
         )
     }
 
-    override suspend fun deleteComment(commentId: String, hardDelete: Boolean?): Result<Unit> =
-        runSafely {
-            api.deleteComment(commentId, hardDelete)
-        }
+    override suspend fun deleteComment(
+        commentId: String,
+        hardDelete: Boolean?,
+    ): Result<Pair<CommentData, ActivityData>> = runSafely {
+        val response = api.deleteComment(commentId, hardDelete)
+        response.comment.toModel() to response.activity.toModel()
+    }
 
     override suspend fun getComment(commentId: String): Result<CommentData> = runSafely {
         api.getComment(commentId).comment.toModel()

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
@@ -129,9 +129,13 @@ internal class ActivityImpl(
     }
 
     override suspend fun deleteComment(commentId: String, hardDelete: Boolean?): Result<Unit> {
-        return commentsRepository.deleteComment(commentId, hardDelete).onSuccess {
-            commentList.mutableState.onCommentRemoved(commentId)
-        }
+        return commentsRepository
+            .deleteComment(commentId, hardDelete)
+            .onSuccess { (comment, activity) ->
+                commentList.mutableState.onCommentRemoved(comment.id)
+                _state.onActivityUpdated(activity)
+            }
+            .map {}
     }
 
     override suspend fun updateComment(

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
@@ -273,7 +273,10 @@ internal class FeedImpl(
     }
 
     override suspend fun deleteComment(commentId: String, hardDelete: Boolean?): Result<Unit> {
-        return commentsRepository.deleteComment(commentId, hardDelete)
+        return commentsRepository
+            .deleteComment(commentId, hardDelete)
+            .onSuccess { _state.onActivityUpdated(it.second) }
+            .map {}
     }
 
     override suspend fun queryFollowSuggestions(limit: Int?): Result<List<FeedData>> {

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImplTest.kt
@@ -30,6 +30,7 @@ import io.getstream.feeds.android.client.api.state.query.CommentsQuery
 import io.getstream.feeds.android.client.api.state.query.toRequest
 import io.getstream.feeds.android.client.internal.repository.RepositoryTestUtils.testDelegation
 import io.getstream.feeds.android.client.internal.test.TestData.commentResponse
+import io.getstream.feeds.android.client.internal.test.TestData.deleteCommentResponse
 import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionResponse
 import io.getstream.feeds.android.client.internal.test.TestData.userResponse
 import io.getstream.feeds.android.network.apis.FeedsApi
@@ -264,10 +265,12 @@ internal class CommentsRepositoryImplTest {
 
     @Test
     fun `on deleteComment, delegate to api`() {
+        val apiResult = deleteCommentResponse()
         testDelegation(
             apiFunction = { feedsApi.deleteComment("commentId", true) },
             repositoryCall = { repository.deleteComment("commentId", true) },
-            apiResult = Unit,
+            apiResult = apiResult,
+            repositoryResult = apiResult.comment.toModel() to apiResult.activity.toModel(),
         )
     }
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
@@ -161,13 +161,16 @@ internal class ActivityImplTest {
     fun `on deleteComment, delegate to repository and notify state`() = runTest {
         val commentId = "comment1"
         val hardDelete = true
+        val expectedActivity = activityData(id = "activityId", text = "Updated activity")
+        val deleteData = commentData(commentId) to expectedActivity
         coEvery { commentsRepository.deleteComment(commentId, hardDelete) } returns
-            Result.success(Unit)
+            Result.success(deleteData)
 
         val result = activity.deleteComment(commentId, hardDelete)
 
         assertEquals(Unit, result.getOrNull())
         coVerify { commentListState.onCommentRemoved(commentId) }
+        assertEquals(expectedActivity, activity.state.activity.value)
     }
 
     @Test

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
@@ -44,6 +44,7 @@ import io.getstream.feeds.android.network.models.ActivityResponse
 import io.getstream.feeds.android.network.models.BookmarkFolderResponse
 import io.getstream.feeds.android.network.models.BookmarkResponse
 import io.getstream.feeds.android.network.models.CommentResponse
+import io.getstream.feeds.android.network.models.DeleteCommentResponse
 import io.getstream.feeds.android.network.models.FeedMemberResponse
 import io.getstream.feeds.android.network.models.FeedResponse
 import io.getstream.feeds.android.network.models.FeedsReactionResponse
@@ -675,6 +676,13 @@ internal object TestData {
             status = "active",
             upvoteCount = 5,
             custom = emptyMap(),
+        )
+
+    fun deleteCommentResponse() =
+        DeleteCommentResponse(
+            duration = "duration",
+            activity = activityResponse(),
+            comment = commentResponse(),
         )
 
     fun pollVoteResponseData() =


### PR DESCRIPTION
### Goal

The backend now returns the relevant activity when we delete a comment, so we should use that to update what we have locally. The important bit is that it will contain an updated comment count so we don't have to compute it locally.

### Implementation

Update the `Activity` using the `ActivityData` returned by the backend when deleting a comment.

### Testing

Delete a comment in an activity and verify that the comment count is updated accordingly. Note that to verify this in the sample, you should check the `Activity` comment count in debug, because we're using `activity.deleteComment` and that currently only affects the `Activity` object state, while the comment count we display in the feed comes from a `Feed` instance's state.

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
