### PR TITLE
Migrate `FeedList`, `ActivityReactionList`, `CommentReactionList`, `BookmarkFolderList` to consuming state update events

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -280,7 +280,7 @@ internal class FeedsClientImpl(
         BookmarkFolderListImpl(
             query = query,
             bookmarksRepository = bookmarksRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun commentList(query: CommentsQuery): CommentList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -204,7 +204,7 @@ internal class FeedsClientImpl(
         FeedListImpl(
             query = query,
             feedsRepository = feedsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun followList(query: FollowsQuery): FollowList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -250,7 +250,7 @@ internal class FeedsClientImpl(
         ActivityReactionListImpl(
             query = query,
             activitiesRepository = activitiesRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override suspend fun addActivity(request: AddActivityRequest): Result<ActivityData> {

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -310,7 +310,7 @@ internal class FeedsClientImpl(
         CommentReactionListImpl(
             query = query,
             commentsRepository = commentsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun memberList(query: MembersQuery): MemberList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListImpl.kt
@@ -24,7 +24,7 @@ import io.getstream.feeds.android.client.api.state.query.ActivityReactionsQuery
 import io.getstream.feeds.android.client.api.state.query.toRequest
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.ActivityReactionListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A list of activity reactions that provides pagination, filtering, and real-time updates.
@@ -42,7 +42,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class ActivityReactionListImpl(
     override val query: ActivityReactionsQuery,
     private val activitiesRepository: ActivitiesRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : ActivityReactionList {
 
     private val _state = ActivityReactionListStateImpl(query)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.state.BookmarkFolderListState
 import io.getstream.feeds.android.client.api.state.query.BookmarkFoldersQuery
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.BookmarkFolderListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A class that manages a paginated list of bookmark folders.
@@ -40,7 +40,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class BookmarkFolderListImpl(
     override val query: BookmarkFoldersQuery,
     private val bookmarksRepository: BookmarksRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : BookmarkFolderList {
 
     private val _state: BookmarkFolderListStateImpl = BookmarkFolderListStateImpl(query)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.state.CommentReactionListState
 import io.getstream.feeds.android.client.api.state.query.CommentReactionsQuery
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.CommentReactionListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A class representing a paginated list of reactions for a specific comment.
@@ -40,7 +40,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class CommentReactionListImpl(
     override val query: CommentReactionsQuery,
     private val commentsRepository: CommentsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : CommentReactionList {
 
     private val _state: CommentReactionListStateImpl = CommentReactionListStateImpl(query)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.state.FeedListState
 import io.getstream.feeds.android.client.api.state.query.FeedsQuery
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.FeedListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * Represents a list of feeds with a query and state.
@@ -36,7 +36,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class FeedListImpl(
     override val query: FeedsQuery,
     private val feedsRepository: FeedsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : FeedList {
 
     private val _state: FeedListStateImpl = FeedListStateImpl(query)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -18,6 +18,7 @@ package io.getstream.feeds.android.client.internal.state.event
 import io.getstream.feeds.android.client.api.model.BookmarkData
 import io.getstream.feeds.android.client.api.model.BookmarkFolderData
 import io.getstream.feeds.android.client.api.model.CommentData
+import io.getstream.feeds.android.client.api.model.FeedData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
@@ -29,6 +30,8 @@ import io.getstream.feeds.android.network.models.CommentDeletedEvent
 import io.getstream.feeds.android.network.models.CommentReactionAddedEvent
 import io.getstream.feeds.android.network.models.CommentReactionDeletedEvent
 import io.getstream.feeds.android.network.models.CommentUpdatedEvent
+import io.getstream.feeds.android.network.models.FeedDeletedEvent
+import io.getstream.feeds.android.network.models.FeedUpdatedEvent
 import io.getstream.feeds.android.network.models.WSEvent
 
 /**
@@ -56,6 +59,10 @@ internal sealed interface StateUpdateEvent {
 
     data class CommentReactionDeleted(val comment: CommentData, val reaction: FeedsReactionData) :
         StateUpdateEvent
+
+    data class FeedUpdated(val feed: FeedData) : StateUpdateEvent
+
+    data class FeedDeleted(val fid: String) : StateUpdateEvent
 }
 
 internal fun WSEvent.toModel(): StateUpdateEvent? =
@@ -80,6 +87,10 @@ internal fun WSEvent.toModel(): StateUpdateEvent? =
 
         is CommentReactionDeletedEvent ->
             StateUpdateEvent.CommentReactionDeleted(comment.toModel(), reaction.toModel())
+
+        is FeedUpdatedEvent -> StateUpdateEvent.FeedUpdated(feed.toModel())
+
+        is FeedDeletedEvent -> StateUpdateEvent.FeedDeleted(fid)
 
         else -> null
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -21,6 +21,8 @@ import io.getstream.feeds.android.client.api.model.CommentData
 import io.getstream.feeds.android.client.api.model.FeedData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.toModel
+import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
+import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
 import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
 import io.getstream.feeds.android.network.models.BookmarkFolderDeletedEvent
 import io.getstream.feeds.android.network.models.BookmarkFolderUpdatedEvent
@@ -39,6 +41,10 @@ import io.getstream.feeds.android.network.models.WSEvent
  * receiving a WebSocket event or having executed a successful API call that can modify the state.
  */
 internal sealed interface StateUpdateEvent {
+
+    data class ActivityReactionAdded(val reaction: FeedsReactionData) : StateUpdateEvent
+
+    data class ActivityReactionDeleted(val reaction: FeedsReactionData) : StateUpdateEvent
 
     data class BookmarkDeleted(val bookmark: BookmarkData) : StateUpdateEvent
 
@@ -67,6 +73,11 @@ internal sealed interface StateUpdateEvent {
 
 internal fun WSEvent.toModel(): StateUpdateEvent? =
     when (this) {
+        is ActivityReactionAddedEvent -> StateUpdateEvent.ActivityReactionAdded(reaction.toModel())
+
+        is ActivityReactionDeletedEvent ->
+            StateUpdateEvent.ActivityReactionDeleted(reaction.toModel())
+
         is BookmarkDeletedEvent -> StateUpdateEvent.BookmarkDeleted(bookmark.toModel())
 
         is BookmarkUpdatedEvent -> StateUpdateEvent.BookmarkUpdated(bookmark.toModel())

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandler.kt
@@ -15,31 +15,30 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.ActivityReactionListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class ActivityReactionListEventHandler(
     private val activityId: String,
     private val state: ActivityReactionListStateUpdates,
-) : FeedsEventListener {
+) : StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is ActivityReactionAddedEvent -> {
-                if (event.activity.id == activityId) {
-                    state.onReactionAdded(event.reaction.toModel())
+            is StateUpdateEvent.ActivityReactionAdded -> {
+                if (event.reaction.activityId == activityId) {
+                    state.onReactionAdded(event.reaction)
                 }
             }
 
-            is ActivityReactionDeletedEvent -> {
-                if (event.activity.id == activityId) {
-                    state.onReactionRemoved(event.reaction.toModel())
+            is StateUpdateEvent.ActivityReactionDeleted -> {
+                if (event.reaction.activityId == activityId) {
+                    state.onReactionRemoved(event.reaction)
                 }
             }
+
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BookmarkFolderListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BookmarkFolderListEventHandler.kt
@@ -15,21 +15,19 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.BookmarkFolderListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.BookmarkFolderDeletedEvent
-import io.getstream.feeds.android.network.models.BookmarkFolderUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class BookmarkFolderListEventHandler(private val state: BookmarkFolderListStateUpdates) :
-    FeedsEventListener {
+    StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is BookmarkFolderDeletedEvent -> state.onBookmarkFolderRemoved(event.bookmarkFolder.id)
-            is BookmarkFolderUpdatedEvent ->
-                state.onBookmarkFolderUpdated(event.bookmarkFolder.toModel())
+            is StateUpdateEvent.BookmarkFolderDeleted ->
+                state.onBookmarkFolderRemoved(event.folderId)
+            is StateUpdateEvent.BookmarkFolderUpdated -> state.onBookmarkFolderUpdated(event.folder)
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReactionListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReactionListEventHandler.kt
@@ -15,17 +15,16 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.CommentReactionListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.CommentReactionDeletedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class CommentReactionListEventHandler(private val state: CommentReactionListStateUpdates) :
-    FeedsEventListener {
-    override fun onEvent(event: WSEvent) {
+    StateUpdateEventListener {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is CommentReactionDeletedEvent -> state.onReactionRemoved(event.reaction.toModel())
+            is StateUpdateEvent.CommentReactionDeleted -> state.onReactionRemoved(event.reaction)
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.ActivityReactionsQuery
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class ActivityReactionListImplTest {
     private val activitiesRepository: ActivitiesRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = ActivityReactionsQuery(activityId = "activity-1", limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.BookmarkFoldersQuery
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.bookmarkFolderData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class BookmarkFolderListImplTest {
     private val bookmarksRepository: BookmarksRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = BookmarkFoldersQuery(limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.CommentReactionsQuery
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class CommentReactionListImplTest {
     private val commentsRepository: CommentsRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = CommentReactionsQuery(commentId = "comment-1", limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.FeedsQuery
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.feedData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class FeedListImplTest {
     private val feedsRepository: FeedsRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = FeedsQuery(limit = 10, watch = false)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandlerTest.kt
@@ -15,17 +15,12 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.ActivityReactionListStateUpdates
-import io.getstream.feeds.android.client.internal.test.TestData.activityResponse
-import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionResponse
-import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
 import io.mockk.called
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.Date
 import org.junit.Test
 
 internal class ActivityReactionListEventHandlerTest {
@@ -35,35 +30,19 @@ internal class ActivityReactionListEventHandlerTest {
     private val handler = ActivityReactionListEventHandler(activityId, state)
 
     @Test
-    fun `on ActivityReactionAddedEvent for matching activity, then call onReactionAdded`() {
-        val activity = activityResponse(activityId)
-        val reaction = feedsReactionResponse()
-        val event =
-            ActivityReactionAddedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                activity = activity,
-                reaction = reaction,
-                type = "feeds.activity.reaction.added",
-            )
+    fun `on ActivityReactionAdded for matching activity, then call onReactionAdded`() {
+        val reaction = feedsReactionData(activityId)
+        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
 
         handler.onEvent(event)
 
-        verify { state.onReactionAdded(reaction.toModel()) }
+        verify { state.onReactionAdded(reaction) }
     }
 
     @Test
-    fun `on ActivityReactionAddedEvent for different activity, then do not call onReactionAdded`() {
-        val activity = activityResponse("different-activity")
-        val reaction = feedsReactionResponse()
-        val event =
-            ActivityReactionAddedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                activity = activity,
-                reaction = reaction,
-                type = "feeds.activity.reaction.added",
-            )
+    fun `on ActivityReactionAdded for different activity, then do not call onReactionAdded`() {
+        val reaction = feedsReactionData("different-activity")
+        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
 
         handler.onEvent(event)
 
@@ -71,35 +50,19 @@ internal class ActivityReactionListEventHandlerTest {
     }
 
     @Test
-    fun `on ActivityReactionDeletedEvent for matching activity, then call onReactionRemoved`() {
-        val activity = activityResponse(activityId)
-        val reaction = feedsReactionResponse()
-        val event =
-            ActivityReactionDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                activity = activity,
-                reaction = reaction,
-                type = "feeds.activity.reaction.deleted",
-            )
+    fun `on ActivityReactionDeleted for matching activity, then call onReactionRemoved`() {
+        val reaction = feedsReactionData(activityId)
+        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
 
         handler.onEvent(event)
 
-        verify { state.onReactionRemoved(reaction.toModel()) }
+        verify { state.onReactionRemoved(reaction) }
     }
 
     @Test
-    fun `on ActivityReactionDeletedEvent for different activity, then do not call onReactionRemoved`() {
-        val activity = activityResponse("different-activity")
-        val reaction = feedsReactionResponse()
-        val event =
-            ActivityReactionDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                activity = activity,
-                reaction = reaction,
-                type = "feeds.activity.reaction.deleted",
-            )
+    fun `on ActivityReactionDeleted for different activity, then do not call onReactionRemoved`() {
+        val reaction = feedsReactionData("different-activity")
+        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
 
         handler.onEvent(event)
 
@@ -108,10 +71,7 @@ internal class ActivityReactionListEventHandlerTest {
 
     @Test
     fun `on unknown event, then do nothing`() {
-        val unknownEvent =
-            object : WSEvent {
-                override fun getWSEventType(): String = "unknown.event"
-            }
+        val unknownEvent = StateUpdateEvent.BookmarkFolderDeleted("folder-id")
 
         handler.onEvent(unknownEvent)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BaseEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BaseEventHandlerTest.kt
@@ -15,24 +15,35 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.internal.state.FeedListStateUpdates
 import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
 import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
+import io.mockk.MockKVerificationScope
+import io.mockk.verify
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 
-internal class FeedListEventHandler(private val state: FeedListStateUpdates) :
-    StateUpdateEventListener {
+@RunWith(Parameterized::class)
+internal abstract class BaseEventHandlerTest<State>(
+    protected val testName: String,
+    protected val event: StateUpdateEvent,
+    protected val verifyBlock: MockKVerificationScope.(State) -> Unit,
+) {
+    protected abstract val state: State
 
-    override fun onEvent(event: StateUpdateEvent) {
-        when (event) {
-            is StateUpdateEvent.FeedUpdated -> {
-                state.onFeedUpdated(event.feed)
-            }
+    protected abstract val handler: StateUpdateEventListener
 
-            is StateUpdateEvent.FeedDeleted -> {
-                state.onFeedRemoved(event.fid)
-            }
+    @Test
+    internal fun `handle event`() {
+        handler.onEvent(event)
+        verify { verifyBlock(state) }
+    }
 
-            else -> {}
-        }
+    companion object {
+        fun <S> testParams(
+            name: String,
+            event: StateUpdateEvent,
+            verifyBlock: MockKVerificationScope.(S) -> Unit,
+        ): Array<Any> = arrayOf(name, event, verifyBlock)
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReactionListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReactionListEventHandlerTest.kt
@@ -15,16 +15,13 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.CommentReactionListStateUpdates
-import io.getstream.feeds.android.client.internal.test.TestData.commentResponse
-import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionResponse
-import io.getstream.feeds.android.network.models.CommentReactionDeletedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.test.TestData.commentData
+import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
 import io.mockk.called
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.Date
 import org.junit.Test
 
 internal class CommentReactionListEventHandlerTest {
@@ -33,29 +30,19 @@ internal class CommentReactionListEventHandlerTest {
     private val handler = CommentReactionListEventHandler(state)
 
     @Test
-    fun `on CommentReactionDeletedEvent, then call onReactionRemoved`() {
-        val reaction = feedsReactionResponse()
-        val comment = commentResponse()
-        val event =
-            CommentReactionDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                reaction = reaction,
-                type = "feeds.comment.reaction.deleted",
-            )
+    fun `on CommentReactionDeleted, then call onReactionRemoved`() {
+        val reaction = feedsReactionData()
+        val comment = commentData()
+        val event = StateUpdateEvent.CommentReactionDeleted(comment, reaction)
 
         handler.onEvent(event)
 
-        verify { state.onReactionRemoved(reaction.toModel()) }
+        verify { state.onReactionRemoved(reaction) }
     }
 
     @Test
     fun `on unknown event, then do nothing`() {
-        val unknownEvent =
-            object : WSEvent {
-                override fun getWSEventType(): String = "unknown.event"
-            }
+        val unknownEvent = StateUpdateEvent.BookmarkFolderDeleted("folder-id")
 
         handler.onEvent(unknownEvent)
 


### PR DESCRIPTION
### Goal

Same as #87, but for `FeedList`, `ActivityReactionList`, `CommentReactionList`, `BookmarkFolderList`

### Implementation

Change handler from `WSEvent` to `StateUpdateEvent`

### Testing

Nothing should change externally, as here we're just consuming WS events using different types from before, but not emitting events from new places (yet).

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
