### PR TITLE
Keep local `ownReactions` when updating a comment

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/CommentData.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/CommentData.kt
@@ -153,3 +153,10 @@ internal fun CommentResponse.toModel(): CommentData =
         upvoteCount = upvoteCount,
         user = user.toModel(),
     )
+
+/**
+ * Updates the comment while preserving own reactions because "own" data from WS events is not
+ * reliable.
+ */
+internal fun CommentData.update(updated: CommentData): CommentData =
+    updated.copy(ownReactions = ownReactions)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/ThreadedCommentData.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/ThreadedCommentData.kt
@@ -229,44 +229,14 @@ internal fun ThreadedCommentData.addReply(
 }
 
 /**
- * Removes a reply from the comment, updating the replies list and reply count.
- *
- * @param comment The reply comment to remove.
- * @return A new [ThreadedCommentData] instance with the updated replies and reply count.
- */
-internal fun ThreadedCommentData.removeReply(comment: ThreadedCommentData): ThreadedCommentData {
-    val replies = this.replies.orEmpty().filter { it.id != comment.id }
-    val replyCount = this.replyCount - 1
-    return this.copy(replies = replies, replyCount = replyCount)
-}
-
-/**
- * Replaces an existing reply in the comment with a new one, updating the replies list.
- *
- * @param comment The new reply comment to replace the existing one.
- * @return A new [ThreadedCommentData] instance with the updated replies.
- */
-internal fun ThreadedCommentData.replaceReply(comment: ThreadedCommentData): ThreadedCommentData {
-    val replies =
-        this.replies.orEmpty().map {
-            if (it.id == comment.id) {
-                comment
-            } else {
-                it
-            }
-        }
-    return this.copy(replies = replies)
-}
-
-/**
  * Sets the comment data for this threaded comment, replacing its properties with those from the
- * provided [CommentData]. The [ThreadedCommentData.meta] and [ThreadedCommentData.replies]
- * properties are preserved from the original instance.
+ * provided [CommentData]. [ThreadedCommentData.ownReactions] is not overwritten because "own" data
+ * coming from WS event is not reliable.
  *
  * @param comment The [CommentData] to set for this threaded comment.
  * @return A new [ThreadedCommentData] instance with the updated comment data.
  */
-internal fun ThreadedCommentData.setCommentData(comment: CommentData): ThreadedCommentData {
+internal fun ThreadedCommentData.update(comment: CommentData): ThreadedCommentData {
     return this.copy(
         attachments = comment.attachments,
         confidenceScore = comment.confidenceScore,
@@ -282,7 +252,7 @@ internal fun ThreadedCommentData.setCommentData(comment: CommentData): ThreadedC
         moderation = comment.moderation,
         objectId = comment.objectId,
         objectType = comment.objectType,
-        ownReactions = comment.ownReactions,
+        ownReactions = this.ownReactions,
         parentId = comment.parentId,
         reactionCount = comment.reactionCount,
         reactionGroups = comment.reactionGroups,

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.model.ThreadedCommentData
 import io.getstream.feeds.android.client.api.model.addReaction
 import io.getstream.feeds.android.client.api.model.addReply
 import io.getstream.feeds.android.client.api.model.removeReaction
-import io.getstream.feeds.android.client.api.model.setCommentData
+import io.getstream.feeds.android.client.api.model.update
 import io.getstream.feeds.android.client.api.state.ActivityCommentListState
 import io.getstream.feeds.android.client.api.state.query.ActivityCommentsQuery
 import io.getstream.feeds.android.client.api.state.query.toComparator
@@ -88,7 +88,7 @@ internal class ActivityCommentListStateImpl(
             current.treeUpdateFirst(
                 matcher = { it.id == comment.id },
                 childrenSelector = { it.replies.orEmpty() },
-                updateElement = { it.setCommentData(comment) },
+                updateElement = { it.update(comment) },
                 updateChildren = { parent, children -> parent.copy(replies = children) },
                 comparator = commentsComparator,
             )

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImpl.kt
@@ -18,6 +18,7 @@ package io.getstream.feeds.android.client.internal.state
 import io.getstream.feeds.android.client.api.model.CommentData
 import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
+import io.getstream.feeds.android.client.api.model.update
 import io.getstream.feeds.android.client.api.state.CommentListState
 import io.getstream.feeds.android.client.api.state.query.CommentsQuery
 import io.getstream.feeds.android.client.api.state.query.toComparator
@@ -71,7 +72,7 @@ internal class CommentListStateImpl(override val query: CommentsQuery) : Comment
             current.treeUpdateFirst(
                 matcher = { it.id == comment.id },
                 childrenSelector = { it.replies.orEmpty() },
-                updateElement = { comment },
+                updateElement = { it.update(comment) },
                 updateChildren = { parent, children -> parent.copy(replies = children) },
                 comparator = comparator,
             )

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListStateImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.model.ThreadedCommentData
 import io.getstream.feeds.android.client.api.model.addReaction
 import io.getstream.feeds.android.client.api.model.addReply
 import io.getstream.feeds.android.client.api.model.removeReaction
-import io.getstream.feeds.android.client.api.model.setCommentData
+import io.getstream.feeds.android.client.api.model.update
 import io.getstream.feeds.android.client.api.state.CommentReplyListState
 import io.getstream.feeds.android.client.api.state.query.CommentRepliesQuery
 import io.getstream.feeds.android.client.api.state.query.toComparator
@@ -145,7 +145,7 @@ internal class CommentReplyListStateImpl(
     ): ThreadedCommentData {
         // If this comment is the parent, update it directly
         if (parent.id == updatedComment.id) {
-            return parent.setCommentData(updatedComment)
+            return parent.update(updatedComment)
         }
         // If the parent has no replies, return it unchanged
         if (parent.replies.isNullOrEmpty()) {

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImplTest.kt
@@ -150,6 +150,24 @@ internal class ActivityCommentListStateImplTest {
     }
 
     @Test
+    fun `on onCommentUpdated, then preserve ownReactions when updating threaded comment`() {
+        val ownReaction = feedsReactionData("c1", "like", "user_1")
+        val originalComment =
+            threadedCommentData(
+                id = "c1",
+                text = "Original comment",
+                ownReactions = listOf(ownReaction),
+            )
+        val update = commentData(id = "c1", text = "Updated comment", ownReactions = emptyList())
+
+        state.onCommentAdded(originalComment)
+        state.onCommentUpdated(update)
+
+        val expectedComment = originalComment.copy(text = "Updated comment")
+        assertEquals(listOf(expectedComment), state.comments.value)
+    }
+
+    @Test
     fun `onCommentRemoved when it's a top-level comment, then remove it from the list`() {
         val comment1 = threadedCommentData(id = "c1", createdAt = Date(1))
         val comment2 = threadedCommentData(id = "c2", createdAt = Date(2))

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImplTest.kt
@@ -20,6 +20,7 @@ import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.CommentsQuery
 import io.getstream.feeds.android.client.api.state.query.CommentsSort
 import io.getstream.feeds.android.client.internal.test.TestData.commentData
+import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
 import java.util.Date
 import org.junit.Assert.assertEquals
 import org.junit.Test
@@ -59,6 +60,23 @@ internal class CommentListStateImplTest {
         state.onCommentUpdated(updatedComment2)
 
         assertEquals(expected, state.comments.value)
+    }
+
+    @Test
+    fun `on onCommentUpdated, then preserve ownReactions when updating comment`() {
+        val ownReaction = feedsReactionData("activity-1", "like", "current-user")
+
+        val originalComment =
+            commentData("comment-1", "Original text", ownReactions = listOf(ownReaction))
+        val result = PaginationResult(listOf(originalComment), PaginationData("next", "previous"))
+
+        val updatedComment = commentData("comment-1", "Updated text", ownReactions = emptyList())
+
+        state.onQueryMoreComments(result)
+        state.onCommentUpdated(updatedComment)
+
+        val expectedComment = updatedComment.copy(ownReactions = listOf(ownReaction))
+        assertEquals(listOf(expectedComment), state.comments.value)
     }
 
     @Test

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
@@ -73,6 +73,7 @@ internal object TestData {
         objectId: String? = null,
         objectType: String = "comment",
         createdAt: Date = Date(1),
+        ownReactions: List<FeedsReactionData> = emptyList(),
     ) =
         CommentData(
             id = id,
@@ -90,7 +91,7 @@ internal object TestData {
             moderation = null,
             objectId = objectId ?: id,
             objectType = objectType,
-            ownReactions = emptyList(),
+            ownReactions = ownReactions,
             reactionCount = 0,
             reactionGroups = emptyMap(),
             replies = emptyList(),
@@ -110,6 +111,7 @@ internal object TestData {
         replies: List<ThreadedCommentData> = emptyList(),
         createdAt: Date = Date(1),
         latestReactions: List<FeedsReactionData> = emptyList(),
+        ownReactions: List<FeedsReactionData> = emptyList(),
         reactionCount: Int = 0,
         reactionGroups: Map<String, ReactionGroupData> = emptyMap(),
         replyCount: Int = replies.size,
@@ -130,7 +132,7 @@ internal object TestData {
             moderation = null,
             objectId = id,
             objectType = "comment",
-            ownReactions = emptyList(),
+            ownReactions = ownReactions,
             reactionCount = reactionCount,
             reactionGroups = reactionGroups,
             replies = replies,


### PR DESCRIPTION
### Goal

The backend returns empty "own" properties in WS events because they're expensive to compute, so we compute them locally instead of relying on the ones in the event.

Like https://github.com/GetStream/stream-feeds-android/pull/80 & https://github.com/GetStream/stream-feeds-android/pull/82

### Implementation

- Added a `CommentData.update` function to update the comment while preserving own reactions & use it where we need to perform the updates.
- Renamed `ThreadedCommentData.setCommentData` to `ThreadedCommentData.update` and change it to preservr own reactions.
- Removed some unused stuff & duplication

### Testing

Manual testing this isn't fully possible atm because of [an unfixed bug in the backend](https://getstream.slack.com/archives/C06RK9WCR09/p1755865823076439)

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
