### PR TITLE
Migrate `Activity` to consuming and firing state update events

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -224,7 +224,6 @@ internal class FeedsClientImpl(
             commentsRepository = commentsRepository,
             pollsRepository = pollsRepository,
             subscriptionManager = stateEventsSubscriptionManager,
-            socketSubscriptionManager = feedsEventsSubscriptionManager,
             commentList =
                 ActivityCommentListImpl(
                     query =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
@@ -33,7 +33,6 @@ import io.getstream.feeds.android.client.internal.repository.CommentsRepository
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
 import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
 import io.getstream.feeds.android.client.internal.state.event.handler.ActivityEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.subscribe.onEvent
 import io.getstream.feeds.android.client.internal.utils.flatMap
@@ -62,8 +61,6 @@ import io.getstream.feeds.android.network.models.UpdatePollRequest
  * @property pollsRepository The repository used to fetch and manage polls.
  * @property commentList The list of comments associated with this activity.
  * @property subscriptionManager The manager for state update subscriptions.
- * @property socketSubscriptionManager The manager for WebSocket subscriptions to receive real-time
- *   updates.
  */
 internal class ActivityImpl(
     override val activityId: String,
@@ -74,7 +71,6 @@ internal class ActivityImpl(
     private val pollsRepository: PollsRepository,
     private val commentList: ActivityCommentListImpl,
     private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
-    socketSubscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
 ) : Activity {
 
     private val _state: ActivityStateImpl = ActivityStateImpl(currentUserId, commentList.state)
@@ -83,7 +79,7 @@ internal class ActivityImpl(
         ActivityEventHandler(fid = fid, activityId = activityId, state = _state)
 
     init {
-        socketSubscriptionManager.subscribe(eventHandler)
+        subscriptionManager.subscribe(eventHandler)
     }
 
     override val state: ActivityState

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
@@ -25,7 +25,10 @@ import io.getstream.feeds.android.client.api.model.PollData
 import io.getstream.feeds.android.client.api.model.PollOptionData
 import io.getstream.feeds.android.client.api.model.PollVoteData
 import io.getstream.feeds.android.client.api.model.ThreadedCommentData
+import io.getstream.feeds.android.client.api.model.addOption
+import io.getstream.feeds.android.client.api.model.removeOption
 import io.getstream.feeds.android.client.api.model.request.ActivityAddCommentRequest
+import io.getstream.feeds.android.client.api.model.updateOption
 import io.getstream.feeds.android.client.api.state.Activity
 import io.getstream.feeds.android.client.api.state.ActivityState
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
@@ -87,7 +90,9 @@ internal class ActivityImpl(
 
     override suspend fun get(): Result<ActivityData> {
         val activity =
-            activitiesRepository.getActivity(activityId).onSuccess { _state.onActivityUpdated(it) }
+            activitiesRepository.getActivity(activityId).onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.ActivityUpdated(fid.rawValue, it))
+            }
         // Query the comments as well (state will be updated automatically)
         queryComments()
         return activity
@@ -131,7 +136,9 @@ internal class ActivityImpl(
             .deleteComment(commentId, hardDelete)
             .onSuccess { (comment, activity) ->
                 subscriptionManager.onEvent(StateUpdateEvent.CommentDeleted(comment))
-                _state.onActivityUpdated(activity)
+                subscriptionManager.onEvent(
+                    StateUpdateEvent.ActivityUpdated(fid.rawValue, activity)
+                )
             }
             .map {}
     }
@@ -176,105 +183,133 @@ internal class ActivityImpl(
     override suspend fun pin(): Result<Unit> {
         return activitiesRepository
             .pin(activityId, fid)
-            .onSuccess { _state.onActivityUpdated(it) }
+            .onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.ActivityUpdated(fid.rawValue, it))
+            }
             .map { Unit }
     }
 
     override suspend fun unpin(): Result<Unit> {
         return activitiesRepository
             .unpin(activityId, fid)
-            .onSuccess { _state.onActivityUpdated(it) }
+            .onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.ActivityUpdated(fid.rawValue, it))
+            }
             .map { Unit }
     }
 
     override suspend fun closePoll(): Result<PollData> {
-        return pollId().flatMap { pollId ->
-            pollsRepository.closePoll(pollId = pollId).onSuccess { _state.onPollUpdated(it) }
+        return poll().flatMap { poll ->
+            pollsRepository.closePoll(pollId = poll.id).onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.PollUpdated(fid.rawValue, it))
+            }
         }
     }
 
     override suspend fun deletePoll(userId: String?): Result<Unit> {
-        return pollId().flatMap { pollId ->
-            pollsRepository.deletePoll(pollId = pollId, userId = userId).onSuccess {
-                _state.onPollDeleted(pollId)
+        return poll().flatMap { poll ->
+            pollsRepository.deletePoll(pollId = poll.id, userId = userId).onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.PollDeleted(fid.rawValue, poll.id))
             }
         }
     }
 
     override suspend fun getPoll(userId: String?): Result<PollData> {
-        return pollId().flatMap { pollId ->
-            pollsRepository.getPoll(pollId = pollId, userId = userId).onSuccess {
-                _state.onPollUpdated(it)
+        return poll().flatMap { poll ->
+            pollsRepository.getPoll(pollId = poll.id, userId = userId).onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.PollUpdated(fid.rawValue, it))
             }
         }
     }
 
     override suspend fun updatePollPartial(request: UpdatePollPartialRequest): Result<PollData> {
-        return pollId().flatMap { pollId ->
-            pollsRepository.updatePollPartial(pollId, request).onSuccess {
-                _state.onPollUpdated(it)
+        return poll().flatMap { poll ->
+            pollsRepository.updatePollPartial(poll.id, request).onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.PollUpdated(fid.rawValue, it))
             }
         }
     }
 
     override suspend fun updatePoll(request: UpdatePollRequest): Result<PollData> {
-        return pollsRepository.updatePoll(request).onSuccess { _state.onPollUpdated(it) }
+        return pollsRepository.updatePoll(request).onSuccess {
+            subscriptionManager.onEvent(StateUpdateEvent.PollUpdated(fid.rawValue, it))
+        }
     }
 
     override suspend fun createPollOption(
         request: CreatePollOptionRequest
     ): Result<PollOptionData> {
-        return pollId().flatMap { pollId ->
-            pollsRepository.createPollOption(pollId, request).onSuccess {
-                _state.onOptionCreated(it)
+        return poll().flatMap { poll ->
+            pollsRepository.createPollOption(poll.id, request).onSuccess {
+                val newPoll = poll.addOption(it)
+                subscriptionManager.onEvent(StateUpdateEvent.PollUpdated(fid.rawValue, newPoll))
             }
         }
     }
 
     override suspend fun deletePollOption(optionId: String, userId: String?): Result<Unit> {
-        return pollId().flatMap { pollId ->
+        return poll().flatMap { poll ->
             pollsRepository
-                .deletePollOption(pollId = pollId, optionId = optionId, userId = userId)
-                .onSuccess { _state.onOptionDeleted(optionId) }
+                .deletePollOption(pollId = poll.id, optionId = optionId, userId = userId)
+                .onSuccess {
+                    val newPoll = poll.removeOption(optionId)
+                    subscriptionManager.onEvent(StateUpdateEvent.PollUpdated(fid.rawValue, newPoll))
+                }
         }
     }
 
     override suspend fun getPollOption(optionId: String, userId: String?): Result<PollOptionData> {
-        return pollId().flatMap { pollId ->
+        return poll().flatMap { poll ->
             pollsRepository
-                .getPollOption(pollId = pollId, optionId = optionId, userId = userId)
-                .onSuccess { _state.onOptionUpdated(it) }
+                .getPollOption(pollId = poll.id, optionId = optionId, userId = userId)
+                .onSuccess {
+                    val newPoll = poll.updateOption(it)
+                    subscriptionManager.onEvent(StateUpdateEvent.PollUpdated(fid.rawValue, newPoll))
+                }
         }
     }
 
     override suspend fun updatePollOption(
         request: UpdatePollOptionRequest
     ): Result<PollOptionData> {
-        return pollId().flatMap { pollId ->
-            pollsRepository.updatePollOption(pollId, request).onSuccess {
-                _state.onOptionUpdated(it)
+        return poll().flatMap { poll ->
+            pollsRepository.updatePollOption(poll.id, request).onSuccess {
+                val newPoll = poll.updateOption(it)
+                subscriptionManager.onEvent(StateUpdateEvent.PollUpdated(fid.rawValue, newPoll))
             }
         }
     }
 
     override suspend fun castPollVote(request: CastPollVoteRequest): Result<PollVoteData?> {
-        return pollId().flatMap { pollId ->
+        return poll().flatMap { poll ->
             pollsRepository
-                .castPollVote(activityId = activityId, pollId = pollId, request = request)
-                .onSuccess { it?.let { vote -> _state.onPollVoteCasted(vote, pollId) } }
+                .castPollVote(activityId = activityId, pollId = poll.id, request = request)
+                .onSuccess {
+                    it?.let { vote ->
+                        subscriptionManager.onEvent(
+                            StateUpdateEvent.PollVoteCasted(fid.rawValue, poll.id, vote)
+                        )
+                    }
+                }
         }
     }
 
     override suspend fun deletePollVote(voteId: String, userId: String?): Result<PollVoteData?> {
-        return pollId().flatMap { pollId ->
+        return poll().flatMap { poll ->
             pollsRepository
                 .deletePollVote(
                     activityId = activityId,
-                    pollId = pollId,
+                    pollId = poll.id,
                     voteId = voteId,
                     userId = userId,
                 )
-                .onSuccess { it?.let { vote -> _state.onPollVoteRemoved(vote, pollId) } }
+                .onSuccess {
+                    it?.let { vote ->
+                        subscriptionManager.onEvent(
+                            StateUpdateEvent.PollVoteRemoved(fid.rawValue, poll.id, vote)
+                        )
+                    }
+                }
         }
     }
 
@@ -287,11 +322,11 @@ internal class ActivityImpl(
         }
     }
 
-    private suspend fun pollId(): Result<String> {
+    private suspend fun poll(): Result<PollData> {
         return ensureActivityLoaded().flatMap {
             val poll = it.poll
             if (poll != null) {
-                Result.success(poll.id)
+                Result.success(poll)
             } else {
                 Result.failure(IllegalStateException("Activity does not have a poll"))
             }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEvent.kt
@@ -29,6 +29,7 @@ import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.network.models.ActivityDeletedEvent
 import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
 import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
+import io.getstream.feeds.android.network.models.ActivityUpdatedEvent
 import io.getstream.feeds.android.network.models.BookmarkAddedEvent
 import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
 import io.getstream.feeds.android.network.models.BookmarkFolderDeletedEvent
@@ -62,9 +63,13 @@ internal sealed interface StateUpdateEvent {
 
     data class ActivityDeleted(val activity: ActivityData) : StateUpdateEvent
 
-    data class ActivityReactionAdded(val reaction: FeedsReactionData) : StateUpdateEvent
+    data class ActivityUpdated(val fid: String, val activity: ActivityData) : StateUpdateEvent
 
-    data class ActivityReactionDeleted(val reaction: FeedsReactionData) : StateUpdateEvent
+    data class ActivityReactionAdded(val fid: String, val reaction: FeedsReactionData) :
+        StateUpdateEvent
+
+    data class ActivityReactionDeleted(val fid: String, val reaction: FeedsReactionData) :
+        StateUpdateEvent
 
     data class BookmarkAdded(val bookmark: BookmarkData) : StateUpdateEvent
 
@@ -122,10 +127,13 @@ internal fun WSEvent.toModel(): StateUpdateEvent? =
     when (this) {
         is ActivityDeletedEvent -> StateUpdateEvent.ActivityDeleted(activity.toModel())
 
-        is ActivityReactionAddedEvent -> StateUpdateEvent.ActivityReactionAdded(reaction.toModel())
+        is ActivityUpdatedEvent -> StateUpdateEvent.ActivityUpdated(fid, activity.toModel())
+
+        is ActivityReactionAddedEvent ->
+            StateUpdateEvent.ActivityReactionAdded(fid, reaction.toModel())
 
         is ActivityReactionDeletedEvent ->
-            StateUpdateEvent.ActivityReactionDeleted(reaction.toModel())
+            StateUpdateEvent.ActivityReactionDeleted(fid, reaction.toModel())
 
         is BookmarkAddedEvent -> StateUpdateEvent.BookmarkAdded(bookmark.toModel())
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityEventHandler.kt
@@ -16,21 +16,9 @@
 package io.getstream.feeds.android.client.internal.state.event.handler
 
 import io.getstream.feeds.android.client.api.model.FeedId
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.ActivityStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
-import io.getstream.feeds.android.network.models.ActivityUpdatedEvent
-import io.getstream.feeds.android.network.models.BookmarkAddedEvent
-import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
-import io.getstream.feeds.android.network.models.PollClosedFeedEvent
-import io.getstream.feeds.android.network.models.PollDeletedFeedEvent
-import io.getstream.feeds.android.network.models.PollUpdatedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteCastedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteChangedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteRemovedFeedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * This class handles activity-related WebSocket events and updates the activity state accordingly.
@@ -44,74 +32,73 @@ internal class ActivityEventHandler(
     private val fid: FeedId,
     private val activityId: String,
     private val state: ActivityStateUpdates,
-) : FeedsEventListener {
+) : StateUpdateEventListener {
 
     /**
-     * Processes a WebSocket event and updates the activity state.
+     * Processes a state update event and updates the activity state.
      *
-     * @param event The WebSocket event to process.
+     * @param event The state update event to process.
      */
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is ActivityReactionAddedEvent -> {
-                if (event.fid != fid.rawValue || event.activity.id != activityId) return
-                state.onReactionAdded(event.reaction.toModel())
+            is StateUpdateEvent.ActivityReactionAdded -> {
+                if (event.fid != fid.rawValue || event.reaction.activityId != activityId) return
+                state.onReactionAdded(event.reaction)
             }
 
-            is ActivityReactionDeletedEvent -> {
-                if (event.fid != fid.rawValue || event.activity.id != activityId) return
-                state.onReactionRemoved(event.reaction.toModel())
+            is StateUpdateEvent.ActivityReactionDeleted -> {
+                if (event.fid != fid.rawValue || event.reaction.activityId != activityId) return
+                state.onReactionRemoved(event.reaction)
             }
 
-            is ActivityUpdatedEvent -> {
+            is StateUpdateEvent.ActivityUpdated -> {
                 if (event.fid != fid.rawValue || event.activity.id != activityId) return
-                state.onActivityUpdated(event.activity.toModel())
+                state.onActivityUpdated(event.activity)
             }
 
-            is BookmarkAddedEvent -> {
+            is StateUpdateEvent.BookmarkAdded -> {
                 val eventActivity = event.bookmark.activity
                 if (fid.rawValue !in eventActivity.feeds || eventActivity.id != activityId) return
-                state.onBookmarkAdded(event.bookmark.toModel())
+                state.onBookmarkAdded(event.bookmark)
             }
 
-            is BookmarkDeletedEvent -> {
+            is StateUpdateEvent.BookmarkDeleted -> {
                 val eventActivity = event.bookmark.activity
                 if (fid.rawValue !in eventActivity.feeds || eventActivity.id != activityId) return
-                state.onBookmarkRemoved(event.bookmark.toModel())
+                state.onBookmarkRemoved(event.bookmark)
             }
 
-            is PollClosedFeedEvent -> {
+            is StateUpdateEvent.PollClosed -> {
                 if (event.fid != fid.rawValue) return
-                state.onPollClosed(event.poll.toModel())
+                state.onPollClosed(event.poll)
             }
 
-            is PollDeletedFeedEvent -> {
+            is StateUpdateEvent.PollDeleted -> {
                 if (event.fid != fid.rawValue) return
-                state.onPollDeleted(event.poll.id)
+                state.onPollDeleted(event.pollId)
             }
 
-            is PollUpdatedFeedEvent -> {
+            is StateUpdateEvent.PollUpdated -> {
                 if (event.fid != fid.rawValue) return
-                state.onPollUpdated(event.poll.toModel())
+                state.onPollUpdated(event.poll)
             }
 
-            is PollVoteCastedFeedEvent -> {
+            is StateUpdateEvent.PollVoteCasted -> {
                 if (event.fid != fid.rawValue) return
-                val vote = event.pollVote.toModel()
-                state.onPollVoteCasted(vote, event.poll.id)
+                state.onPollVoteCasted(event.vote, event.pollId)
             }
 
-            is PollVoteChangedFeedEvent -> {
+            is StateUpdateEvent.PollVoteChanged -> {
                 if (event.fid != fid.rawValue) return
-                val vote = event.pollVote.toModel()
-                state.onPollVoteChanged(vote, event.poll.id)
+                state.onPollVoteChanged(event.vote, event.pollId)
             }
 
-            is PollVoteRemovedFeedEvent -> {
+            is StateUpdateEvent.PollVoteRemoved -> {
                 if (event.fid != fid.rawValue) return
-                val vote = event.pollVote.toModel()
-                state.onPollVoteRemoved(vote, event.poll.id)
+                state.onPollVoteRemoved(event.vote, event.pollId)
             }
+
+            else -> {}
         }
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
@@ -15,7 +15,6 @@
  */
 package io.getstream.feeds.android.client.internal.state
 
-import io.getstream.android.core.api.subscribe.StreamSubscriptionManager
 import io.getstream.feeds.android.client.api.file.FeedUploadPayload
 import io.getstream.feeds.android.client.api.model.FeedId
 import io.getstream.feeds.android.client.api.model.PollData
@@ -25,7 +24,6 @@ import io.getstream.feeds.android.client.internal.repository.ActivitiesRepositor
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
 import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.activityData
 import io.getstream.feeds.android.client.internal.test.TestData.commentData
@@ -62,8 +60,6 @@ internal class ActivityImplTest {
         every { state } returns commentListState
     }
     private val stateEventListener: StateUpdateEventListener = mockk(relaxed = true)
-    private val socketSubscriptionManager: StreamSubscriptionManager<FeedsEventListener> =
-        mockk(relaxed = true)
 
     private val activity =
         ActivityImpl(
@@ -75,7 +71,6 @@ internal class ActivityImplTest {
             pollsRepository = pollsRepository,
             commentList = activityCommentListImpl,
             subscriptionManager = TestSubscriptionManager(stateEventListener),
-            socketSubscriptionManager = socketSubscriptionManager,
         )
 
     @Test

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
@@ -24,6 +24,7 @@ import io.getstream.feeds.android.client.internal.repository.ActivitiesRepositor
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
 import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent.PollUpdated
 import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.test.TestData.activityData
 import io.getstream.feeds.android.client.internal.test.TestData.commentData
@@ -64,7 +65,7 @@ internal class ActivityImplTest {
     private val activity =
         ActivityImpl(
             activityId = "activityId",
-            fid = FeedId("feedId"),
+            fid = FeedId("group:feed"),
             currentUserId = "currentUserId",
             activitiesRepository = activitiesRepository,
             commentsRepository = commentsRepository,
@@ -116,6 +117,9 @@ internal class ActivityImplTest {
 
         assertEquals(activityData, result.getOrNull())
         assertEquals(activityData, activity.state.activity.value)
+        verify {
+            stateEventListener.onEvent(StateUpdateEvent.ActivityUpdated("group:feed", activityData))
+        }
     }
 
     @Test
@@ -167,8 +171,13 @@ internal class ActivityImplTest {
         val result = activity.deleteComment(commentId, hardDelete)
 
         assertEquals(Unit, result.getOrNull())
-        verify { stateEventListener.onEvent(StateUpdateEvent.CommentDeleted(deleteData.first)) }
         assertEquals(expectedActivity, activity.state.activity.value)
+        verify {
+            stateEventListener.onEvent(StateUpdateEvent.CommentDeleted(deleteData.first))
+            stateEventListener.onEvent(
+                StateUpdateEvent.ActivityUpdated("group:feed", expectedActivity)
+            )
+        }
     }
 
     @Test
@@ -226,25 +235,31 @@ internal class ActivityImplTest {
     @Test
     fun `on pin, delegate to repository and update state`() = runTest {
         val activityData = activityData("activityId")
-        coEvery { activitiesRepository.pin("activityId", FeedId("feedId")) } returns
+        coEvery { activitiesRepository.pin("activityId", FeedId("group:feed")) } returns
             Result.success(activityData)
 
         val result = activity.pin()
 
         assertEquals(Unit, result.getOrNull())
         assertEquals(activityData, activity.state.activity.value)
+        verify {
+            stateEventListener.onEvent(StateUpdateEvent.ActivityUpdated("group:feed", activityData))
+        }
     }
 
     @Test
     fun `on unpin, delegate to repository and update state`() = runTest {
         val activityData = activityData("activityId")
-        coEvery { activitiesRepository.unpin("activityId", FeedId("feedId")) } returns
+        coEvery { activitiesRepository.unpin("activityId", FeedId("group:feed")) } returns
             Result.success(activityData)
 
         val result = activity.unpin()
 
         assertEquals(Unit, result.getOrNull())
         assertEquals(activityData, activity.state.activity.value)
+        verify {
+            stateEventListener.onEvent(StateUpdateEvent.ActivityUpdated("group:feed", activityData))
+        }
     }
 
     @Test
@@ -260,6 +275,7 @@ internal class ActivityImplTest {
 
         assertEquals(updatedPoll, result.getOrNull())
         assertEquals(updatedPoll, activity.state.poll.value)
+        verify { stateEventListener.onEvent(PollUpdated("group:feed", updatedPoll)) }
     }
 
     @Test
@@ -274,6 +290,7 @@ internal class ActivityImplTest {
 
         assertEquals(closedPoll, result.getOrNull())
         assertEquals(closedPoll, activity.state.poll.value)
+        verify { stateEventListener.onEvent(PollUpdated("group:feed", closedPoll)) }
     }
 
     @Test
@@ -289,19 +306,24 @@ internal class ActivityImplTest {
 
             assertEquals(Unit, result.getOrNull())
             assertEquals(null, activity.state.poll.value)
+            verify {
+                stateEventListener.onEvent(StateUpdateEvent.PollDeleted("group:feed", "poll-1"))
+            }
         }
 
     @Test
     fun `on createPollOption when activity has poll, delegate to repository and update state`() =
         runTest {
-            val poll = pollData("poll-1")
+            val poll = pollData("poll-1", options = listOf(pollOptionData("option-1", "Option 1")))
             val request = CreatePollOptionRequest(text = "New Option")
-            val option = pollOptionData("option-3", "New Option")
-            val expectedOptions =
-                listOf(
-                    pollOptionData("option-1", "Test Option"),
-                    pollOptionData("option-2", "Test Option 2"),
-                    pollOptionData("option-3", "New Option"),
+            val option = pollOptionData("option-2", "New Option")
+            val expectedPoll =
+                poll.copy(
+                    options =
+                        listOf(
+                            pollOptionData("option-1", "Option 1"),
+                            pollOptionData("option-2", "New Option"),
+                        )
                 )
 
             setupActivityWithPoll(poll)
@@ -311,7 +333,8 @@ internal class ActivityImplTest {
             val result = activity.createPollOption(request)
 
             assertEquals(option, result.getOrNull())
-            assertEquals(expectedOptions, activity.state.poll.value?.options)
+            assertEquals(expectedPoll, activity.state.poll.value)
+            verify { stateEventListener.onEvent(PollUpdated("group:feed", expectedPoll)) }
         }
 
     @Test
@@ -332,6 +355,11 @@ internal class ActivityImplTest {
             assertEquals(1, actualPoll.voteCount)
             assertEquals(1, actualPoll.voteCountsByOption["option-1"])
             assertEquals(listOf(vote), actualPoll.latestVotesByOption["option-1"])
+            verify {
+                stateEventListener.onEvent(
+                    StateUpdateEvent.PollVoteCasted("group:feed", "poll-1", vote)
+                )
+            }
         }
 
     @Test
@@ -349,6 +377,11 @@ internal class ActivityImplTest {
 
             assertEquals(vote, result.getOrNull())
             assertNotNull("Poll should still exist", activity.state.poll.value)
+            verify {
+                stateEventListener.onEvent(
+                    StateUpdateEvent.PollVoteRemoved("group:feed", "poll-1", vote)
+                )
+            }
         }
 
     @Test
@@ -366,6 +399,7 @@ internal class ActivityImplTest {
 
             assertEquals(updatedPoll, result.getOrNull())
             assertEquals(updatedPoll, activity.state.poll.value)
+            verify { stateEventListener.onEvent(PollUpdated("group:feed", updatedPoll)) }
         }
 
     @Test
@@ -382,14 +416,19 @@ internal class ActivityImplTest {
 
             assertEquals(updatedPoll, result.getOrNull())
             assertEquals(updatedPoll, activity.state.poll.value)
+            verify { stateEventListener.onEvent(PollUpdated("group:feed", updatedPoll)) }
         }
 
     @Test
     fun `on deletePollOption when activity has poll, delegate to repository`() = runTest {
-        val poll = pollData("poll-1")
+        val poll =
+            pollData(
+                "poll-1",
+                options = listOf(pollOptionData("option-1"), pollOptionData("option-2")),
+            )
         val optionId = "option-1"
         val userId = "user-1"
-        val expectedOptions = listOf(pollOptionData("option-2", "Test Option 2"))
+        val expectedPoll = poll.copy(options = listOf(pollOptionData("option-2")))
 
         setupActivityWithPoll(poll)
         coEvery { pollsRepository.deletePollOption("poll-1", optionId, userId) } returns
@@ -398,7 +437,8 @@ internal class ActivityImplTest {
         val result = activity.deletePollOption(optionId, userId)
 
         assertEquals(Unit, result.getOrNull())
-        assertEquals(expectedOptions, activity.state.poll.value?.options)
+        assertEquals(expectedPoll, activity.state.poll.value)
+        verify { stateEventListener.onEvent(PollUpdated("group:feed", expectedPoll)) }
     }
 
     @Test
@@ -407,7 +447,8 @@ internal class ActivityImplTest {
             val poll = pollData("poll-1")
             val optionId = "option-1"
             val userId = "user-1"
-            val option = pollOptionData(optionId)
+            val option = pollOptionData(optionId, text = "Updated text")
+            val expectedPoll = poll.copy(options = listOf(option))
 
             setupActivityWithPoll(poll)
             coEvery { pollsRepository.getPollOption("poll-1", optionId, userId) } returns
@@ -416,19 +457,17 @@ internal class ActivityImplTest {
             val result = activity.getPollOption(optionId, userId)
 
             assertEquals(option, result.getOrNull())
+            verify { stateEventListener.onEvent(PollUpdated("group:feed", expectedPoll)) }
         }
 
     @Test
     fun `on updatePollOption when activity has poll, delegate to repository and update state`() =
         runTest {
-            val poll = pollData("poll-1")
+            val poll = pollData("poll-1", options = listOf(pollOptionData("option-1")))
             val updatedOption = pollOptionData("option-1", text = "Updated Option")
             val request = UpdatePollOptionRequest(id = "option-1", text = "Updated Option")
-            val expectedOptions =
-                listOf(
-                    pollOptionData("option-1", "Updated Option"),
-                    pollOptionData("option-2", "Test Option 2"),
-                )
+            val expectedPoll =
+                poll.copy(options = listOf(pollOptionData("option-1", "Updated Option")))
 
             setupActivityWithPoll(poll)
             coEvery { pollsRepository.updatePollOption("poll-1", request) } returns
@@ -437,7 +476,8 @@ internal class ActivityImplTest {
             val result = activity.updatePollOption(request)
 
             assertEquals(updatedOption, result.getOrNull())
-            assertEquals(expectedOptions, activity.state.poll.value?.options)
+            assertEquals(expectedPoll, activity.state.poll.value)
+            verify { stateEventListener.onEvent(PollUpdated("group:feed", expectedPoll)) }
         }
 
     private suspend fun setupActivityWithPoll(poll: PollData = pollData("poll-1")) {

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityStateImplTest.kt
@@ -22,7 +22,6 @@ import io.getstream.feeds.android.client.internal.test.TestData.activityData
 import io.getstream.feeds.android.client.internal.test.TestData.bookmarkData
 import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
 import io.getstream.feeds.android.client.internal.test.TestData.pollData
-import io.getstream.feeds.android.client.internal.test.TestData.pollOptionData
 import io.getstream.feeds.android.client.internal.test.TestData.pollVoteData
 import io.getstream.feeds.android.client.internal.test.TestData.reactionGroupData
 import io.mockk.mockk
@@ -307,43 +306,6 @@ internal class ActivityStateImplTest {
         activityState.onPollUpdated(differentPoll)
 
         assertEquals(initialPoll, activityState.poll.value)
-    }
-
-    @Test
-    fun `on onOptionCreated, then add option to poll`() = runTest {
-        val initialPoll = pollData("poll-1", "Test Poll")
-        setupInitialPoll(initialPoll)
-
-        val newOption = pollOptionData("option-3", "New Option")
-        activityState.onOptionCreated(newOption)
-
-        val updatedPoll = activityState.poll.value
-        assertEquals(3, updatedPoll?.options?.size)
-        assertEquals(newOption, updatedPoll?.options?.last())
-    }
-
-    @Test
-    fun `on onOptionDeleted, then remove option from poll`() = runTest {
-        val initialPoll = pollData("poll-1", "Test Poll")
-        setupInitialPoll(initialPoll)
-
-        activityState.onOptionDeleted("option-1")
-
-        val updatedPoll = activityState.poll.value
-        assertEquals(1, updatedPoll?.options?.size)
-        assertEquals("option-2", updatedPoll?.options?.first()?.id)
-    }
-
-    @Test
-    fun `on onOptionUpdated, then update option in poll`() = runTest {
-        val initialPoll = pollData("poll-1", "Test Poll")
-        setupInitialPoll(initialPoll)
-
-        val updatedOption = pollOptionData("option-1", "Updated Option Text")
-        activityState.onOptionUpdated(updatedOption)
-
-        val updatedPoll = activityState.poll.value
-        assertEquals(updatedOption, updatedPoll?.options?.first())
     }
 
     @Test

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandlerTest.kt
@@ -44,7 +44,7 @@ internal class ActivityListEventHandlerTest {
     @Test
     fun `on ActivityReactionAdded, then call onReactionAdded`() {
         val reaction = feedsReactionData("activity-1")
-        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
+        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
 
         handler.onEvent(event)
 
@@ -54,7 +54,7 @@ internal class ActivityListEventHandlerTest {
     @Test
     fun `on ActivityReactionDeleted, then call onReactionRemoved`() {
         val reaction = feedsReactionData("activity-1")
-        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
+        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
 
         handler.onEvent(event)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityReactionListEventHandlerTest.kt
@@ -32,7 +32,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionAdded for matching activity, then call onReactionAdded`() {
         val reaction = feedsReactionData(activityId)
-        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
+        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
 
         handler.onEvent(event)
 
@@ -42,7 +42,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionAdded for different activity, then do not call onReactionAdded`() {
         val reaction = feedsReactionData("different-activity")
-        val event = StateUpdateEvent.ActivityReactionAdded(reaction)
+        val event = StateUpdateEvent.ActivityReactionAdded("feed-1", reaction)
 
         handler.onEvent(event)
 
@@ -52,7 +52,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionDeleted for matching activity, then call onReactionRemoved`() {
         val reaction = feedsReactionData(activityId)
-        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
+        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
 
         handler.onEvent(event)
 
@@ -62,7 +62,7 @@ internal class ActivityReactionListEventHandlerTest {
     @Test
     fun `on ActivityReactionDeleted for different activity, then do not call onReactionRemoved`() {
         val reaction = feedsReactionData("different-activity")
-        val event = StateUpdateEvent.ActivityReactionDeleted(reaction)
+        val event = StateUpdateEvent.ActivityReactionDeleted("feed-1", reaction)
 
         handler.onEvent(event)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
@@ -468,6 +468,7 @@ internal object TestData {
         voteCount: Int = 0,
         latestVotesByOption: Map<String, List<PollVoteData>> = emptyMap(),
         voteCountsByOption: Map<String, Int> = emptyMap(),
+        options: List<PollOptionData> = listOf(pollOptionData()),
     ): PollData =
         PollData(
             allowAnswers = allowAnswers,
@@ -485,7 +486,7 @@ internal object TestData {
             latestVotesByOption = latestVotesByOption,
             maxVotesAllowed = null,
             name = name,
-            options = listOf(pollOptionData(), pollOptionData("option-2", "Test Option 2")),
+            options = options,
             ownVotes = ownVotes,
             updatedAt = Date(1000),
             voteCount = voteCount,


### PR DESCRIPTION
### Goal

Similar to previous PRs like e.g. #83, #89, we migrate `Activity`. But this time, in addition to consuming state update events, we also fire them on successful api calls instead of updating the state directly. This now finally means that whoever is listening to those events will be updated even if we're not receiving socket events (as described in #83).

### Implementation

- Change handler from `WSEvent` to `StateUpdateEvent`
- Fire events from `ActivityImpl` instead of updating the state directly

| Before | Now |
|---|---|
| `_state.onActivityUpdated(activity)` | `subscriptionManager.onEvent(ActivityUpdated(fid, activity))` |

### Testing

Disable socket events in the sample and perform operations through an `Activity`, e.g. adding a vote to a poll, or adding a comment, and verify that relevant already-migrated objects (e.g. `PollVoteList`, `Activity` itself) are update correctly. Note: `Feed` object will not yet react in this situation, because it's not migrated yet (coming in the next PR).

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
