### PR TITLE
Migrate `CommentList` & `BookmarkList` to consuming state update events

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -273,7 +273,7 @@ internal class FeedsClientImpl(
         BookmarkListImpl(
             query = query,
             bookmarksRepository = bookmarksRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun bookmarkFolderList(query: BookmarkFoldersQuery): BookmarkFolderList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -287,7 +287,7 @@ internal class FeedsClientImpl(
         CommentListImpl(
             query = query,
             commentsRepository = commentsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun activityCommentList(query: ActivityCommentsQuery): ActivityCommentList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.state.BookmarkListState
 import io.getstream.feeds.android.client.api.state.query.BookmarksQuery
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.BookmarkListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A class that manages a paginated list of bookmarks.
@@ -39,7 +39,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class BookmarkListImpl(
     override val query: BookmarksQuery,
     private val bookmarksRepository: BookmarksRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : BookmarkList {
 
     private val _state: BookmarkListStateImpl = BookmarkListStateImpl(query)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListImpl.kt
@@ -22,7 +22,7 @@ import io.getstream.feeds.android.client.api.state.CommentListState
 import io.getstream.feeds.android.client.api.state.query.CommentsQuery
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.CommentListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A class representing a paginated list of comments for a specific query.
@@ -39,7 +39,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class CommentListImpl(
     override val query: CommentsQuery,
     private val commentsRepository: CommentsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : CommentList {
 
     private val _state: CommentListStateImpl = CommentListStateImpl(query)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -15,9 +15,15 @@
  */
 package io.getstream.feeds.android.client.internal.state.event
 
+import io.getstream.feeds.android.client.api.model.BookmarkData
+import io.getstream.feeds.android.client.api.model.BookmarkFolderData
 import io.getstream.feeds.android.client.api.model.CommentData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.toModel
+import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
+import io.getstream.feeds.android.network.models.BookmarkFolderDeletedEvent
+import io.getstream.feeds.android.network.models.BookmarkFolderUpdatedEvent
+import io.getstream.feeds.android.network.models.BookmarkUpdatedEvent
 import io.getstream.feeds.android.network.models.CommentAddedEvent
 import io.getstream.feeds.android.network.models.CommentDeletedEvent
 import io.getstream.feeds.android.network.models.CommentReactionAddedEvent
@@ -30,6 +36,14 @@ import io.getstream.feeds.android.network.models.WSEvent
  * receiving a WebSocket event or having executed a successful API call that can modify the state.
  */
 internal sealed interface StateUpdateEvent {
+
+    data class BookmarkDeleted(val bookmark: BookmarkData) : StateUpdateEvent
+
+    data class BookmarkUpdated(val bookmark: BookmarkData) : StateUpdateEvent
+
+    data class BookmarkFolderDeleted(val folderId: String) : StateUpdateEvent
+
+    data class BookmarkFolderUpdated(val folder: BookmarkFolderData) : StateUpdateEvent
 
     data class CommentAdded(val comment: CommentData) : StateUpdateEvent
 
@@ -46,6 +60,15 @@ internal sealed interface StateUpdateEvent {
 
 internal fun WSEvent.toModel(): StateUpdateEvent? =
     when (this) {
+        is BookmarkDeletedEvent -> StateUpdateEvent.BookmarkDeleted(bookmark.toModel())
+
+        is BookmarkUpdatedEvent -> StateUpdateEvent.BookmarkUpdated(bookmark.toModel())
+
+        is BookmarkFolderDeletedEvent -> StateUpdateEvent.BookmarkFolderDeleted(bookmarkFolder.id)
+
+        is BookmarkFolderUpdatedEvent ->
+            StateUpdateEvent.BookmarkFolderUpdated(bookmarkFolder.toModel())
+
         is CommentAddedEvent -> StateUpdateEvent.CommentAdded(comment.toModel())
 
         is CommentUpdatedEvent -> StateUpdateEvent.CommentUpdated(comment.toModel())

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityCommentListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityCommentListEventHandler.kt
@@ -57,6 +57,8 @@ internal class ActivityCommentListEventHandler(
                     state.onCommentReactionRemoved(event.comment.id, event.reaction)
                 }
             }
+
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BookmarkListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BookmarkListEventHandler.kt
@@ -15,26 +15,22 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.BookmarkListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
-import io.getstream.feeds.android.network.models.BookmarkFolderDeletedEvent
-import io.getstream.feeds.android.network.models.BookmarkFolderUpdatedEvent
-import io.getstream.feeds.android.network.models.BookmarkUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class BookmarkListEventHandler(private val state: BookmarkListStateUpdates) :
-    FeedsEventListener {
+    StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is BookmarkFolderDeletedEvent -> state.onBookmarkFolderRemoved(event.bookmarkFolder.id)
-            is BookmarkFolderUpdatedEvent ->
-                state.onBookmarkFolderUpdated(event.bookmarkFolder.toModel())
+            is StateUpdateEvent.BookmarkFolderDeleted ->
+                state.onBookmarkFolderRemoved(event.folderId)
 
-            is BookmarkUpdatedEvent -> state.onBookmarkUpdated(event.bookmark.toModel())
-            is BookmarkDeletedEvent -> state.onBookmarkRemoved(event.bookmark.toModel())
+            is StateUpdateEvent.BookmarkFolderUpdated -> state.onBookmarkFolderUpdated(event.folder)
+            is StateUpdateEvent.BookmarkUpdated -> state.onBookmarkUpdated(event.bookmark)
+            is StateUpdateEvent.BookmarkDeleted -> state.onBookmarkRemoved(event.bookmark)
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentListEventHandler.kt
@@ -15,20 +15,18 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.CommentListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.CommentDeletedEvent
-import io.getstream.feeds.android.network.models.CommentUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class CommentListEventHandler(private val state: CommentListStateUpdates) :
-    FeedsEventListener {
+    StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is CommentDeletedEvent -> state.onCommentRemoved(event.comment.id)
-            is CommentUpdatedEvent -> state.onCommentUpdated(event.comment.toModel())
+            is StateUpdateEvent.CommentDeleted -> state.onCommentRemoved(event.comment.id)
+            is StateUpdateEvent.CommentUpdated -> state.onCommentUpdated(event.comment)
+            else -> Unit
         }
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.BookmarksQuery
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.bookmarkData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class BookmarkListImplTest {
     private val bookmarksRepository: BookmarksRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = BookmarksQuery(limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.CommentsQuery
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.commentData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class CommentListImplTest {
     private val commentsRepository: CommentsRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = CommentsQuery(filter = null, limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BookmarkListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BookmarkListEventHandlerTest.kt
@@ -15,19 +15,14 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.BookmarkListStateUpdates
-import io.getstream.feeds.android.client.internal.test.TestData.bookmarkFolderResponse
-import io.getstream.feeds.android.client.internal.test.TestData.bookmarkResponse
-import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
-import io.getstream.feeds.android.network.models.BookmarkFolderDeletedEvent
-import io.getstream.feeds.android.network.models.BookmarkFolderUpdatedEvent
-import io.getstream.feeds.android.network.models.BookmarkUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.test.TestData.bookmarkData
+import io.getstream.feeds.android.client.internal.test.TestData.bookmarkFolderData
+import io.getstream.feeds.android.client.internal.test.TestData.commentData
 import io.mockk.called
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.Date
 import org.junit.Test
 
 internal class BookmarkListEventHandlerTest {
@@ -37,70 +32,48 @@ internal class BookmarkListEventHandlerTest {
 
     @Test
     fun `on BookmarkFolderDeletedEvent, then call onBookmarkFolderRemoved`() {
-        val bookmarkFolder = bookmarkFolderResponse()
-        val event =
-            BookmarkFolderDeletedEvent(
-                createdAt = Date(),
-                bookmarkFolder = bookmarkFolder,
-                type = "feeds.bookmark_folder.deleted",
-            )
+        val folderId = "folder-1"
+        val event = StateUpdateEvent.BookmarkFolderDeleted(folderId)
 
         handler.onEvent(event)
 
-        verify { state.onBookmarkFolderRemoved(bookmarkFolder.id) }
+        verify { state.onBookmarkFolderRemoved(folderId) }
     }
 
     @Test
     fun `on BookmarkFolderUpdatedEvent, then call onBookmarkFolderUpdated`() {
-        val bookmarkFolder = bookmarkFolderResponse()
-        val event =
-            BookmarkFolderUpdatedEvent(
-                createdAt = Date(),
-                bookmarkFolder = bookmarkFolder,
-                type = "feeds.bookmark_folder.updated",
-            )
+        val folder = bookmarkFolderData()
+        val event = StateUpdateEvent.BookmarkFolderUpdated(folder)
 
         handler.onEvent(event)
 
-        verify { state.onBookmarkFolderUpdated(bookmarkFolder.toModel()) }
+        verify { state.onBookmarkFolderUpdated(folder) }
     }
 
     @Test
     fun `on BookmarkUpdatedEvent, then call onBookmarkUpdated`() {
-        val bookmark = bookmarkResponse()
-        val event =
-            BookmarkUpdatedEvent(
-                createdAt = Date(),
-                bookmark = bookmark,
-                type = "feeds.bookmark.updated",
-            )
+        val bookmark = bookmarkData()
+        val event = StateUpdateEvent.BookmarkUpdated(bookmark)
 
         handler.onEvent(event)
 
-        verify { state.onBookmarkUpdated(bookmark.toModel()) }
+        verify { state.onBookmarkUpdated(bookmark) }
     }
 
     @Test
     fun `on BookmarkDeletedEvent, then call onBookmarkRemoved`() {
-        val bookmark = bookmarkResponse()
-        val event =
-            BookmarkDeletedEvent(
-                createdAt = Date(),
-                bookmark = bookmark,
-                type = "feeds.bookmark.updated",
-            )
+        val bookmark = bookmarkData()
+        val event = StateUpdateEvent.BookmarkDeleted(bookmark)
 
         handler.onEvent(event)
 
-        verify { state.onBookmarkRemoved(bookmark.toModel()) }
+        verify { state.onBookmarkRemoved(bookmark) }
     }
 
     @Test
     fun `on unknown event, then do nothing`() {
-        val unknownEvent =
-            object : WSEvent {
-                override fun getWSEventType(): String = "unknown.event"
-            }
+        val comment = commentData()
+        val unknownEvent = StateUpdateEvent.CommentAdded(comment)
 
         handler.onEvent(unknownEvent)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentListEventHandlerTest.kt
@@ -15,16 +15,12 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.CommentListStateUpdates
-import io.getstream.feeds.android.client.internal.test.TestData.commentResponse
-import io.getstream.feeds.android.network.models.CommentDeletedEvent
-import io.getstream.feeds.android.network.models.CommentUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.test.TestData.commentData
 import io.mockk.called
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.Date
 import org.junit.Test
 
 internal class CommentListEventHandlerTest {
@@ -34,42 +30,28 @@ internal class CommentListEventHandlerTest {
 
     @Test
     fun `on CommentUpdatedEvent, then call onCommentUpdated`() {
-        val comment = commentResponse()
-        val event =
-            CommentUpdatedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                type = "feeds.comment.updated",
-            )
+        val comment = commentData()
+        val event = StateUpdateEvent.CommentUpdated(comment)
 
         handler.onEvent(event)
 
-        verify { state.onCommentUpdated(comment.toModel()) }
+        verify { state.onCommentUpdated(comment) }
     }
 
     @Test
     fun `on CommentDeletedEvent, then call onCommentRemoved`() {
-        val comment = commentResponse()
-        val event =
-            CommentDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                type = "feeds.comment.deleted",
-            )
+        val comment = commentData()
+        val event = StateUpdateEvent.CommentDeleted(comment)
 
         handler.onEvent(event)
 
-        verify { state.onCommentRemoved(event.comment.id) }
+        verify { state.onCommentRemoved(comment.id) }
     }
 
     @Test
     fun `on unknown event, then do nothing`() {
-        val unknownEvent =
-            object : WSEvent {
-                override fun getWSEventType(): String = "unknown.event"
-            }
+        val comment = commentData()
+        val unknownEvent = StateUpdateEvent.CommentAdded(comment)
 
         handler.onEvent(unknownEvent)
 


### PR DESCRIPTION
### Goal

Continuing from https://github.com/GetStream/stream-feeds-android/pull/83, we migrate the `CommentList` & `BookmarkList`

### Implementation

Change handler from `WSEvent` to `StateUpdateEvent`

### Testing

Nothing should change externally, as here we're just consuming WS events using different types from before, but not emitting events from new places (yet).

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
