### PR TITLE
Migrate the remaining `XyzList` controllers

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -244,7 +244,7 @@ internal class FeedsClientImpl(
             query = query,
             currentUserId = user.id,
             activitiesRepository = activitiesRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun activityReactionList(query: ActivityReactionsQuery): ActivityReactionList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -303,7 +303,7 @@ internal class FeedsClientImpl(
             query = query,
             currentUserId = user.id,
             commentsRepository = commentsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun commentReactionList(query: CommentReactionsQuery): CommentReactionList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -332,7 +332,7 @@ internal class FeedsClientImpl(
         PollListImpl(
             query = query,
             pollsRepository = pollsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun moderationConfigList(query: ModerationConfigsQuery): ModerationConfigList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -196,7 +196,8 @@ internal class FeedsClientImpl(
             commentsRepository = commentsRepository,
             feedsRepository = feedsRepository,
             pollsRepository = pollsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            socketSubscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
             feedWatchHandler = feedWatchHandler,
         )
 
@@ -317,7 +318,7 @@ internal class FeedsClientImpl(
         MemberListImpl(
             query = query,
             feedsRepository = feedsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun pollVoteList(query: PollVotesQuery): PollVoteList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -325,7 +325,7 @@ internal class FeedsClientImpl(
         PollVoteListImpl(
             query = query,
             repository = pollsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun pollList(query: PollsQuery): PollList =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -211,7 +211,7 @@ internal class FeedsClientImpl(
         FollowListImpl(
             query = query,
             feedsRepository = feedsRepository,
-            subscriptionManager = feedsEventsSubscriptionManager,
+            subscriptionManager = stateEventsSubscriptionManager,
         )
 
     override fun activity(activityId: String, fid: FeedId): Activity =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.state.ActivityListState
 import io.getstream.feeds.android.client.api.state.query.ActivitiesQuery
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.ActivityListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A paginated list of activities that supports real-time updates and filtering.
@@ -42,7 +42,7 @@ internal class ActivityListImpl(
     override val query: ActivitiesQuery,
     private val currentUserId: String,
     private val activitiesRepository: ActivitiesRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : ActivityList {
 
     private val _state: ActivityListStateImpl = ActivityListStateImpl(query, currentUserId)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListImpl.kt
@@ -22,7 +22,7 @@ import io.getstream.feeds.android.client.api.state.CommentReplyListState
 import io.getstream.feeds.android.client.api.state.query.CommentRepliesQuery
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.CommentReplyListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A class representing a paginated list of replies for a specific comment.
@@ -41,7 +41,7 @@ internal class CommentReplyListImpl(
     override val query: CommentRepliesQuery,
     private val currentUserId: String,
     private val commentsRepository: CommentsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : CommentReplyList {
 
     private val _state: CommentReplyListStateImpl = CommentReplyListStateImpl(query, currentUserId)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
@@ -40,6 +40,7 @@ import io.getstream.feeds.android.client.internal.repository.FeedsRepository
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.FeedEventHandler
 import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.utils.flatMap
 import io.getstream.feeds.android.network.models.AcceptFollowRequest
 import io.getstream.feeds.android.network.models.AddActivityRequest
@@ -81,7 +82,8 @@ import io.getstream.feeds.android.network.models.UpdateFeedRequest
  * @property commentsRepository The [CommentsRepository] used to manage comments in the feed.
  * @property feedsRepository The [FeedsRepository] used to manage feed data and operations.
  * @property pollsRepository The [PollsRepository] used to manage polls in the feed.
- * @property subscriptionManager The [StreamSubscriptionManager] used to manage WebSocket
+ * @property subscriptionManager The manager for state update subscriptions.
+ * @param socketSubscriptionManager The [StreamSubscriptionManager] used to manage WebSocket
  *   subscriptions for feed events.
  */
 internal class FeedImpl(
@@ -92,7 +94,8 @@ internal class FeedImpl(
     private val commentsRepository: CommentsRepository,
     private val feedsRepository: FeedsRepository,
     private val pollsRepository: PollsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
+    socketSubscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
     private val feedWatchHandler: FeedWatchHandler,
 ) : Feed {
 
@@ -113,7 +116,7 @@ internal class FeedImpl(
     private val eventHandler = FeedEventHandler(fid = fid, state = _state)
 
     init {
-        subscriptionManager.subscribe(eventHandler)
+        socketSubscriptionManager.subscribe(eventHandler)
     }
 
     private val group: String

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListImpl.kt
@@ -24,7 +24,7 @@ import io.getstream.feeds.android.client.api.state.query.FollowsQuery
 import io.getstream.feeds.android.client.api.state.query.toRequest
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.FollowListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A class that manages a paginated list of follows.
@@ -40,7 +40,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class FollowListImpl(
     override val query: FollowsQuery,
     private val feedsRepository: FeedsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : FollowList {
 
     private val _state: FollowListStateImpl = FollowListStateImpl(query)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListImpl.kt
@@ -24,7 +24,7 @@ import io.getstream.feeds.android.client.api.state.query.MembersQuery
 import io.getstream.feeds.android.client.api.state.query.toRequest
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.MemberListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * A class that manages a paginated list of feed members.
@@ -40,7 +40,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class MemberListImpl(
     override val query: MembersQuery,
     private val feedsRepository: FeedsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
 ) : MemberList {
 
     private val _state: MemberListStateImpl = MemberListStateImpl(query)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.state.PollListState
 import io.getstream.feeds.android.client.api.state.query.PollsQuery
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.PollListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * Implementation of [PollList] that manages the state of a list of polls.
@@ -41,7 +41,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class PollListImpl(
     override val query: PollsQuery,
     private val pollsRepository: PollsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
     private val _state: PollListStateImpl = PollListStateImpl(query),
 ) : PollList {
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListImpl.kt
@@ -23,7 +23,7 @@ import io.getstream.feeds.android.client.api.state.PollVoteListState
 import io.getstream.feeds.android.client.api.state.query.PollVotesQuery
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.PollVoteListEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * An implementation of [PollVoteList] that manages the state and queries for poll votes.
@@ -41,7 +41,7 @@ import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 internal class PollVoteListImpl(
     override val query: PollVotesQuery,
     private val repository: PollsRepository,
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
     private val _state: PollVoteListStateImpl = PollVoteListStateImpl(query),
 ) : PollVoteList {
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -62,11 +62,9 @@ internal sealed interface StateUpdateEvent {
 
     data class ActivityDeleted(val activity: ActivityData) : StateUpdateEvent
 
-    data class ActivityReactionAdded(val fid: String, val reaction: FeedsReactionData) :
-        StateUpdateEvent
+    data class ActivityReactionAdded(val reaction: FeedsReactionData) : StateUpdateEvent
 
-    data class ActivityReactionDeleted(val fid: String, val reaction: FeedsReactionData) :
-        StateUpdateEvent
+    data class ActivityReactionDeleted(val reaction: FeedsReactionData) : StateUpdateEvent
 
     data class BookmarkAdded(val bookmark: BookmarkData) : StateUpdateEvent
 
@@ -124,11 +122,10 @@ internal fun WSEvent.toModel(): StateUpdateEvent? =
     when (this) {
         is ActivityDeletedEvent -> StateUpdateEvent.ActivityDeleted(activity.toModel())
 
-        is ActivityReactionAddedEvent ->
-            StateUpdateEvent.ActivityReactionAdded(fid, reaction.toModel())
+        is ActivityReactionAddedEvent -> StateUpdateEvent.ActivityReactionAdded(reaction.toModel())
 
         is ActivityReactionDeletedEvent ->
-            StateUpdateEvent.ActivityReactionDeleted(fid, reaction.toModel())
+            StateUpdateEvent.ActivityReactionDeleted(reaction.toModel())
 
         is BookmarkAddedEvent -> StateUpdateEvent.BookmarkAdded(bookmark.toModel())
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -23,6 +23,7 @@ import io.getstream.feeds.android.client.api.model.FeedMemberData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.FollowData
 import io.getstream.feeds.android.client.api.model.PollData
+import io.getstream.feeds.android.client.api.model.PollVoteData
 import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
 import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
@@ -42,7 +43,12 @@ import io.getstream.feeds.android.network.models.FeedMemberUpdatedEvent
 import io.getstream.feeds.android.network.models.FeedUpdatedEvent
 import io.getstream.feeds.android.network.models.FollowDeletedEvent
 import io.getstream.feeds.android.network.models.FollowUpdatedEvent
+import io.getstream.feeds.android.network.models.PollClosedFeedEvent
+import io.getstream.feeds.android.network.models.PollDeletedFeedEvent
 import io.getstream.feeds.android.network.models.PollUpdatedFeedEvent
+import io.getstream.feeds.android.network.models.PollVoteCastedFeedEvent
+import io.getstream.feeds.android.network.models.PollVoteChangedFeedEvent
+import io.getstream.feeds.android.network.models.PollVoteRemovedFeedEvent
 import io.getstream.feeds.android.network.models.WSEvent
 
 /**
@@ -89,7 +95,20 @@ internal sealed interface StateUpdateEvent {
 
     data class FollowDeleted(val follow: FollowData) : StateUpdateEvent
 
-    data class PollUpdated(val poll: PollData) : StateUpdateEvent
+    data class PollClosed(val fid: String, val poll: PollData) : StateUpdateEvent
+
+    data class PollDeleted(val fid: String, val pollId: String) : StateUpdateEvent
+
+    data class PollUpdated(val fid: String, val poll: PollData) : StateUpdateEvent
+
+    data class PollVoteCasted(val fid: String, val pollId: String, val vote: PollVoteData) :
+        StateUpdateEvent
+
+    data class PollVoteChanged(val fid: String, val pollId: String, val vote: PollVoteData) :
+        StateUpdateEvent
+
+    data class PollVoteRemoved(val fid: String, val pollId: String, val vote: PollVoteData) :
+        StateUpdateEvent
 }
 
 internal fun WSEvent.toModel(): StateUpdateEvent? =
@@ -134,7 +153,20 @@ internal fun WSEvent.toModel(): StateUpdateEvent? =
 
         is FeedMemberUpdatedEvent -> StateUpdateEvent.FeedMemberUpdated(fid, member.toModel())
 
-        is PollUpdatedFeedEvent -> StateUpdateEvent.PollUpdated(poll.toModel())
+        is PollClosedFeedEvent -> StateUpdateEvent.PollClosed(fid, poll.toModel())
+
+        is PollDeletedFeedEvent -> StateUpdateEvent.PollDeleted(fid, poll.id)
+
+        is PollUpdatedFeedEvent -> StateUpdateEvent.PollUpdated(fid, poll.toModel())
+
+        is PollVoteCastedFeedEvent ->
+            StateUpdateEvent.PollVoteCasted(fid, poll.id, pollVote.toModel())
+
+        is PollVoteChangedFeedEvent ->
+            StateUpdateEvent.PollVoteChanged(fid, poll.id, pollVote.toModel())
+
+        is PollVoteRemovedFeedEvent ->
+            StateUpdateEvent.PollVoteRemoved(fid, poll.id, pollVote.toModel())
 
         else -> null
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -20,6 +20,7 @@ import io.getstream.feeds.android.client.api.model.BookmarkFolderData
 import io.getstream.feeds.android.client.api.model.CommentData
 import io.getstream.feeds.android.client.api.model.FeedData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
+import io.getstream.feeds.android.client.api.model.FollowData
 import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
 import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
@@ -34,6 +35,8 @@ import io.getstream.feeds.android.network.models.CommentReactionDeletedEvent
 import io.getstream.feeds.android.network.models.CommentUpdatedEvent
 import io.getstream.feeds.android.network.models.FeedDeletedEvent
 import io.getstream.feeds.android.network.models.FeedUpdatedEvent
+import io.getstream.feeds.android.network.models.FollowDeletedEvent
+import io.getstream.feeds.android.network.models.FollowUpdatedEvent
 import io.getstream.feeds.android.network.models.WSEvent
 
 /**
@@ -69,6 +72,10 @@ internal sealed interface StateUpdateEvent {
     data class FeedUpdated(val feed: FeedData) : StateUpdateEvent
 
     data class FeedDeleted(val fid: String) : StateUpdateEvent
+
+    data class FollowUpdated(val follow: FollowData) : StateUpdateEvent
+
+    data class FollowDeleted(val follow: FollowData) : StateUpdateEvent
 }
 
 internal fun WSEvent.toModel(): StateUpdateEvent? =
@@ -102,6 +109,10 @@ internal fun WSEvent.toModel(): StateUpdateEvent? =
         is FeedUpdatedEvent -> StateUpdateEvent.FeedUpdated(feed.toModel())
 
         is FeedDeletedEvent -> StateUpdateEvent.FeedDeleted(fid)
+
+        is FollowUpdatedEvent -> StateUpdateEvent.FollowUpdated(follow.toModel())
+
+        is FollowDeletedEvent -> StateUpdateEvent.FollowDeleted(follow.toModel())
 
         else -> null
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -15,6 +15,7 @@
  */
 package io.getstream.feeds.android.client.internal.state.event
 
+import io.getstream.feeds.android.client.api.model.ActivityData
 import io.getstream.feeds.android.client.api.model.BookmarkData
 import io.getstream.feeds.android.client.api.model.BookmarkFolderData
 import io.getstream.feeds.android.client.api.model.CommentData
@@ -25,8 +26,10 @@ import io.getstream.feeds.android.client.api.model.FollowData
 import io.getstream.feeds.android.client.api.model.PollData
 import io.getstream.feeds.android.client.api.model.PollVoteData
 import io.getstream.feeds.android.client.api.model.toModel
+import io.getstream.feeds.android.network.models.ActivityDeletedEvent
 import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
 import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
+import io.getstream.feeds.android.network.models.BookmarkAddedEvent
 import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
 import io.getstream.feeds.android.network.models.BookmarkFolderDeletedEvent
 import io.getstream.feeds.android.network.models.BookmarkFolderUpdatedEvent
@@ -57,9 +60,15 @@ import io.getstream.feeds.android.network.models.WSEvent
  */
 internal sealed interface StateUpdateEvent {
 
-    data class ActivityReactionAdded(val reaction: FeedsReactionData) : StateUpdateEvent
+    data class ActivityDeleted(val activity: ActivityData) : StateUpdateEvent
 
-    data class ActivityReactionDeleted(val reaction: FeedsReactionData) : StateUpdateEvent
+    data class ActivityReactionAdded(val fid: String, val reaction: FeedsReactionData) :
+        StateUpdateEvent
+
+    data class ActivityReactionDeleted(val fid: String, val reaction: FeedsReactionData) :
+        StateUpdateEvent
+
+    data class BookmarkAdded(val bookmark: BookmarkData) : StateUpdateEvent
 
     data class BookmarkDeleted(val bookmark: BookmarkData) : StateUpdateEvent
 
@@ -113,10 +122,15 @@ internal sealed interface StateUpdateEvent {
 
 internal fun WSEvent.toModel(): StateUpdateEvent? =
     when (this) {
-        is ActivityReactionAddedEvent -> StateUpdateEvent.ActivityReactionAdded(reaction.toModel())
+        is ActivityDeletedEvent -> StateUpdateEvent.ActivityDeleted(activity.toModel())
+
+        is ActivityReactionAddedEvent ->
+            StateUpdateEvent.ActivityReactionAdded(fid, reaction.toModel())
 
         is ActivityReactionDeletedEvent ->
-            StateUpdateEvent.ActivityReactionDeleted(reaction.toModel())
+            StateUpdateEvent.ActivityReactionDeleted(fid, reaction.toModel())
+
+        is BookmarkAddedEvent -> StateUpdateEvent.BookmarkAdded(bookmark.toModel())
 
         is BookmarkDeletedEvent -> StateUpdateEvent.BookmarkDeleted(bookmark.toModel())
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -22,6 +22,7 @@ import io.getstream.feeds.android.client.api.model.FeedData
 import io.getstream.feeds.android.client.api.model.FeedMemberData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.FollowData
+import io.getstream.feeds.android.client.api.model.PollData
 import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
 import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
@@ -41,6 +42,7 @@ import io.getstream.feeds.android.network.models.FeedMemberUpdatedEvent
 import io.getstream.feeds.android.network.models.FeedUpdatedEvent
 import io.getstream.feeds.android.network.models.FollowDeletedEvent
 import io.getstream.feeds.android.network.models.FollowUpdatedEvent
+import io.getstream.feeds.android.network.models.PollUpdatedFeedEvent
 import io.getstream.feeds.android.network.models.WSEvent
 
 /**
@@ -86,6 +88,8 @@ internal sealed interface StateUpdateEvent {
     data class FollowUpdated(val follow: FollowData) : StateUpdateEvent
 
     data class FollowDeleted(val follow: FollowData) : StateUpdateEvent
+
+    data class PollUpdated(val poll: PollData) : StateUpdateEvent
 }
 
 internal fun WSEvent.toModel(): StateUpdateEvent? =
@@ -129,6 +133,8 @@ internal fun WSEvent.toModel(): StateUpdateEvent? =
         is FeedMemberRemovedEvent -> StateUpdateEvent.FeedMemberRemoved(fid, memberId)
 
         is FeedMemberUpdatedEvent -> StateUpdateEvent.FeedMemberUpdated(fid, member.toModel())
+
+        is PollUpdatedFeedEvent -> StateUpdateEvent.PollUpdated(poll.toModel())
 
         else -> null
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -19,6 +19,7 @@ import io.getstream.feeds.android.client.api.model.BookmarkData
 import io.getstream.feeds.android.client.api.model.BookmarkFolderData
 import io.getstream.feeds.android.client.api.model.CommentData
 import io.getstream.feeds.android.client.api.model.FeedData
+import io.getstream.feeds.android.client.api.model.FeedMemberData
 import io.getstream.feeds.android.client.api.model.FeedsReactionData
 import io.getstream.feeds.android.client.api.model.FollowData
 import io.getstream.feeds.android.client.api.model.toModel
@@ -34,6 +35,9 @@ import io.getstream.feeds.android.network.models.CommentReactionAddedEvent
 import io.getstream.feeds.android.network.models.CommentReactionDeletedEvent
 import io.getstream.feeds.android.network.models.CommentUpdatedEvent
 import io.getstream.feeds.android.network.models.FeedDeletedEvent
+import io.getstream.feeds.android.network.models.FeedMemberAddedEvent
+import io.getstream.feeds.android.network.models.FeedMemberRemovedEvent
+import io.getstream.feeds.android.network.models.FeedMemberUpdatedEvent
 import io.getstream.feeds.android.network.models.FeedUpdatedEvent
 import io.getstream.feeds.android.network.models.FollowDeletedEvent
 import io.getstream.feeds.android.network.models.FollowUpdatedEvent
@@ -72,6 +76,12 @@ internal sealed interface StateUpdateEvent {
     data class FeedUpdated(val feed: FeedData) : StateUpdateEvent
 
     data class FeedDeleted(val fid: String) : StateUpdateEvent
+
+    data class FeedMemberAdded(val fid: String, val member: FeedMemberData) : StateUpdateEvent
+
+    data class FeedMemberRemoved(val fid: String, val memberId: String) : StateUpdateEvent
+
+    data class FeedMemberUpdated(val fid: String, val member: FeedMemberData) : StateUpdateEvent
 
     data class FollowUpdated(val follow: FollowData) : StateUpdateEvent
 
@@ -113,6 +123,12 @@ internal fun WSEvent.toModel(): StateUpdateEvent? =
         is FollowUpdatedEvent -> StateUpdateEvent.FollowUpdated(follow.toModel())
 
         is FollowDeletedEvent -> StateUpdateEvent.FollowDeleted(follow.toModel())
+
+        is FeedMemberAddedEvent -> StateUpdateEvent.FeedMemberAdded(fid, member.toModel())
+
+        is FeedMemberRemovedEvent -> StateUpdateEvent.FeedMemberRemoved(fid, memberId)
+
+        is FeedMemberUpdatedEvent -> StateUpdateEvent.FeedMemberUpdated(fid, member.toModel())
 
         else -> null
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandler.kt
@@ -15,30 +15,22 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.ActivityListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.ActivityDeletedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
-import io.getstream.feeds.android.network.models.BookmarkAddedEvent
-import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
-import io.getstream.feeds.android.network.models.CommentAddedEvent
-import io.getstream.feeds.android.network.models.CommentDeletedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class ActivityListEventHandler(private val state: ActivityListStateUpdates) :
-    FeedsEventListener {
+    StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is ActivityDeletedEvent -> state.onActivityRemoved(event.activity.toModel())
-            is ActivityReactionAddedEvent -> state.onReactionAdded(event.reaction.toModel())
-            is ActivityReactionDeletedEvent -> state.onReactionRemoved(event.reaction.toModel())
-            is BookmarkAddedEvent -> state.onBookmarkAdded(event.bookmark.toModel())
-            is BookmarkDeletedEvent -> state.onBookmarkRemoved(event.bookmark.toModel())
-            is CommentAddedEvent -> state.onCommentAdded(event.comment.toModel())
-            is CommentDeletedEvent -> state.onCommentRemoved(event.comment.toModel())
+            is StateUpdateEvent.ActivityDeleted -> state.onActivityRemoved(event.activity)
+            is StateUpdateEvent.ActivityReactionAdded -> state.onReactionAdded(event.reaction)
+            is StateUpdateEvent.ActivityReactionDeleted -> state.onReactionRemoved(event.reaction)
+            is StateUpdateEvent.BookmarkAdded -> state.onBookmarkAdded(event.bookmark)
+            is StateUpdateEvent.BookmarkDeleted -> state.onBookmarkRemoved(event.bookmark)
+            is StateUpdateEvent.CommentAdded -> state.onCommentAdded(event.comment)
+            is StateUpdateEvent.CommentDeleted -> state.onCommentRemoved(event.comment)
             else -> {
                 // No action needed for other event types
             }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReplyListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReplyListEventHandler.kt
@@ -16,36 +16,32 @@
 package io.getstream.feeds.android.client.internal.state.event.handler
 
 import io.getstream.feeds.android.client.api.model.ThreadedCommentData
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.CommentReplyListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.CommentAddedEvent
-import io.getstream.feeds.android.network.models.CommentDeletedEvent
-import io.getstream.feeds.android.network.models.CommentReactionAddedEvent
-import io.getstream.feeds.android.network.models.CommentReactionDeletedEvent
-import io.getstream.feeds.android.network.models.CommentUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class CommentReplyListEventHandler(private val state: CommentReplyListStateUpdates) :
-    FeedsEventListener {
+    StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is CommentAddedEvent -> {
-                state.onCommentAdded(ThreadedCommentData(event.comment.toModel()))
+            is StateUpdateEvent.CommentAdded -> {
+                state.onCommentAdded(ThreadedCommentData(event.comment))
             }
-            is CommentDeletedEvent -> {
+            is StateUpdateEvent.CommentDeleted -> {
                 state.onCommentRemoved(event.comment.id)
             }
-            is CommentUpdatedEvent -> {
-                state.onCommentUpdated(event.comment.toModel())
+            is StateUpdateEvent.CommentUpdated -> {
+                state.onCommentUpdated(event.comment)
             }
-            is CommentReactionAddedEvent -> {
-                state.onCommentReactionAdded(event.comment.id, event.reaction.toModel())
+            is StateUpdateEvent.CommentReactionAdded -> {
+                state.onCommentReactionAdded(event.comment.id, event.reaction)
             }
-            is CommentReactionDeletedEvent -> {
-                state.onCommentReactionRemoved(event.comment.id, event.reaction.toModel())
+            is StateUpdateEvent.CommentReactionDeleted -> {
+                state.onCommentReactionRemoved(event.comment.id, event.reaction)
             }
+
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/FollowListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/FollowListEventHandler.kt
@@ -15,25 +15,24 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.FollowListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.FollowDeletedEvent
-import io.getstream.feeds.android.network.models.FollowUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class FollowListEventHandler(private val state: FollowListStateUpdates) :
-    FeedsEventListener {
+    StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is FollowUpdatedEvent -> {
-                state.onFollowUpdated(event.follow.toModel())
+            is StateUpdateEvent.FollowUpdated -> {
+                state.onFollowUpdated(event.follow)
             }
 
-            is FollowDeletedEvent -> {
-                state.onFollowRemoved(event.follow.toModel())
+            is StateUpdateEvent.FollowDeleted -> {
+                state.onFollowRemoved(event.follow)
             }
+
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/MemberListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/MemberListEventHandler.kt
@@ -16,37 +16,35 @@
 package io.getstream.feeds.android.client.internal.state.event.handler
 
 import io.getstream.feeds.android.client.api.model.FeedId
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.MemberListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.FeedMemberAddedEvent
-import io.getstream.feeds.android.network.models.FeedMemberRemovedEvent
-import io.getstream.feeds.android.network.models.FeedMemberUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 internal class MemberListEventHandler(
     private val fid: FeedId,
     private val state: MemberListStateUpdates,
-) : FeedsEventListener {
-    override fun onEvent(event: WSEvent) {
+) : StateUpdateEventListener {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is FeedMemberAddedEvent -> {
+            is StateUpdateEvent.FeedMemberAdded -> {
                 if (event.fid == fid.rawValue) {
-                    state.onMemberAdded(event.member.toModel())
+                    state.onMemberAdded(event.member)
                 }
             }
 
-            is FeedMemberRemovedEvent -> {
+            is StateUpdateEvent.FeedMemberRemoved -> {
                 if (event.fid == fid.rawValue) {
                     state.onMemberRemoved(event.memberId)
                 }
             }
 
-            is FeedMemberUpdatedEvent -> {
+            is StateUpdateEvent.FeedMemberUpdated -> {
                 if (event.fid == fid.rawValue) {
-                    state.onMemberUpdated(event.member.toModel())
+                    state.onMemberUpdated(event.member)
                 }
             }
+
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/PollListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/PollListEventHandler.kt
@@ -24,7 +24,8 @@ import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventList
  *
  * @property state The instance that manages updates to the poll list state.
  */
-internal class PollListEventHandler(private val state: PollListStateUpdates) : StateUpdateEventListener {
+internal class PollListEventHandler(private val state: PollListStateUpdates) :
+    StateUpdateEventListener {
 
     override fun onEvent(event: StateUpdateEvent) {
         when (event) {

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/PollListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/PollListEventHandler.kt
@@ -15,24 +15,24 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.PollListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.PollUpdatedFeedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * Handles events related to poll updates in the poll list state.
  *
  * @property state The instance that manages updates to the poll list state.
  */
-internal class PollListEventHandler(private val state: PollListStateUpdates) : FeedsEventListener {
+internal class PollListEventHandler(private val state: PollListStateUpdates) : StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is PollUpdatedFeedEvent -> {
-                state.onPollUpdated(event.poll.toModel())
+            is StateUpdateEvent.PollUpdated -> {
+                state.onPollUpdated(event.poll)
             }
+
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/PollVoteListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/PollVoteListEventHandler.kt
@@ -15,13 +15,9 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.PollVoteListStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.PollVoteCastedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteChangedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteRemovedFeedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * Handles events related to poll vote lists in the feed state.
@@ -32,24 +28,26 @@ import io.getstream.feeds.android.network.models.WSEvent
 internal class PollVoteListEventHandler(
     private val pollId: String,
     private val state: PollVoteListStateUpdates,
-) : FeedsEventListener {
+) : StateUpdateEventListener {
 
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is PollVoteCastedFeedEvent -> {
-                if (event.poll.id != pollId) return
-                state.pollVoteAdded(event.pollVote.toModel())
+            is StateUpdateEvent.PollVoteCasted -> {
+                if (event.pollId != pollId) return
+                state.pollVoteAdded(event.vote)
             }
 
-            is PollVoteChangedFeedEvent -> {
-                if (event.poll.id != pollId) return
-                state.pollVoteUpdated(event.pollVote.toModel())
+            is StateUpdateEvent.PollVoteChanged -> {
+                if (event.pollId != pollId) return
+                state.pollVoteUpdated(event.vote)
             }
 
-            is PollVoteRemovedFeedEvent -> {
-                if (event.poll.id != pollId) return
-                state.pollVoteRemoved(event.pollVote.id)
+            is StateUpdateEvent.PollVoteRemoved -> {
+                if (event.pollId != pollId) return
+                state.pollVoteRemoved(event.vote.id)
             }
+
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.ActivitiesQuery
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.activityData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class ActivityListImplTest {
     private val activitiesRepository: ActivitiesRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = ActivitiesQuery(limit = 10)
     private val currentUserId = "user-123"

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.model.ThreadedCommentData
 import io.getstream.feeds.android.client.api.state.query.CommentRepliesQuery
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.threadedCommentData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class CommentReplyListImplTest {
     private val commentsRepository: CommentsRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val currentUserId = "user-1"
     private val query = CommentRepliesQuery(commentId = "comment-1", limit = 10)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
@@ -703,6 +703,7 @@ internal class FeedImplTest {
             commentsRepository = commentsRepository,
             feedsRepository = feedsRepository,
             pollsRepository = pollsRepository,
+            socketSubscriptionManager = mockk(relaxed = true),
             subscriptionManager = mockk(relaxed = true),
             feedWatchHandler = feedWatchHandler,
         )

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FollowListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FollowListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.FollowsQuery
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.followData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class FollowListImplTest {
     private val feedsRepository: FeedsRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = FollowsQuery(limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/MemberListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/MemberListImplTest.kt
@@ -22,7 +22,7 @@ import io.getstream.feeds.android.client.api.model.PaginationData
 import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.state.query.MembersQuery
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.feedMemberData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -33,7 +33,7 @@ import org.junit.Test
 
 internal class MemberListImplTest {
     private val feedsRepository: FeedsRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = MembersQuery(fid = FeedId("user", "test"), limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.model.PollData
 import io.getstream.feeds.android.client.api.state.query.PollsQuery
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.pollData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class PollListImplTest {
     private val pollsRepository: PollsRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = PollsQuery(limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListImplTest.kt
@@ -21,7 +21,7 @@ import io.getstream.feeds.android.client.api.model.PaginationResult
 import io.getstream.feeds.android.client.api.model.PollVoteData
 import io.getstream.feeds.android.client.api.state.query.PollVotesQuery
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.pollVoteData
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -32,7 +32,7 @@ import org.junit.Test
 
 internal class PollVoteListImplTest {
     private val pollsRepository: PollsRepository = mockk()
-    private val subscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
+    private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener> =
         mockk(relaxed = true)
     private val query = PollVotesQuery(pollId = "poll-1", userId = "user-1", limit = 10)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandlerTest.kt
@@ -44,7 +44,7 @@ internal class ActivityListEventHandlerTest {
     @Test
     fun `on ActivityReactionAdded, then call onReactionAdded`() {
         val reaction = feedsReactionData("activity-1")
-        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
+        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
 
         handler.onEvent(event)
 
@@ -54,7 +54,7 @@ internal class ActivityListEventHandlerTest {
     @Test
     fun `on ActivityReactionDeleted, then call onReactionRemoved`() {
         val reaction = feedsReactionData("activity-1")
-        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
+        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
 
         handler.onEvent(event)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandlerTest.kt
@@ -15,24 +15,15 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.ActivityListStateUpdates
-import io.getstream.feeds.android.client.internal.test.TestData.activityResponse
-import io.getstream.feeds.android.client.internal.test.TestData.bookmarkResponse
-import io.getstream.feeds.android.client.internal.test.TestData.commentResponse
-import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionResponse
-import io.getstream.feeds.android.network.models.ActivityDeletedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
-import io.getstream.feeds.android.network.models.BookmarkAddedEvent
-import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
-import io.getstream.feeds.android.network.models.CommentAddedEvent
-import io.getstream.feeds.android.network.models.CommentDeletedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.test.TestData.activityData
+import io.getstream.feeds.android.client.internal.test.TestData.bookmarkData
+import io.getstream.feeds.android.client.internal.test.TestData.commentData
+import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
 import io.mockk.called
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.Date
 import org.junit.Test
 
 internal class ActivityListEventHandlerTest {
@@ -41,126 +32,78 @@ internal class ActivityListEventHandlerTest {
     private val handler = ActivityListEventHandler(state)
 
     @Test
-    fun `on ActivityDeletedEvent, then call onActivityRemoved`() {
-        val activity = activityResponse()
-        val event =
-            ActivityDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                activity = activity,
-                type = "feeds.activity.deleted",
-            )
+    fun `on ActivityDeleted, then call onActivityRemoved`() {
+        val activity = activityData()
+        val event = StateUpdateEvent.ActivityDeleted(activity)
 
         handler.onEvent(event)
 
-        verify { state.onActivityRemoved(activity.toModel()) }
+        verify { state.onActivityRemoved(activity) }
     }
 
     @Test
-    fun `on ActivityReactionAddedEvent, then call onReactionAdded`() {
-        val activity = activityResponse()
-        val reaction = feedsReactionResponse()
-        val event =
-            ActivityReactionAddedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                activity = activity,
-                reaction = reaction,
-                type = "feeds.activity.reaction.added",
-            )
+    fun `on ActivityReactionAdded, then call onReactionAdded`() {
+        val reaction = feedsReactionData("activity-1")
+        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
 
         handler.onEvent(event)
 
-        verify { state.onReactionAdded(reaction.toModel()) }
+        verify { state.onReactionAdded(reaction) }
     }
 
     @Test
-    fun `on ActivityReactionDeletedEvent, then call onReactionRemoved`() {
-        val activity = activityResponse()
-        val reaction = feedsReactionResponse()
-        val event =
-            ActivityReactionDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                activity = activity,
-                reaction = reaction,
-                type = "feeds.activity.reaction.deleted",
-            )
+    fun `on ActivityReactionDeleted, then call onReactionRemoved`() {
+        val reaction = feedsReactionData("activity-1")
+        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
 
         handler.onEvent(event)
 
-        verify { state.onReactionRemoved(reaction.toModel()) }
+        verify { state.onReactionRemoved(reaction) }
     }
 
     @Test
-    fun `on BookmarkAddedEvent, then call onBookmarkAdded`() {
-        val bookmark = bookmarkResponse()
-        val event =
-            BookmarkAddedEvent(
-                createdAt = Date(),
-                bookmark = bookmark,
-                type = "feeds.bookmark.added",
-            )
+    fun `on BookmarkAdded, then call onBookmarkAdded`() {
+        val bookmark = bookmarkData()
+        val event = StateUpdateEvent.BookmarkAdded(bookmark)
 
         handler.onEvent(event)
 
-        verify { state.onBookmarkAdded(bookmark.toModel()) }
+        verify { state.onBookmarkAdded(bookmark) }
     }
 
     @Test
-    fun `on BookmarkDeletedEvent, then call onBookmarkRemoved`() {
-        val bookmark = bookmarkResponse()
-        val event =
-            BookmarkDeletedEvent(
-                createdAt = Date(),
-                bookmark = bookmark,
-                type = "feeds.bookmark.deleted",
-            )
+    fun `on BookmarkDeleted, then call onBookmarkRemoved`() {
+        val bookmark = bookmarkData()
+        val event = StateUpdateEvent.BookmarkDeleted(bookmark)
 
         handler.onEvent(event)
 
-        verify { state.onBookmarkRemoved(bookmark.toModel()) }
+        verify { state.onBookmarkRemoved(bookmark) }
     }
 
     @Test
-    fun `on CommentAddedEvent, then call onCommentAdded`() {
-        val comment = commentResponse()
-        val event =
-            CommentAddedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                activity = activityResponse(),
-                type = "feeds.comment.added",
-            )
+    fun `on CommentAdded, then call onCommentAdded`() {
+        val comment = commentData()
+        val event = StateUpdateEvent.CommentAdded(comment)
 
         handler.onEvent(event)
 
-        verify { state.onCommentAdded(comment.toModel()) }
+        verify { state.onCommentAdded(comment) }
     }
 
     @Test
-    fun `on CommentDeletedEvent, then call onCommentRemoved`() {
-        val comment = commentResponse()
-        val event =
-            CommentDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                type = "feeds.comment.deleted",
-            )
+    fun `on CommentDeleted, then call onCommentRemoved`() {
+        val comment = commentData()
+        val event = StateUpdateEvent.CommentDeleted(comment)
 
         handler.onEvent(event)
 
-        verify { state.onCommentRemoved(comment.toModel()) }
+        verify { state.onCommentRemoved(comment) }
     }
 
     @Test
     fun `on unknown event, then do nothing`() {
-        val unknownEvent =
-            object : WSEvent {
-                override fun getWSEventType(): String = "unknown.event"
-            }
+        val unknownEvent = StateUpdateEvent.FeedDeleted("feed-id")
 
         handler.onEvent(unknownEvent)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandlerTest.kt
@@ -32,7 +32,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionAdded for matching activity, then call onReactionAdded`() {
         val reaction = feedsReactionData(activityId)
-        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
+        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
 
         handler.onEvent(event)
 
@@ -42,7 +42,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionAdded for different activity, then do not call onReactionAdded`() {
         val reaction = feedsReactionData("different-activity")
-        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
+        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
 
         handler.onEvent(event)
 
@@ -52,7 +52,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionDeleted for matching activity, then call onReactionRemoved`() {
         val reaction = feedsReactionData(activityId)
-        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
+        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
 
         handler.onEvent(event)
 
@@ -62,7 +62,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionDeleted for different activity, then do not call onReactionRemoved`() {
         val reaction = feedsReactionData("different-activity")
-        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
+        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
 
         handler.onEvent(event)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandlerTest.kt
@@ -32,7 +32,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionAdded for matching activity, then call onReactionAdded`() {
         val reaction = feedsReactionData(activityId)
-        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
+        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
 
         handler.onEvent(event)
 
@@ -42,7 +42,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionAdded for different activity, then do not call onReactionAdded`() {
         val reaction = feedsReactionData("different-activity")
-        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
+        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
 
         handler.onEvent(event)
 
@@ -52,7 +52,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionDeleted for matching activity, then call onReactionRemoved`() {
         val reaction = feedsReactionData(activityId)
-        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
+        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
 
         handler.onEvent(event)
 
@@ -62,7 +62,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionDeleted for different activity, then do not call onReactionRemoved`() {
         val reaction = feedsReactionData("different-activity")
-        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
+        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
 
         handler.onEvent(event)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReplyListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReplyListEventHandlerTest.kt
@@ -16,21 +16,13 @@
 package io.getstream.feeds.android.client.internal.state.event.handler
 
 import io.getstream.feeds.android.client.api.model.ThreadedCommentData
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.CommentReplyListStateUpdates
-import io.getstream.feeds.android.client.internal.test.TestData.activityResponse
-import io.getstream.feeds.android.client.internal.test.TestData.commentResponse
-import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionResponse
-import io.getstream.feeds.android.network.models.CommentAddedEvent
-import io.getstream.feeds.android.network.models.CommentDeletedEvent
-import io.getstream.feeds.android.network.models.CommentReactionAddedEvent
-import io.getstream.feeds.android.network.models.CommentReactionDeletedEvent
-import io.getstream.feeds.android.network.models.CommentUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.test.TestData.commentData
+import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
 import io.mockk.called
 import io.mockk.mockk
 import io.mockk.verify
-import java.util.Date
 import org.junit.Test
 
 internal class CommentReplyListEventHandlerTest {
@@ -39,32 +31,19 @@ internal class CommentReplyListEventHandlerTest {
     private val handler = CommentReplyListEventHandler(state)
 
     @Test
-    fun `on CommentAddedEvent, then call onCommentAdded`() {
-        val comment = commentResponse()
-        val event =
-            CommentAddedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                activity = activityResponse(),
-                type = "feeds.comment.added",
-            )
+    fun `on CommentAdded, then call onCommentAdded`() {
+        val comment = commentData()
+        val event = StateUpdateEvent.CommentAdded(comment)
 
         handler.onEvent(event)
 
-        verify { state.onCommentAdded(ThreadedCommentData(comment.toModel())) }
+        verify { state.onCommentAdded(ThreadedCommentData(comment)) }
     }
 
     @Test
-    fun `on CommentDeletedEvent, then call onCommentRemoved`() {
-        val comment = commentResponse()
-        val event =
-            CommentDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                type = "feeds.comment.deleted",
-            )
+    fun `on CommentDeleted, then call onCommentRemoved`() {
+        val comment = commentData()
+        val event = StateUpdateEvent.CommentDeleted(comment)
 
         handler.onEvent(event)
 
@@ -72,64 +51,40 @@ internal class CommentReplyListEventHandlerTest {
     }
 
     @Test
-    fun `on CommentUpdatedEvent, then call onCommentUpdated`() {
-        val comment = commentResponse()
-        val event =
-            CommentUpdatedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                type = "feeds.comment.updated",
-            )
+    fun `on CommentUpdated, then call onCommentUpdated`() {
+        val comment = commentData()
+        val event = StateUpdateEvent.CommentUpdated(comment)
 
         handler.onEvent(event)
 
-        verify { state.onCommentUpdated(comment.toModel()) }
+        verify { state.onCommentUpdated(comment) }
     }
 
     @Test
-    fun `on CommentReactionAddedEvent, then call onCommentReactionAdded`() {
-        val comment = commentResponse()
-        val reaction = feedsReactionResponse()
-        val event =
-            CommentReactionAddedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                activity = activityResponse(),
-                comment = comment,
-                reaction = reaction,
-                type = "feeds.comment.reaction.added",
-            )
+    fun `on CommentReactionAdded, then call onCommentReactionAdded`() {
+        val comment = commentData()
+        val reaction = feedsReactionData()
+        val event = StateUpdateEvent.CommentReactionAdded(comment, reaction)
 
         handler.onEvent(event)
 
-        verify { state.onCommentReactionAdded(comment.id, reaction.toModel()) }
+        verify { state.onCommentReactionAdded(comment.id, reaction) }
     }
 
     @Test
-    fun `on CommentReactionDeletedEvent, then call onCommentReactionRemoved`() {
-        val comment = commentResponse()
-        val reaction = feedsReactionResponse()
-        val event =
-            CommentReactionDeletedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                comment = comment,
-                reaction = reaction,
-                type = "feeds.comment.reaction.deleted",
-            )
+    fun `on CommentReactionDeleted, then call onCommentReactionRemoved`() {
+        val comment = commentData()
+        val reaction = feedsReactionData()
+        val event = StateUpdateEvent.CommentReactionDeleted(comment, reaction)
 
         handler.onEvent(event)
 
-        verify { state.onCommentReactionRemoved(comment.id, reaction.toModel()) }
+        verify { state.onCommentReactionRemoved(comment.id, reaction) }
     }
 
     @Test
     fun `on unknown event, then do nothing`() {
-        val unknownEvent =
-            object : WSEvent {
-                override fun getWSEventType(): String = "unknown.event"
-            }
+        val unknownEvent = StateUpdateEvent.FeedDeleted("feed-id")
 
         handler.onEvent(unknownEvent)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/MemberListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/MemberListEventHandlerTest.kt
@@ -16,64 +16,64 @@
 package io.getstream.feeds.android.client.internal.state.event.handler
 
 import io.getstream.feeds.android.client.api.model.FeedId
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.MemberListStateUpdates
-import io.getstream.feeds.android.client.internal.test.TestData.feedMemberResponse
-import io.getstream.feeds.android.network.models.FeedMemberRemovedEvent
-import io.getstream.feeds.android.network.models.FeedMemberUpdatedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent.FeedMemberAdded
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent.FeedMemberRemoved
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent.FeedMemberUpdated
+import io.getstream.feeds.android.client.internal.test.TestData.feedMemberData
+import io.mockk.MockKVerificationScope
 import io.mockk.called
 import io.mockk.mockk
-import io.mockk.verify
-import java.util.Date
-import org.junit.Test
+import org.junit.runners.Parameterized
 
-internal class MemberListEventHandlerTest {
-    private val fid = FeedId("user:feed-1")
-    private val state: MemberListStateUpdates = mockk(relaxed = true)
+internal class MemberListEventHandlerTest(
+    testName: String,
+    event: StateUpdateEvent,
+    verifyBlock: MockKVerificationScope.(MemberListStateUpdates) -> Unit,
+) : BaseEventHandlerTest<MemberListStateUpdates>(testName, event, verifyBlock) {
 
-    private val handler = MemberListEventHandler(fid, state)
+    override val state: MemberListStateUpdates = mockk(relaxed = true)
+    override val handler = MemberListEventHandler(FeedId(fid), state)
 
-    @Test
-    fun `on FeedMemberRemovedEvent, then call onMemberRemoved`() {
-        val event =
-            FeedMemberRemovedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                memberId = "member-1",
-                type = "feeds.feed_member.removed",
+    companion object {
+        private val fid = "user:feed-1"
+        private const val differentFeedId = "user:different-feed"
+
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data(): List<Array<Any>> =
+            listOf(
+                testParams<MemberListStateUpdates>(
+                    name = "FeedMemberAdded matching feed",
+                    event = FeedMemberAdded(fid, feedMemberData()),
+                    verifyBlock = { state -> state.onMemberAdded(feedMemberData()) },
+                ),
+                testParams<MemberListStateUpdates>(
+                    name = "FeedMemberAdded non-matching feed",
+                    event = FeedMemberAdded(differentFeedId, feedMemberData()),
+                    verifyBlock = { state -> state wasNot called },
+                ),
+                testParams<MemberListStateUpdates>(
+                    name = "FeedMemberRemoved matching feed",
+                    event = FeedMemberRemoved(fid, "member-1"),
+                    verifyBlock = { state -> state.onMemberRemoved("member-1") },
+                ),
+                testParams<MemberListStateUpdates>(
+                    name = "FeedMemberRemoved non-matching feed",
+                    event = FeedMemberRemoved(differentFeedId, "member-1"),
+                    verifyBlock = { state -> state wasNot called },
+                ),
+                testParams<MemberListStateUpdates>(
+                    name = "FeedMemberUpdated matching feed",
+                    event = FeedMemberUpdated(fid, feedMemberData()),
+                    verifyBlock = { state -> state.onMemberUpdated(feedMemberData()) },
+                ),
+                testParams<MemberListStateUpdates>(
+                    name = "FeedMemberUpdated non-matching feed",
+                    event = FeedMemberUpdated(differentFeedId, feedMemberData()),
+                    verifyBlock = { state -> state wasNot called },
+                ),
             )
-
-        handler.onEvent(event)
-
-        verify { state.onMemberRemoved("member-1") }
-    }
-
-    @Test
-    fun `on FeedMemberUpdatedEvent, then call onMemberUpdated`() {
-        val member = feedMemberResponse()
-        val event =
-            FeedMemberUpdatedEvent(
-                createdAt = Date(),
-                fid = "user:feed-1",
-                member = member,
-                type = "feeds.feed_member.updated",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onMemberUpdated(member.toModel()) }
-    }
-
-    @Test
-    fun `on unknown event, then do nothing`() {
-        val unknownEvent =
-            object : WSEvent {
-                override fun getWSEventType(): String = "unknown.event"
-            }
-
-        handler.onEvent(unknownEvent)
-
-        verify { state wasNot called }
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/PollListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/PollListEventHandlerTest.kt
@@ -39,7 +39,7 @@ internal class PollListEventHandlerTest(
             listOf(
                 testParams<PollListStateUpdates>(
                     name = "PollUpdated",
-                    event = PollUpdated(pollData()),
+                    event = PollUpdated("feed-1", pollData()),
                     verifyBlock = { state -> state.onPollUpdated(pollData()) },
                 )
             )


### PR DESCRIPTION
### Goal

Same as https://github.com/GetStream/stream-feeds-android/pull/87, but for `FollowList`, `CommentReplyList`, `MemberList`, `PollList`, `PollVoteList`, `ActivityList`. With this, the only things left to migrate are `Activity` & `Feed`.

### Implementation

Change handler from `WSEvent` to `StateUpdateEvent`

### Testing

Nothing should change externally, as here we're just consuming WS events using different types from before, but not emitting events from new places (yet).


### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
