### PR TITLE
Keep local ownBookmarks, ownReactions, & ownVotes when updating an activity

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/ActivityData.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/ActivityData.kt
@@ -198,6 +198,17 @@ internal fun ActivityResponse.Visibility.toModel(): ActivityDataVisibility =
     }
 
 /**
+ * Extension function to update the activity while preserving own bookmarks, reactions, and poll
+ * votes because "own" data from WS events is not reliable.
+ */
+internal fun ActivityData.update(updated: ActivityData): ActivityData =
+    updated.copy(
+        ownBookmarks = ownBookmarks,
+        ownReactions = ownReactions,
+        poll = updated.poll?.let { poll?.update(it) ?: it },
+    )
+
+/**
  * Adds a comment to the activity, updating the comment count and the list of comments.
  *
  * @param comment The comment to be added.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityStateImpl.kt
@@ -68,8 +68,14 @@ internal class ActivityStateImpl(
         get() = _poll.asStateFlow()
 
     override fun onActivityUpdated(activity: ActivityData) {
-        _activity.update { activity }
-        _poll.update { activity.poll }
+        _activity.update { current -> current?.update(activity) ?: activity }
+        _poll.update { current ->
+            if (activity.poll == null) {
+                null
+            } else {
+                current?.update(activity.poll) ?: activity.poll
+            }
+        }
     }
 
     override fun onReactionAdded(reaction: FeedsReactionData) {

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedStateImpl.kt
@@ -174,16 +174,12 @@ internal class FeedStateImpl(
 
         // Update the activities list
         _activities.update { current ->
-            current.upsertSorted(activity, ActivityData::id, activitiesSorting)
+            current.updateIf({ it.id == activity.id }) { it.update(activity) }
         }
         // Update the pinned activities if the activity is pinned
         _pinnedActivities.update { current ->
-            current.map { pin ->
-                if (pin.activity.id == activity.id) {
-                    pin.copy(activity = activity)
-                } else {
-                    pin
-                }
+            current.updateIf({ it.activity.id == activity.id }) { pin ->
+                pin.copy(activity = pin.activity.update(activity))
             }
         }
     }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
@@ -196,6 +196,8 @@ internal object TestData {
         text: String? = null,
         type: String = "post",
         poll: PollData? = null,
+        ownBookmarks: List<BookmarkData> = emptyList(),
+        ownReactions: List<FeedsReactionData> = emptyList(),
     ): ActivityData =
         ActivityData(
             attachments = emptyList(),
@@ -217,8 +219,8 @@ internal object TestData {
             mentionedUsers = emptyList(),
             moderation = null,
             notificationContext = null,
-            ownBookmarks = emptyList(),
-            ownReactions = emptyList(),
+            ownBookmarks = ownBookmarks,
+            ownReactions = ownReactions,
             parent = null,
             poll = poll,
             popularity = 0,


### PR DESCRIPTION

### Goal

Similar to #80

The backend returns empty "own" properties in WS events because they're expensive to compute, so we compute them locally instead of relying on the ones in the event.

### Implementation

Added an `ActivityData.update` function to update the activity while preserving own properties & use it where we need to perform the updates.

### Testing

Trigger an "activity updated" event and verify that the `own` properties are not overwritten. This is easy to see for example when adding a bookmark in the sample: before these changes, the count would increase but the bookmark wouldn't show as added by the current user.

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
