### PR TITLE
Migrate `Feed` to consuming and firing state update events

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -196,7 +196,6 @@ internal class FeedsClientImpl(
             commentsRepository = commentsRepository,
             feedsRepository = feedsRepository,
             pollsRepository = pollsRepository,
-            socketSubscriptionManager = feedsEventsSubscriptionManager,
             subscriptionManager = stateEventsSubscriptionManager,
             feedWatchHandler = feedWatchHandler,
         )

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepository.kt
@@ -76,7 +76,7 @@ internal interface FeedsRepository {
 
     suspend fun follow(request: FollowRequest): Result<FollowData>
 
-    suspend fun unfollow(source: FeedId, target: FeedId): Result<Unit>
+    suspend fun unfollow(source: FeedId, target: FeedId): Result<FollowData>
 
     suspend fun acceptFollow(request: AcceptFollowRequest): Result<FollowData>
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImpl.kt
@@ -135,8 +135,8 @@ internal class FeedsRepositoryImpl(private val api: FeedsApi) : FeedsRepository 
         api.follow(request).follow.toModel()
     }
 
-    override suspend fun unfollow(source: FeedId, target: FeedId): Result<Unit> = runSafely {
-        api.unfollow(source = source.rawValue, target = target.rawValue)
+    override suspend fun unfollow(source: FeedId, target: FeedId): Result<FollowData> = runSafely {
+        api.unfollow(source = source.rawValue, target = target.rawValue).follow.toModel()
     }
 
     override suspend fun acceptFollow(request: AcceptFollowRequest): Result<FollowData> =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
@@ -118,7 +118,9 @@ internal class ActivityImpl(
     ): Result<CommentData> {
         return commentsRepository
             .addComment(request = request, attachmentUploadProgress = attachmentUploadProgress)
-            .onSuccess { subscriptionManager.onEvent(StateUpdateEvent.CommentAdded(it)) }
+            .onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.CommentAdded(fid.rawValue, it))
+            }
     }
 
     override suspend fun addCommentsBatch(
@@ -127,7 +129,9 @@ internal class ActivityImpl(
     ): Result<List<CommentData>> {
         return commentsRepository.addCommentsBatch(requests, attachmentUploadProgress).onSuccess {
             comments ->
-            comments.forEach { subscriptionManager.onEvent(StateUpdateEvent.CommentAdded(it)) }
+            comments.forEach {
+                subscriptionManager.onEvent(StateUpdateEvent.CommentAdded(fid.rawValue, it))
+            }
         }
     }
 
@@ -135,7 +139,7 @@ internal class ActivityImpl(
         return commentsRepository
             .deleteComment(commentId, hardDelete)
             .onSuccess { (comment, activity) ->
-                subscriptionManager.onEvent(StateUpdateEvent.CommentDeleted(comment))
+                subscriptionManager.onEvent(StateUpdateEvent.CommentDeleted(fid.rawValue, comment))
                 subscriptionManager.onEvent(
                     StateUpdateEvent.ActivityUpdated(fid.rawValue, activity)
                 )

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImpl.kt
@@ -82,8 +82,8 @@ internal class ActivityListStateImpl(
         }
     }
 
-    override fun onActivityRemoved(activity: ActivityData) {
-        _activities.update { current -> current.filter { it.id != activity.id } }
+    override fun onActivityRemoved(activityId: String) {
+        _activities.update { current -> current.filter { it.id != activityId } }
     }
 
     override fun onActivityUpdated(activity: ActivityData) {
@@ -194,9 +194,9 @@ internal interface ActivityListStateUpdates {
     /**
      * Called when an activity is removed from the list.
      *
-     * @param activity The activity that was removed.
+     * @param activityId The ID of the activity that was removed.
      */
-    fun onActivityRemoved(activity: ActivityData)
+    fun onActivityRemoved(activityId: String)
 
     /**
      * Called when an activity is updated in the list.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
@@ -39,7 +39,6 @@ import io.getstream.feeds.android.client.internal.repository.CommentsRepository
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
 import io.getstream.feeds.android.client.internal.repository.PollsRepository
 import io.getstream.feeds.android.client.internal.state.event.handler.FeedEventHandler
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
 import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 import io.getstream.feeds.android.client.internal.utils.flatMap
 import io.getstream.feeds.android.network.models.AcceptFollowRequest
@@ -83,8 +82,6 @@ import io.getstream.feeds.android.network.models.UpdateFeedRequest
  * @property feedsRepository The [FeedsRepository] used to manage feed data and operations.
  * @property pollsRepository The [PollsRepository] used to manage polls in the feed.
  * @property subscriptionManager The manager for state update subscriptions.
- * @param socketSubscriptionManager The [StreamSubscriptionManager] used to manage WebSocket
- *   subscriptions for feed events.
  */
 internal class FeedImpl(
     private val query: FeedQuery,
@@ -95,7 +92,6 @@ internal class FeedImpl(
     private val feedsRepository: FeedsRepository,
     private val pollsRepository: PollsRepository,
     private val subscriptionManager: StreamSubscriptionManager<StateUpdateEventListener>,
-    socketSubscriptionManager: StreamSubscriptionManager<FeedsEventListener>,
     private val feedWatchHandler: FeedWatchHandler,
 ) : Feed {
 
@@ -116,7 +112,7 @@ internal class FeedImpl(
     private val eventHandler = FeedEventHandler(fid = fid, state = _state)
 
     init {
-        socketSubscriptionManager.subscribe(eventHandler)
+        subscriptionManager.subscribe(eventHandler)
     }
 
     private val group: String

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
@@ -360,13 +360,13 @@ internal class FeedImpl(
 
     override suspend fun acceptFeedMember(): Result<FeedMemberData> {
         return feedsRepository.acceptFeedMember(feedGroupId = group, feedId = id).onSuccess {
-            subscriptionManager.onEvent(StateUpdateEvent.FeedMemberAdded(fid.rawValue, it))
+            subscriptionManager.onEvent(StateUpdateEvent.FeedMemberUpdated(fid.rawValue, it))
         }
     }
 
     override suspend fun rejectFeedMember(): Result<FeedMemberData> {
         return feedsRepository.rejectFeedMember(feedGroupId = group, feedId = id).onSuccess {
-            subscriptionManager.onEvent(StateUpdateEvent.FeedMemberRemoved(fid.rawValue, it.id))
+            subscriptionManager.onEvent(StateUpdateEvent.FeedMemberUpdated(fid.rawValue, it))
         }
     }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedStateImpl.kt
@@ -366,6 +366,7 @@ internal class FeedStateImpl(
             _following.update { it.upsert(follow, FollowData::id) }
         } else if (follow.isFollowerOf(fid)) {
             _followers.update { it.upsert(follow, FollowData::id) }
+            _followRequests.update { current -> current.filter { it.id != follow.id } }
         }
     }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandler.kt
@@ -24,7 +24,7 @@ internal class ActivityListEventHandler(private val state: ActivityListStateUpda
 
     override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is StateUpdateEvent.ActivityDeleted -> state.onActivityRemoved(event.activity)
+            is StateUpdateEvent.ActivityDeleted -> state.onActivityRemoved(event.activityId)
             is StateUpdateEvent.ActivityReactionAdded -> state.onReactionAdded(event.reaction)
             is StateUpdateEvent.ActivityReactionDeleted -> state.onReactionRemoved(event.reaction)
             is StateUpdateEvent.BookmarkAdded -> state.onBookmarkAdded(event.bookmark)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/FeedEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/FeedEventHandler.kt
@@ -16,6 +16,7 @@
 package io.getstream.feeds.android.client.internal.state.event.handler
 
 import io.getstream.feeds.android.client.api.model.FeedId
+import io.getstream.feeds.android.client.api.model.FollowData
 import io.getstream.feeds.android.client.internal.state.FeedStateUpdates
 import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
 import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
@@ -123,19 +124,19 @@ internal class FeedEventHandler(private val fid: FeedId, private val state: Feed
             }
 
             is StateUpdateEvent.FollowAdded -> {
-                if (event.follow.run { sourceFeed.fid == fid || targetFeed.fid == fid }) {
+                if (event.follow.matchesFeed()) {
                     state.onFollowAdded(event.follow)
                 }
             }
 
             is StateUpdateEvent.FollowDeleted -> {
-                if (event.follow.run { sourceFeed.fid == fid || targetFeed.fid == fid }) {
+                if (event.follow.matchesFeed()) {
                     state.onFollowRemoved(event.follow)
                 }
             }
 
             is StateUpdateEvent.FollowUpdated -> {
-                if (event.follow.run { sourceFeed.fid == fid || targetFeed.fid == fid }) {
+                if (event.follow.matchesFeed()) {
                     state.onFollowUpdated(event.follow)
                 }
             }
@@ -190,4 +191,6 @@ internal class FeedEventHandler(private val fid: FeedId, private val state: Feed
             }
         }
     }
+
+    private fun FollowData.matchesFeed() = sourceFeed.fid == fid || targetFeed.fid == fid
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/FeedEventHandler.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/FeedEventHandler.kt
@@ -16,34 +16,9 @@
 package io.getstream.feeds.android.client.internal.state.event.handler
 
 import io.getstream.feeds.android.client.api.model.FeedId
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.FeedStateUpdates
-import io.getstream.feeds.android.client.internal.subscribe.FeedsEventListener
-import io.getstream.feeds.android.network.models.ActivityAddedEvent
-import io.getstream.feeds.android.network.models.ActivityDeletedEvent
-import io.getstream.feeds.android.network.models.ActivityPinnedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
-import io.getstream.feeds.android.network.models.ActivityRemovedFromFeedEvent
-import io.getstream.feeds.android.network.models.ActivityUnpinnedEvent
-import io.getstream.feeds.android.network.models.ActivityUpdatedEvent
-import io.getstream.feeds.android.network.models.BookmarkAddedEvent
-import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
-import io.getstream.feeds.android.network.models.CommentAddedEvent
-import io.getstream.feeds.android.network.models.CommentDeletedEvent
-import io.getstream.feeds.android.network.models.FeedDeletedEvent
-import io.getstream.feeds.android.network.models.FeedUpdatedEvent
-import io.getstream.feeds.android.network.models.FollowCreatedEvent
-import io.getstream.feeds.android.network.models.FollowDeletedEvent
-import io.getstream.feeds.android.network.models.FollowUpdatedEvent
-import io.getstream.feeds.android.network.models.NotificationFeedUpdatedEvent
-import io.getstream.feeds.android.network.models.PollClosedFeedEvent
-import io.getstream.feeds.android.network.models.PollDeletedFeedEvent
-import io.getstream.feeds.android.network.models.PollUpdatedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteCastedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteChangedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteRemovedFeedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.subscribe.StateUpdateEventListener
 
 /**
  * This class handles feed events and updates the feed state accordingly. It is responsible for
@@ -54,160 +29,159 @@ import io.getstream.feeds.android.network.models.WSEvent
  * @property state The instance that manages updates to the feed state.
  */
 internal class FeedEventHandler(private val fid: FeedId, private val state: FeedStateUpdates) :
-    FeedsEventListener {
+    StateUpdateEventListener {
 
     /**
-     * Processes a WebSocket event and updates the feed state.
+     * Processes a state update event and updates the feed state.
      *
-     * @param event The WebSocket event to process.
+     * @param event The state update event to process.
      */
-    override fun onEvent(event: WSEvent) {
+    override fun onEvent(event: StateUpdateEvent) {
         when (event) {
-            is ActivityAddedEvent -> {
+            is StateUpdateEvent.ActivityAdded -> {
                 if (event.fid == fid.rawValue) {
-                    state.onActivityAdded(event.activity.toModel())
+                    state.onActivityAdded(event.activity)
                 }
             }
 
-            is ActivityDeletedEvent -> {
+            is StateUpdateEvent.ActivityDeleted -> {
                 if (event.fid == fid.rawValue) {
-                    state.onActivityRemoved(event.activity.id)
+                    state.onActivityRemoved(event.activityId)
                 }
             }
 
-            is ActivityRemovedFromFeedEvent -> {
+            is StateUpdateEvent.ActivityRemovedFromFeed -> {
                 if (event.fid == fid.rawValue) {
-                    state.onActivityRemoved(event.activity.id)
+                    state.onActivityRemoved(event.activityId)
                 }
             }
 
-            is ActivityReactionAddedEvent -> {
+            is StateUpdateEvent.ActivityReactionAdded -> {
                 if (event.fid == fid.rawValue) {
-                    state.onReactionAdded(event.reaction.toModel())
+                    state.onReactionAdded(event.reaction)
                 }
             }
 
-            is ActivityReactionDeletedEvent -> {
+            is StateUpdateEvent.ActivityReactionDeleted -> {
                 if (event.fid == fid.rawValue) {
-                    state.onReactionRemoved(event.reaction.toModel())
+                    state.onReactionRemoved(event.reaction)
                 }
             }
 
-            is ActivityUpdatedEvent -> {
+            is StateUpdateEvent.ActivityUpdated -> {
                 if (event.fid == fid.rawValue) {
-                    state.onActivityUpdated(event.activity.toModel())
+                    state.onActivityUpdated(event.activity)
                 }
             }
 
-            is ActivityPinnedEvent -> {
+            is StateUpdateEvent.ActivityPinned -> {
                 if (event.fid == fid.rawValue) {
-                    state.onActivityPinned(event.pinnedActivity.toModel())
+                    state.onActivityPinned(event.pinnedActivity)
                 }
             }
 
-            is ActivityUnpinnedEvent -> {
+            is StateUpdateEvent.ActivityUnpinned -> {
                 if (event.fid == fid.rawValue) {
-                    state.onActivityUnpinned(event.pinnedActivity.activity.id)
+                    state.onActivityUnpinned(event.activityId)
                 }
             }
 
-            is BookmarkAddedEvent -> {
+            is StateUpdateEvent.BookmarkAdded -> {
                 if (event.bookmark.activity.feeds.contains(fid.rawValue)) {
-                    state.onBookmarkAdded(event.bookmark.toModel())
+                    state.onBookmarkAdded(event.bookmark)
                 }
             }
 
-            is BookmarkDeletedEvent -> {
+            is StateUpdateEvent.BookmarkDeleted -> {
                 if (event.bookmark.activity.feeds.contains(fid.rawValue)) {
-                    state.onBookmarkRemoved(event.bookmark.toModel())
+                    state.onBookmarkRemoved(event.bookmark)
                 }
             }
 
-            is CommentAddedEvent -> {
+            is StateUpdateEvent.CommentAdded -> {
                 if (event.fid == fid.rawValue) {
-                    state.onCommentAdded(event.comment.toModel())
+                    state.onCommentAdded(event.comment)
                 }
             }
 
-            is CommentDeletedEvent -> {
+            is StateUpdateEvent.CommentDeleted -> {
                 if (event.fid == fid.rawValue) {
-                    state.onCommentRemoved(event.comment.toModel())
+                    state.onCommentRemoved(event.comment)
                 }
             }
 
-            is FeedDeletedEvent -> {
+            is StateUpdateEvent.FeedDeleted -> {
                 if (event.fid == fid.rawValue) {
                     state.onFeedDeleted()
                 }
             }
 
-            is FeedUpdatedEvent -> {
-                if (event.fid == fid.rawValue) {
-                    state.onFeedUpdated(event.feed.toModel())
+            is StateUpdateEvent.FeedUpdated -> {
+                if (event.feed.fid == fid) {
+                    state.onFeedUpdated(event.feed)
                 }
             }
 
-            is FollowCreatedEvent -> {
-                if (event.fid == fid.rawValue) {
-                    state.onFollowAdded(event.follow.toModel())
+            is StateUpdateEvent.FollowAdded -> {
+                if (event.follow.run { sourceFeed.fid == fid || targetFeed.fid == fid }) {
+                    state.onFollowAdded(event.follow)
                 }
             }
 
-            is FollowDeletedEvent -> {
-                if (event.fid == fid.rawValue) {
-                    state.onFollowRemoved(event.follow.toModel())
+            is StateUpdateEvent.FollowDeleted -> {
+                if (event.follow.run { sourceFeed.fid == fid || targetFeed.fid == fid }) {
+                    state.onFollowRemoved(event.follow)
                 }
             }
 
-            is FollowUpdatedEvent -> {
-                if (event.fid == fid.rawValue) {
-                    state.onFollowUpdated(event.follow.toModel())
+            is StateUpdateEvent.FollowUpdated -> {
+                if (event.follow.run { sourceFeed.fid == fid || targetFeed.fid == fid }) {
+                    state.onFollowUpdated(event.follow)
                 }
             }
 
-            is NotificationFeedUpdatedEvent -> {
+            is StateUpdateEvent.NotificationFeedUpdated -> {
                 if (event.fid == fid.rawValue) {
                     state.onNotificationFeedUpdated(
-                        aggregatedActivities =
-                            event.aggregatedActivities?.map { it.toModel() }.orEmpty(),
+                        aggregatedActivities = event.aggregatedActivities,
                         notificationStatus = event.notificationStatus,
                     )
                 }
             }
 
-            is PollClosedFeedEvent -> {
+            is StateUpdateEvent.PollClosed -> {
                 if (event.fid == fid.rawValue) {
                     state.onPollClosed(event.poll.id)
                 }
             }
 
-            is PollDeletedFeedEvent -> {
+            is StateUpdateEvent.PollDeleted -> {
                 if (event.fid == fid.rawValue) {
-                    state.onPollDeleted(event.poll.id)
+                    state.onPollDeleted(event.pollId)
                 }
             }
 
-            is PollUpdatedFeedEvent -> {
+            is StateUpdateEvent.PollUpdated -> {
                 if (event.fid == fid.rawValue) {
-                    state.onPollUpdated(event.poll.toModel())
+                    state.onPollUpdated(event.poll)
                 }
             }
 
-            is PollVoteCastedFeedEvent -> {
+            is StateUpdateEvent.PollVoteCasted -> {
                 if (event.fid == fid.rawValue) {
-                    state.onPollVoteCasted(event.pollVote.toModel(), event.poll.id)
+                    state.onPollVoteCasted(event.vote, event.pollId)
                 }
             }
 
-            is PollVoteChangedFeedEvent -> {
+            is StateUpdateEvent.PollVoteChanged -> {
                 if (event.fid == fid.rawValue) {
-                    state.onPollVoteChanged(event.pollVote.toModel(), event.poll.id)
+                    state.onPollVoteChanged(event.vote, event.pollId)
                 }
             }
 
-            is PollVoteRemovedFeedEvent -> {
+            is StateUpdateEvent.PollVoteRemoved -> {
                 if (event.fid == fid.rawValue) {
-                    state.onPollVoteRemoved(event.pollVote.toModel(), event.poll.id)
+                    state.onPollVoteRemoved(event.vote, event.pollId)
                 }
             }
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImplTest.kt
@@ -48,6 +48,7 @@ import io.getstream.feeds.android.network.models.FollowRequest
 import io.getstream.feeds.android.network.models.QueryFeedMembersRequest
 import io.getstream.feeds.android.network.models.QueryFollowsRequest
 import io.getstream.feeds.android.network.models.RejectFollowRequest
+import io.getstream.feeds.android.network.models.UnfollowResponse
 import io.getstream.feeds.android.network.models.UpdateFeedMembersRequest
 import io.getstream.feeds.android.network.models.UpdateFeedRequest
 import io.mockk.mockk
@@ -190,12 +191,14 @@ internal class FeedsRepositoryImplTest {
     fun `on unfollow, delegate to api`() = runTest {
         val source = FeedId("user:user-1")
         val target = FeedId("user:user-2")
+        val followResponseData = followResponse()
+        val unfollowResponse = UnfollowResponse(duration = "duration", follow = followResponseData)
 
         testDelegation(
             apiFunction = { feedsApi.unfollow("user:user-1", "user:user-2") },
             repositoryCall = { repository.unfollow(source, target) },
-            apiResult = Unit,
-            repositoryResult = Unit,
+            apiResult = unfollowResponse,
+            repositoryResult = unfollowResponse.follow.toModel(),
         )
     }
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
@@ -83,7 +83,9 @@ internal class ActivityImplTest {
 
         activity.addComment(request, progress)
 
-        verify { stateEventListener.onEvent(StateUpdateEvent.CommentAdded(commentData)) }
+        verify {
+            stateEventListener.onEvent(StateUpdateEvent.CommentAdded("group:feed", commentData))
+        }
     }
 
     @Test
@@ -100,7 +102,7 @@ internal class ActivityImplTest {
         activity.addCommentsBatch(requests)
 
         commentData.forEach { data ->
-            verify { stateEventListener.onEvent(StateUpdateEvent.CommentAdded(data)) }
+            verify { stateEventListener.onEvent(StateUpdateEvent.CommentAdded("group:feed", data)) }
         }
     }
 
@@ -173,7 +175,9 @@ internal class ActivityImplTest {
         assertEquals(Unit, result.getOrNull())
         assertEquals(expectedActivity, activity.state.activity.value)
         verify {
-            stateEventListener.onEvent(StateUpdateEvent.CommentDeleted(deleteData.first))
+            stateEventListener.onEvent(
+                StateUpdateEvent.CommentDeleted("group:feed", deleteData.first)
+            )
             stateEventListener.onEvent(
                 StateUpdateEvent.ActivityUpdated("group:feed", expectedActivity)
             )

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImplTest.kt
@@ -71,7 +71,7 @@ internal class ActivityListStateImplTest {
         val paginationResult = defaultPaginationResult(initialActivities)
         activityListState.onQueryMoreActivities(paginationResult, queryConfig)
 
-        activityListState.onActivityRemoved(initialActivities[0])
+        activityListState.onActivityRemoved(initialActivities[0].id)
 
         val remainingActivities = activityListState.activities.value
         assertEquals(listOf(initialActivities[1]), remainingActivities)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
@@ -703,7 +703,6 @@ internal class FeedImplTest {
             commentsRepository = commentsRepository,
             feedsRepository = feedsRepository,
             pollsRepository = pollsRepository,
-            socketSubscriptionManager = mockk(relaxed = true),
             subscriptionManager = mockk(relaxed = true),
             feedWatchHandler = feedWatchHandler,
         )

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
@@ -595,7 +595,9 @@ internal class FeedImplTest {
         val result = feed.acceptFeedMember()
 
         assertEquals(member, result.getOrNull())
-        verify { stateEventListener.onEvent(StateUpdateEvent.FeedMemberAdded("group:id", member)) }
+        verify {
+            stateEventListener.onEvent(StateUpdateEvent.FeedMemberUpdated("group:id", member))
+        }
     }
 
     @Test
@@ -609,7 +611,7 @@ internal class FeedImplTest {
 
         assertEquals(member, result.getOrNull())
         verify {
-            stateEventListener.onEvent(StateUpdateEvent.FeedMemberRemoved("group:id", member.id))
+            stateEventListener.onEvent(StateUpdateEvent.FeedMemberUpdated("group:id", member))
         }
     }
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImplTest.kt
@@ -56,8 +56,8 @@ internal class FollowListStateImplTest {
 
         val updatedFollow =
             followData(
-                sourceUserId = "user-1",
-                targetUserId = "user-2",
+                sourceFid = "user:user-1",
+                targetFid = "user:user-2",
                 createdAt = java.util.Date(1000),
             )
         followListState.onFollowUpdated(updatedFollow)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEventToModelTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/StateUpdateEventToModelTest.kt
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.feeds.android.client.internal.state.event
+
+import io.getstream.feeds.android.client.internal.test.TestData
+import io.getstream.feeds.android.network.models.ActivityAddedEvent
+import io.getstream.feeds.android.network.models.ActivityDeletedEvent
+import io.getstream.feeds.android.network.models.ActivityPinnedEvent
+import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
+import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
+import io.getstream.feeds.android.network.models.ActivityRemovedFromFeedEvent
+import io.getstream.feeds.android.network.models.ActivityUnpinnedEvent
+import io.getstream.feeds.android.network.models.ActivityUpdatedEvent
+import io.getstream.feeds.android.network.models.BookmarkAddedEvent
+import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
+import io.getstream.feeds.android.network.models.BookmarkFolderDeletedEvent
+import io.getstream.feeds.android.network.models.BookmarkFolderUpdatedEvent
+import io.getstream.feeds.android.network.models.BookmarkUpdatedEvent
+import io.getstream.feeds.android.network.models.CommentAddedEvent
+import io.getstream.feeds.android.network.models.CommentDeletedEvent
+import io.getstream.feeds.android.network.models.CommentReactionAddedEvent
+import io.getstream.feeds.android.network.models.CommentReactionDeletedEvent
+import io.getstream.feeds.android.network.models.CommentUpdatedEvent
+import io.getstream.feeds.android.network.models.FeedDeletedEvent
+import io.getstream.feeds.android.network.models.FeedMemberAddedEvent
+import io.getstream.feeds.android.network.models.FeedMemberRemovedEvent
+import io.getstream.feeds.android.network.models.FeedMemberUpdatedEvent
+import io.getstream.feeds.android.network.models.FeedUpdatedEvent
+import io.getstream.feeds.android.network.models.FollowCreatedEvent
+import io.getstream.feeds.android.network.models.FollowDeletedEvent
+import io.getstream.feeds.android.network.models.FollowUpdatedEvent
+import io.getstream.feeds.android.network.models.NotificationFeedUpdatedEvent
+import io.getstream.feeds.android.network.models.NotificationStatusResponse
+import io.getstream.feeds.android.network.models.PollClosedFeedEvent
+import io.getstream.feeds.android.network.models.PollDeletedFeedEvent
+import io.getstream.feeds.android.network.models.PollUpdatedFeedEvent
+import io.getstream.feeds.android.network.models.PollVoteCastedFeedEvent
+import io.getstream.feeds.android.network.models.PollVoteChangedFeedEvent
+import io.getstream.feeds.android.network.models.PollVoteRemovedFeedEvent
+import io.getstream.feeds.android.network.models.WSEvent
+import java.util.Date
+import kotlin.reflect.KClass
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+internal class StateUpdateEventToModelTest(
+    private val testName: String,
+    private val wsEvent: WSEvent,
+    private val expectedType: KClass<StateUpdateEvent>,
+) {
+
+    @Test
+    fun testToModel() {
+        val result = wsEvent.toModel()
+
+        assertNotNull("Should not return null for $testName", result)
+        assertEquals("Wrong return type for $testName", expectedType, result!!::class)
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters(name = "{0}")
+        fun data(): Collection<Array<Any>> =
+            listOf(
+                activityAdded().shouldMapTo<StateUpdateEvent.ActivityAdded>(),
+                activityDeleted().shouldMapTo<StateUpdateEvent.ActivityDeleted>(),
+                activityRemovedFromFeed().shouldMapTo<StateUpdateEvent.ActivityRemovedFromFeed>(),
+                activityUpdated().shouldMapTo<StateUpdateEvent.ActivityUpdated>(),
+                activityPinned().shouldMapTo<StateUpdateEvent.ActivityPinned>(),
+                activityUnpinned().shouldMapTo<StateUpdateEvent.ActivityUnpinned>(),
+                activityReactionAdded().shouldMapTo<StateUpdateEvent.ActivityReactionAdded>(),
+                activityReactionDeleted().shouldMapTo<StateUpdateEvent.ActivityReactionDeleted>(),
+                bookmarkAdded().shouldMapTo<StateUpdateEvent.BookmarkAdded>(),
+                bookmarkDeleted().shouldMapTo<StateUpdateEvent.BookmarkDeleted>(),
+                bookmarkUpdated().shouldMapTo<StateUpdateEvent.BookmarkUpdated>(),
+                bookmarkFolderDeleted().shouldMapTo<StateUpdateEvent.BookmarkFolderDeleted>(),
+                bookmarkFolderUpdated().shouldMapTo<StateUpdateEvent.BookmarkFolderUpdated>(),
+                commentAdded().shouldMapTo<StateUpdateEvent.CommentAdded>(),
+                commentUpdated().shouldMapTo<StateUpdateEvent.CommentUpdated>(),
+                commentDeleted().shouldMapTo<StateUpdateEvent.CommentDeleted>(),
+                commentReactionAdded().shouldMapTo<StateUpdateEvent.CommentReactionAdded>(),
+                commentReactionDeleted().shouldMapTo<StateUpdateEvent.CommentReactionDeleted>(),
+                feedUpdated().shouldMapTo<StateUpdateEvent.FeedUpdated>(),
+                feedDeleted().shouldMapTo<StateUpdateEvent.FeedDeleted>(),
+                followCreated().shouldMapTo<StateUpdateEvent.FollowAdded>(),
+                followUpdated().shouldMapTo<StateUpdateEvent.FollowUpdated>(),
+                followDeleted().shouldMapTo<StateUpdateEvent.FollowDeleted>(),
+                notificationFeedUpdated().shouldMapTo<StateUpdateEvent.NotificationFeedUpdated>(),
+                feedMemberAdded().shouldMapTo<StateUpdateEvent.FeedMemberAdded>(),
+                feedMemberRemoved().shouldMapTo<StateUpdateEvent.FeedMemberRemoved>(),
+                feedMemberUpdated().shouldMapTo<StateUpdateEvent.FeedMemberUpdated>(),
+                pollClosedFeed().shouldMapTo<StateUpdateEvent.PollClosed>(),
+                pollDeletedFeed().shouldMapTo<StateUpdateEvent.PollDeleted>(),
+                pollUpdatedFeed().shouldMapTo<StateUpdateEvent.PollUpdated>(),
+                pollVoteCastedFeed().shouldMapTo<StateUpdateEvent.PollVoteCasted>(),
+                pollVoteChangedFeed().shouldMapTo<StateUpdateEvent.PollVoteChanged>(),
+                pollVoteRemovedFeed().shouldMapTo<StateUpdateEvent.PollVoteRemoved>(),
+            )
+
+        private inline fun <reified S : StateUpdateEvent> WSEvent.shouldMapTo() =
+            arrayOf(this::class.simpleName.orEmpty(), this, S::class)
+
+        private fun activityAdded() =
+            ActivityAddedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                activity = TestData.activityResponse(),
+                type = "activity.added",
+            )
+
+        private fun activityDeleted() =
+            ActivityDeletedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                activity = TestData.activityResponse(),
+                type = "activity.deleted",
+            )
+
+        private fun activityUpdated() =
+            ActivityUpdatedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                activity = TestData.activityResponse(),
+                type = "activity.updated",
+            )
+
+        private fun activityRemovedFromFeed() =
+            ActivityRemovedFromFeedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                activity = TestData.activityResponse(),
+                type = "activity.removed",
+            )
+
+        private fun activityPinned() =
+            ActivityPinnedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                pinnedActivity = TestData.activityPinResponse(),
+                type = "activity.pinned",
+            )
+
+        private fun activityUnpinned() =
+            ActivityUnpinnedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                pinnedActivity = TestData.activityPinResponse(),
+                type = "activity.unpinned",
+            )
+
+        private fun activityReactionAdded() =
+            ActivityReactionAddedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                activity = TestData.activityResponse(),
+                reaction = TestData.feedsReactionResponse(),
+                type = "reaction.added",
+            )
+
+        private fun activityReactionDeleted() =
+            ActivityReactionDeletedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                activity = TestData.activityResponse(),
+                reaction = TestData.feedsReactionResponse(),
+                type = "reaction.deleted",
+            )
+
+        private fun bookmarkAdded() =
+            BookmarkAddedEvent(
+                createdAt = Date(1000),
+                bookmark = TestData.bookmarkResponse(),
+                type = "bookmark.added",
+            )
+
+        private fun bookmarkDeleted() =
+            BookmarkDeletedEvent(
+                createdAt = Date(1000),
+                bookmark = TestData.bookmarkResponse(),
+                type = "bookmark.deleted",
+            )
+
+        private fun bookmarkUpdated() =
+            BookmarkUpdatedEvent(
+                createdAt = Date(1000),
+                bookmark = TestData.bookmarkResponse(),
+                type = "bookmark.updated",
+            )
+
+        private fun bookmarkFolderDeleted() =
+            BookmarkFolderDeletedEvent(
+                createdAt = Date(1000),
+                bookmarkFolder = TestData.bookmarkFolderResponse(),
+                type = "bookmark_folder.deleted",
+            )
+
+        private fun bookmarkFolderUpdated() =
+            BookmarkFolderUpdatedEvent(
+                createdAt = Date(1000),
+                bookmarkFolder = TestData.bookmarkFolderResponse(),
+                type = "bookmark_folder.updated",
+            )
+
+        private fun commentAdded() =
+            CommentAddedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                activity = TestData.activityResponse(),
+                comment = TestData.commentResponse(),
+                type = "comment.added",
+            )
+
+        private fun commentUpdated() =
+            CommentUpdatedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                comment = TestData.commentResponse(),
+                type = "comment.updated",
+            )
+
+        private fun commentDeleted() =
+            CommentDeletedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                comment = TestData.commentResponse(),
+                type = "comment.deleted",
+            )
+
+        private fun commentReactionAdded() =
+            CommentReactionAddedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                activity = TestData.activityResponse(),
+                comment = TestData.commentResponse(),
+                reaction = TestData.feedsReactionResponse(),
+                type = "comment_reaction.added",
+            )
+
+        private fun commentReactionDeleted() =
+            CommentReactionDeletedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                comment = TestData.commentResponse(),
+                reaction = TestData.feedsReactionResponse(),
+                type = "comment_reaction.deleted",
+            )
+
+        private fun feedUpdated() =
+            FeedUpdatedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                feed = TestData.feedResponse(),
+                type = "feed.updated",
+            )
+
+        private fun feedDeleted() =
+            FeedDeletedEvent(createdAt = Date(1000), fid = "group:feed", type = "feed.deleted")
+
+        private fun followCreated() =
+            FollowCreatedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                follow = TestData.followResponse(),
+                type = "follow.created",
+            )
+
+        private fun followUpdated() =
+            FollowUpdatedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                follow = TestData.followResponse(),
+                type = "follow.updated",
+            )
+
+        private fun followDeleted() =
+            FollowDeletedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                follow = TestData.followResponse(),
+                type = "follow.deleted",
+            )
+
+        private fun notificationFeedUpdated() =
+            NotificationFeedUpdatedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                aggregatedActivities = emptyList(),
+                notificationStatus = NotificationStatusResponse(unread = 5, unseen = 3),
+                type = "notification_feed.updated",
+            )
+
+        private fun feedMemberAdded() =
+            FeedMemberAddedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                member = TestData.feedMemberResponse(),
+                type = "feed_member.added",
+            )
+
+        private fun feedMemberRemoved() =
+            FeedMemberRemovedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                memberId = "user-1",
+                type = "feed_member.removed",
+            )
+
+        private fun feedMemberUpdated() =
+            FeedMemberUpdatedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                member = TestData.feedMemberResponse(),
+                type = "feed_member.updated",
+            )
+
+        private fun pollClosedFeed() =
+            PollClosedFeedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                poll = TestData.pollResponseData(),
+                type = "poll.closed",
+            )
+
+        private fun pollDeletedFeed() =
+            PollDeletedFeedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                poll = TestData.pollResponseData(),
+                type = "poll.deleted",
+            )
+
+        private fun pollUpdatedFeed() =
+            PollUpdatedFeedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                poll = TestData.pollResponseData(),
+                type = "poll.updated",
+            )
+
+        private fun pollVoteCastedFeed() =
+            PollVoteCastedFeedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                poll = TestData.pollResponseData(),
+                pollVote = TestData.pollVoteResponseData(),
+                type = "poll_vote.casted",
+            )
+
+        private fun pollVoteChangedFeed() =
+            PollVoteChangedFeedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                poll = TestData.pollResponseData(),
+                pollVote = TestData.pollVoteResponseData(),
+                type = "poll_vote.changed",
+            )
+
+        private fun pollVoteRemovedFeed() =
+            PollVoteRemovedFeedEvent(
+                createdAt = Date(1000),
+                fid = "group:feed",
+                poll = TestData.pollResponseData(),
+                pollVote = TestData.pollVoteResponseData(),
+                type = "poll_vote.removed",
+            )
+    }
+}

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityCommentListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityCommentListEventHandlerTest.kt
@@ -34,7 +34,7 @@ internal class ActivityCommentListEventHandlerTest {
     @Test
     fun `on CommentAdded for matching object, then call onCommentAdded`() {
         val comment = commentData(objectId = objectId, objectType = objectType)
-        val event = StateUpdateEvent.CommentAdded(comment)
+        val event = StateUpdateEvent.CommentAdded("feed-1", comment)
 
         handler.onEvent(event)
 
@@ -44,7 +44,7 @@ internal class ActivityCommentListEventHandlerTest {
     @Test
     fun `on CommentAdded for different object, then do not call onCommentAdded`() {
         val comment = commentData(objectId = "different-activity", objectType = objectType)
-        val event = StateUpdateEvent.CommentAdded(comment)
+        val event = StateUpdateEvent.CommentAdded("feed-1", comment)
 
         handler.onEvent(event)
 
@@ -54,7 +54,7 @@ internal class ActivityCommentListEventHandlerTest {
     @Test
     fun `on CommentDeleted for matching object, then call onCommentRemoved`() {
         val comment = commentData(objectId = objectId, objectType = objectType)
-        val event = StateUpdateEvent.CommentDeleted(comment)
+        val event = StateUpdateEvent.CommentDeleted("feed-1", comment)
 
         handler.onEvent(event)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/ActivityListEventHandlerTest.kt
@@ -17,7 +17,6 @@ package io.getstream.feeds.android.client.internal.state.event.handler
 
 import io.getstream.feeds.android.client.internal.state.ActivityListStateUpdates
 import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
-import io.getstream.feeds.android.client.internal.test.TestData.activityData
 import io.getstream.feeds.android.client.internal.test.TestData.bookmarkData
 import io.getstream.feeds.android.client.internal.test.TestData.commentData
 import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
@@ -33,12 +32,11 @@ internal class ActivityListEventHandlerTest {
 
     @Test
     fun `on ActivityDeleted, then call onActivityRemoved`() {
-        val activity = activityData()
-        val event = StateUpdateEvent.ActivityDeleted(activity)
+        val event = StateUpdateEvent.ActivityDeleted("feed-1", "activity-1")
 
         handler.onEvent(event)
 
-        verify { state.onActivityRemoved(activity) }
+        verify { state.onActivityRemoved("activity-1") }
     }
 
     @Test
@@ -84,7 +82,7 @@ internal class ActivityListEventHandlerTest {
     @Test
     fun `on CommentAdded, then call onCommentAdded`() {
         val comment = commentData()
-        val event = StateUpdateEvent.CommentAdded(comment)
+        val event = StateUpdateEvent.CommentAdded("feed-1", comment)
 
         handler.onEvent(event)
 
@@ -94,7 +92,7 @@ internal class ActivityListEventHandlerTest {
     @Test
     fun `on CommentDeleted, then call onCommentRemoved`() {
         val comment = commentData()
-        val event = StateUpdateEvent.CommentDeleted(comment)
+        val event = StateUpdateEvent.CommentDeleted("feed-1", comment)
 
         handler.onEvent(event)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BookmarkListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/BookmarkListEventHandlerTest.kt
@@ -73,7 +73,7 @@ internal class BookmarkListEventHandlerTest {
     @Test
     fun `on unknown event, then do nothing`() {
         val comment = commentData()
-        val unknownEvent = StateUpdateEvent.CommentAdded(comment)
+        val unknownEvent = StateUpdateEvent.CommentAdded("feed-1", comment)
 
         handler.onEvent(unknownEvent)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentListEventHandlerTest.kt
@@ -41,7 +41,7 @@ internal class CommentListEventHandlerTest {
     @Test
     fun `on CommentDeletedEvent, then call onCommentRemoved`() {
         val comment = commentData()
-        val event = StateUpdateEvent.CommentDeleted(comment)
+        val event = StateUpdateEvent.CommentDeleted("feed-1", comment)
 
         handler.onEvent(event)
 
@@ -51,7 +51,7 @@ internal class CommentListEventHandlerTest {
     @Test
     fun `on unknown event, then do nothing`() {
         val comment = commentData()
-        val unknownEvent = StateUpdateEvent.CommentAdded(comment)
+        val unknownEvent = StateUpdateEvent.CommentAdded("feed-1", comment)
 
         handler.onEvent(unknownEvent)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReplyListEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/CommentReplyListEventHandlerTest.kt
@@ -33,7 +33,7 @@ internal class CommentReplyListEventHandlerTest {
     @Test
     fun `on CommentAdded, then call onCommentAdded`() {
         val comment = commentData()
-        val event = StateUpdateEvent.CommentAdded(comment)
+        val event = StateUpdateEvent.CommentAdded("feed-1", comment)
 
         handler.onEvent(event)
 
@@ -43,7 +43,7 @@ internal class CommentReplyListEventHandlerTest {
     @Test
     fun `on CommentDeleted, then call onCommentRemoved`() {
         val comment = commentData()
-        val event = StateUpdateEvent.CommentDeleted(comment)
+        val event = StateUpdateEvent.CommentDeleted("feed-1", comment)
 
         handler.onEvent(event)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/FeedEventHandlerTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/event/handler/FeedEventHandlerTest.kt
@@ -15,492 +15,423 @@
  */
 package io.getstream.feeds.android.client.internal.state.event.handler
 
+import io.getstream.feeds.android.client.api.model.ActivityPinData
+import io.getstream.feeds.android.client.api.model.AggregatedActivityData
 import io.getstream.feeds.android.client.api.model.FeedId
-import io.getstream.feeds.android.client.api.model.toModel
 import io.getstream.feeds.android.client.internal.state.FeedStateUpdates
-import io.getstream.feeds.android.client.internal.test.TestData.activityResponse
-import io.getstream.feeds.android.client.internal.test.TestData.bookmarkResponse
-import io.getstream.feeds.android.client.internal.test.TestData.commentResponse
-import io.getstream.feeds.android.client.internal.test.TestData.feedResponse
-import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionResponse
-import io.getstream.feeds.android.client.internal.test.TestData.followResponse
-import io.getstream.feeds.android.client.internal.test.TestData.pinActivityResponse
-import io.getstream.feeds.android.client.internal.test.TestData.pollResponseData
-import io.getstream.feeds.android.client.internal.test.TestData.pollVoteResponseData
-import io.getstream.feeds.android.network.models.ActivityAddedEvent
-import io.getstream.feeds.android.network.models.ActivityDeletedEvent
-import io.getstream.feeds.android.network.models.ActivityPinnedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionAddedEvent
-import io.getstream.feeds.android.network.models.ActivityReactionDeletedEvent
-import io.getstream.feeds.android.network.models.ActivityRemovedFromFeedEvent
-import io.getstream.feeds.android.network.models.ActivityUnpinnedEvent
-import io.getstream.feeds.android.network.models.ActivityUpdatedEvent
-import io.getstream.feeds.android.network.models.BookmarkAddedEvent
-import io.getstream.feeds.android.network.models.BookmarkDeletedEvent
-import io.getstream.feeds.android.network.models.CommentAddedEvent
-import io.getstream.feeds.android.network.models.CommentDeletedEvent
-import io.getstream.feeds.android.network.models.FeedDeletedEvent
-import io.getstream.feeds.android.network.models.FeedUpdatedEvent
-import io.getstream.feeds.android.network.models.FollowCreatedEvent
-import io.getstream.feeds.android.network.models.FollowDeletedEvent
-import io.getstream.feeds.android.network.models.FollowUpdatedEvent
-import io.getstream.feeds.android.network.models.NotificationFeedUpdatedEvent
-import io.getstream.feeds.android.network.models.PollClosedFeedEvent
-import io.getstream.feeds.android.network.models.PollDeletedFeedEvent
-import io.getstream.feeds.android.network.models.PollUpdatedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteCastedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteChangedFeedEvent
-import io.getstream.feeds.android.network.models.PollVoteRemovedFeedEvent
-import io.getstream.feeds.android.network.models.WSEvent
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
+import io.getstream.feeds.android.client.internal.test.TestData.activityData
+import io.getstream.feeds.android.client.internal.test.TestData.bookmarkData
+import io.getstream.feeds.android.client.internal.test.TestData.commentData
+import io.getstream.feeds.android.client.internal.test.TestData.feedData
+import io.getstream.feeds.android.client.internal.test.TestData.feedsReactionData
+import io.getstream.feeds.android.client.internal.test.TestData.followData
+import io.getstream.feeds.android.client.internal.test.TestData.pollData
+import io.getstream.feeds.android.client.internal.test.TestData.pollVoteData
+import io.getstream.feeds.android.network.models.NotificationStatusResponse
 import io.mockk.called
+import io.mockk.clearMocks
 import io.mockk.mockk
 import io.mockk.verify
 import java.util.Date
 import org.junit.Test
 
 internal class FeedEventHandlerTest {
-    private val fid = FeedId("user", "feed-1")
+    private val fid = FeedId("group", "feed-1")
     private val state: FeedStateUpdates = mockk(relaxed = true)
 
     private val handler = FeedEventHandler(fid, state)
 
     @Test
-    fun `on ActivityAddedEvent for matching feed, then call onActivityAdded`() {
-        val activity = activityResponse()
-        val event =
-            ActivityAddedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
+    fun `on ActivityAdded, then handle based on feed match`() {
+        val activity = activityData()
+        val matchingEvent = StateUpdateEvent.ActivityAdded(fid.rawValue, activity)
+        val nonMatchingEvent = StateUpdateEvent.ActivityAdded("group:different", activity)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onActivityAdded(activity) },
+        )
+    }
+
+    @Test
+    fun `on ActivityRemovedFromFeed, then handle based on feed match`() {
+        val activityId = "activity-1"
+        val matchingEvent = StateUpdateEvent.ActivityRemovedFromFeed(fid.rawValue, activityId)
+        val nonMatchingEvent =
+            StateUpdateEvent.ActivityRemovedFromFeed("group:different", activityId)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onActivityRemoved(activityId) },
+        )
+    }
+
+    @Test
+    fun `on ActivityDeleted, then handle based on feed match`() {
+        val matchingEvent = StateUpdateEvent.ActivityDeleted(fid.rawValue, "activity-1")
+        val nonMatchingEvent = StateUpdateEvent.ActivityDeleted("group:different", "activity-1")
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onActivityRemoved("activity-1") },
+        )
+    }
+
+    @Test
+    fun `on ActivityUpdated, then handle based on feed match`() {
+        val activity = activityData()
+        val matchingEvent = StateUpdateEvent.ActivityUpdated(fid.rawValue, activity)
+        val nonMatchingEvent = StateUpdateEvent.ActivityUpdated("group:different", activity)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onActivityUpdated(activity) },
+        )
+    }
+
+    @Test
+    fun `on ActivityReactionAdded, then handle based on feed match`() {
+        val reaction = feedsReactionData("activity-1")
+        val matchingEvent = StateUpdateEvent.ActivityReactionAdded(fid.rawValue, reaction)
+        val nonMatchingEvent = StateUpdateEvent.ActivityReactionAdded("group:different", reaction)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onReactionAdded(reaction) },
+        )
+    }
+
+    @Test
+    fun `on ActivityReactionDeleted, then handle based on feed match`() {
+        val reaction = feedsReactionData("activity-1")
+        val matchingEvent = StateUpdateEvent.ActivityReactionDeleted(fid.rawValue, reaction)
+        val nonMatchingEvent = StateUpdateEvent.ActivityReactionDeleted("group:different", reaction)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onReactionRemoved(reaction) },
+        )
+    }
+
+    @Test
+    fun `on ActivityPinned, then handle based on feed match`() {
+        val activity = activityData()
+        val pinnedActivity =
+            ActivityPinData(
                 activity = activity,
-                type = "feeds.activity.added",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onActivityAdded(activity.toModel()) }
-    }
-
-    @Test
-    fun `on ActivityAddedEvent for different feed, then do not call onActivityAdded`() {
-        val activity = activityResponse()
-        val event =
-            ActivityAddedEvent(
                 createdAt = Date(),
-                fid = "user:different-feed",
-                activity = activity,
-                type = "feeds.activity.added",
+                fid = fid,
+                updatedAt = Date(),
+                userId = "user-1",
             )
+        val matchingEvent = StateUpdateEvent.ActivityPinned(fid.rawValue, pinnedActivity)
+        val nonMatchingEvent = StateUpdateEvent.ActivityPinned("group:different", pinnedActivity)
 
-        handler.onEvent(event)
-
-        verify(exactly = 0) { state.onActivityAdded(any()) }
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onActivityPinned(pinnedActivity) },
+        )
     }
 
     @Test
-    fun `on ActivityRemovedFromFeedEvent for matching feed, then call onActivityRemoved`() {
-        val activity = activityResponse()
-        val event =
-            ActivityRemovedFromFeedEvent(
+    fun `on ActivityUnpinned, then handle based on feed match`() {
+        val activityId = "activity-1"
+        val matchingEvent = StateUpdateEvent.ActivityUnpinned(fid.rawValue, activityId)
+        val nonMatchingEvent = StateUpdateEvent.ActivityUnpinned("group:different", activityId)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onActivityUnpinned(activityId) },
+        )
+    }
+
+    @Test
+    fun `on BookmarkAdded, then handle based on activity feed match`() {
+        val matchingActivity = activityData().copy(feeds = listOf(fid.rawValue, "other:feed"))
+        val matchingBookmark = bookmarkData().copy(activity = matchingActivity)
+        val matchingEvent = StateUpdateEvent.BookmarkAdded(matchingBookmark)
+
+        val nonMatchingActivity = activityData().copy(feeds = listOf("other:feed", "another:feed"))
+        val nonMatchingBookmark = bookmarkData().copy(activity = nonMatchingActivity)
+        val nonMatchingEvent = StateUpdateEvent.BookmarkAdded(nonMatchingBookmark)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onBookmarkAdded(matchingBookmark) },
+        )
+    }
+
+    @Test
+    fun `on BookmarkDeleted, then handle based on activity feed match`() {
+        val matchingActivity = activityData().copy(feeds = listOf(fid.rawValue))
+        val matchingBookmark = bookmarkData().copy(activity = matchingActivity)
+        val matchingEvent = StateUpdateEvent.BookmarkDeleted(matchingBookmark)
+
+        val nonMatchingActivity = activityData().copy(feeds = listOf("other:feed"))
+        val nonMatchingBookmark = bookmarkData().copy(activity = nonMatchingActivity)
+        val nonMatchingEvent = StateUpdateEvent.BookmarkDeleted(nonMatchingBookmark)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onBookmarkRemoved(matchingBookmark) },
+        )
+    }
+
+    @Test
+    fun `on CommentAdded, then handle based on feed match`() {
+        val comment = commentData()
+        val matchingEvent = StateUpdateEvent.CommentAdded(fid.rawValue, comment)
+        val nonMatchingEvent = StateUpdateEvent.CommentAdded("group:different", comment)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onCommentAdded(comment) },
+        )
+    }
+
+    @Test
+    fun `on CommentDeleted, then handle based on feed match`() {
+        val comment = commentData()
+        val matchingEvent = StateUpdateEvent.CommentDeleted(fid.rawValue, comment)
+        val nonMatchingEvent = StateUpdateEvent.CommentDeleted("group:different", comment)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onCommentRemoved(comment) },
+        )
+    }
+
+    @Test
+    fun `on FeedDeleted, then handle based on feed match`() {
+        val matchingEvent = StateUpdateEvent.FeedDeleted(fid.rawValue)
+        val nonMatchingEvent = StateUpdateEvent.FeedDeleted("group:different")
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onFeedDeleted() },
+        )
+    }
+
+    @Test
+    fun `on FeedUpdated, then handle based on feed match`() {
+        val matchingFeed = feedData(id = fid.id, groupId = fid.group)
+        val matchingEvent = StateUpdateEvent.FeedUpdated(matchingFeed)
+
+        val nonMatchingFeed = feedData(id = "group:different", groupId = "group")
+        val nonMatchingEvent = StateUpdateEvent.FeedUpdated(nonMatchingFeed)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onFeedUpdated(matchingFeed) },
+        )
+    }
+
+    @Test
+    fun `on FollowAdded, then handle based on feed match`() {
+        val matchingFollow = followData(sourceFid = fid.rawValue)
+        val matchingEvent = StateUpdateEvent.FollowAdded(matchingFollow)
+
+        val nonMatchingFollow = followData(sourceFid = "other:feed", targetFid = "another:feed")
+        val nonMatchingEvent = StateUpdateEvent.FollowAdded(nonMatchingFollow)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onFollowAdded(matchingFollow) },
+        )
+    }
+
+    @Test
+    fun `on FollowDeleted, then handle based on feed match`() {
+        val matchingFollow = followData(sourceFid = fid.rawValue)
+        val matchingEvent = StateUpdateEvent.FollowDeleted(matchingFollow)
+
+        val nonMatchingFollow = followData(sourceFid = "other:feed", targetFid = "another:feed")
+        val nonMatchingEvent = StateUpdateEvent.FollowDeleted(nonMatchingFollow)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onFollowRemoved(matchingFollow) },
+        )
+    }
+
+    @Test
+    fun `on FollowUpdated, then handle based on feed match`() {
+        val matchingFollow = followData(sourceFid = fid.rawValue)
+        val matchingEvent = StateUpdateEvent.FollowUpdated(matchingFollow)
+
+        val nonMatchingFollow = followData(sourceFid = "other:feed", targetFid = "another:feed")
+        val nonMatchingEvent = StateUpdateEvent.FollowUpdated(nonMatchingFollow)
+
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onFollowUpdated(matchingFollow) },
+        )
+    }
+
+    @Test
+    fun `on NotificationFeedUpdated, then handle based on feed match`() {
+        val activity = activityData()
+        val aggregatedActivity =
+            AggregatedActivityData(
+                activities = listOf(activity),
+                activityCount = 1,
                 createdAt = Date(),
-                fid = fid.rawValue,
-                activity = activity,
-                type = "feeds.activity.removed_from_feed",
+                group = "test-group",
+                score = 1.0f,
+                updatedAt = Date(),
+                userCount = 1,
+                userCountTruncated = false,
+            )
+        val aggregatedActivities = listOf(aggregatedActivity)
+        val notificationStatus = NotificationStatusResponse(unread = 0, unseen = 1)
+        val matchingEvent =
+            StateUpdateEvent.NotificationFeedUpdated(
+                fid.rawValue,
+                aggregatedActivities,
+                notificationStatus,
+            )
+        val nonMatchingEvent =
+            StateUpdateEvent.NotificationFeedUpdated(
+                "group:different",
+                aggregatedActivities,
+                notificationStatus,
             )
 
-        handler.onEvent(event)
-
-        verify { state.onActivityRemoved(activity.id) }
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = {
+                state.onNotificationFeedUpdated(aggregatedActivities, notificationStatus)
+            },
+        )
     }
 
     @Test
-    fun `on ActivityDeletedEvent for matching feed, then call onActivityRemoved`() {
-        val activity = activityResponse()
-        val event =
-            ActivityDeletedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                activity = activity,
-                type = "feeds.activity.deleted",
-            )
+    fun `on PollClosed, then handle based on feed match`() {
+        val poll = pollData()
+        val matchingEvent = StateUpdateEvent.PollClosed(fid.rawValue, poll)
+        val nonMatchingEvent = StateUpdateEvent.PollClosed("group:different", poll)
 
-        handler.onEvent(event)
-
-        verify { state.onActivityRemoved(activity.id) }
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onPollClosed(poll.id) },
+        )
     }
 
     @Test
-    fun `on ActivityUpdatedEvent for matching feed, then call onActivityUpdated`() {
-        val activity = activityResponse()
-        val event =
-            ActivityUpdatedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                activity = activity,
-                type = "feeds.activity.updated",
-            )
+    fun `on PollDeleted, then handle based on feed match`() {
+        val pollId = "poll-1"
+        val matchingEvent = StateUpdateEvent.PollDeleted(fid.rawValue, pollId)
+        val nonMatchingEvent = StateUpdateEvent.PollDeleted("group:different", pollId)
 
-        handler.onEvent(event)
-
-        verify { state.onActivityUpdated(activity.toModel()) }
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onPollDeleted(pollId) },
+        )
     }
 
     @Test
-    fun `on ActivityReactionAddedEvent for matching feed, then call onReactionAdded`() {
-        val activity = activityResponse()
-        val reaction = feedsReactionResponse()
-        val event =
-            ActivityReactionAddedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                activity = activity,
-                reaction = reaction,
-                type = "feeds.activity.reaction.added",
-            )
+    fun `on PollUpdated, then handle based on feed match`() {
+        val poll = pollData()
+        val matchingEvent = StateUpdateEvent.PollUpdated(fid.rawValue, poll)
+        val nonMatchingEvent = StateUpdateEvent.PollUpdated("group:different", poll)
 
-        handler.onEvent(event)
-
-        verify { state.onReactionAdded(reaction.toModel()) }
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onPollUpdated(poll) },
+        )
     }
 
     @Test
-    fun `on ActivityReactionDeletedEvent for matching feed, then call onReactionRemoved`() {
-        val activity = activityResponse()
-        val reaction = feedsReactionResponse()
-        val event =
-            ActivityReactionDeletedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                activity = activity,
-                reaction = reaction,
-                type = "feeds.activity.reaction.deleted",
-            )
+    fun `on PollVoteCasted, then handle based on feed match`() {
+        val pollId = "poll-1"
+        val pollVote = pollVoteData()
+        val matchingEvent = StateUpdateEvent.PollVoteCasted(fid.rawValue, pollId, pollVote)
+        val nonMatchingEvent = StateUpdateEvent.PollVoteCasted("group:different", pollId, pollVote)
 
-        handler.onEvent(event)
-
-        verify { state.onReactionRemoved(reaction.toModel()) }
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onPollVoteCasted(pollVote, pollId) },
+        )
     }
 
     @Test
-    fun `on ActivityPinnedEvent for matching feed, then call onActivityPinned`() {
-        val pinnedActivity = pinActivityResponse()
-        val event =
-            ActivityPinnedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                pinnedActivity = pinnedActivity,
-                type = "feeds.activity.pinned",
-            )
+    fun `on PollVoteChanged, then handle based on feed match`() {
+        val pollId = "poll-1"
+        val pollVote = pollVoteData()
+        val matchingEvent = StateUpdateEvent.PollVoteChanged(fid.rawValue, pollId, pollVote)
+        val nonMatchingEvent = StateUpdateEvent.PollVoteChanged("group:different", pollId, pollVote)
 
-        handler.onEvent(event)
-
-        verify { state.onActivityPinned(pinnedActivity.toModel()) }
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onPollVoteChanged(pollVote, pollId) },
+        )
     }
 
     @Test
-    fun `on ActivityUnpinnedEvent for matching feed, then call onActivityUnpinned`() {
-        val pinnedActivity = pinActivityResponse()
-        val event =
-            ActivityUnpinnedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                pinnedActivity = pinnedActivity,
-                type = "feeds.activity.unpinned",
-            )
+    fun `on PollVoteRemoved, then handle based on feed match`() {
+        val pollId = "poll-1"
+        val pollVote = pollVoteData()
+        val matchingEvent = StateUpdateEvent.PollVoteRemoved(fid.rawValue, pollId, pollVote)
+        val nonMatchingEvent = StateUpdateEvent.PollVoteRemoved("group:different", pollId, pollVote)
 
-        handler.onEvent(event)
-
-        verify { state.onActivityUnpinned(pinnedActivity.activity.id) }
-    }
-
-    @Test
-    fun `on BookmarkAddedEvent for activity in feed, then call onBookmarkAdded`() {
-        val bookmark =
-            bookmarkResponse()
-                .copy(
-                    activity = activityResponse().copy(feeds = listOf(fid.rawValue, "other:feed"))
-                )
-        val event =
-            BookmarkAddedEvent(
-                createdAt = Date(),
-                bookmark = bookmark,
-                type = "feeds.bookmark.added",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onBookmarkAdded(bookmark.toModel()) }
-    }
-
-    @Test
-    fun `on BookmarkAddedEvent for activity not in feed, then do not call onBookmarkAdded`() {
-        val bookmark =
-            bookmarkResponse()
-                .copy(
-                    activity = activityResponse().copy(feeds = listOf("other:feed", "another:feed"))
-                )
-        val event =
-            BookmarkAddedEvent(
-                createdAt = Date(),
-                bookmark = bookmark,
-                type = "feeds.bookmark.added",
-            )
-
-        handler.onEvent(event)
-
-        verify(exactly = 0) { state.onBookmarkAdded(any()) }
-    }
-
-    @Test
-    fun `on BookmarkDeletedEvent for activity in feed, then call onBookmarkRemoved`() {
-        val bookmark =
-            bookmarkResponse()
-                .copy(activity = activityResponse().copy(feeds = listOf(fid.rawValue)))
-        val event =
-            BookmarkDeletedEvent(
-                createdAt = Date(),
-                bookmark = bookmark,
-                type = "feeds.bookmark.deleted",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onBookmarkRemoved(bookmark.toModel()) }
-    }
-
-    @Test
-    fun `on CommentAddedEvent for matching feed, then call onCommentAdded`() {
-        val comment = commentResponse()
-        val event =
-            CommentAddedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                comment = comment,
-                type = "feeds.comment.added",
-                activity = activityResponse(),
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onCommentAdded(comment.toModel()) }
-    }
-
-    @Test
-    fun `on CommentDeletedEvent for matching feed, then call onCommentRemoved`() {
-        val comment = commentResponse()
-        val event =
-            CommentDeletedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                comment = comment,
-                type = "feeds.comment.deleted",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onCommentRemoved(comment.toModel()) }
-    }
-
-    @Test
-    fun `on FeedDeletedEvent for matching feed, then call onFeedDeleted`() {
-        val event =
-            FeedDeletedEvent(createdAt = Date(), fid = fid.rawValue, type = "feeds.feed.deleted")
-
-        handler.onEvent(event)
-
-        verify { state.onFeedDeleted() }
-    }
-
-    @Test
-    fun `on FeedUpdatedEvent for matching feed, then call onFeedUpdated`() {
-        val feed = feedResponse()
-        val event =
-            FeedUpdatedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                feed = feed,
-                type = "feeds.feed.updated",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onFeedUpdated(feed.toModel()) }
-    }
-
-    @Test
-    fun `on FollowCreatedEvent for matching feed, then call onFollowAdded`() {
-        val follow = followResponse()
-        val event =
-            FollowCreatedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                follow = follow,
-                type = "feeds.follow.created",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onFollowAdded(follow.toModel()) }
-    }
-
-    @Test
-    fun `on FollowDeletedEvent for matching feed, then call onFollowRemoved`() {
-        val follow = followResponse()
-        val event =
-            FollowDeletedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                follow = follow,
-                type = "feeds.follow.deleted",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onFollowRemoved(follow.toModel()) }
-    }
-
-    @Test
-    fun `on FollowUpdatedEvent for matching feed, then call onFollowUpdated`() {
-        val follow = followResponse()
-        val event =
-            FollowUpdatedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                follow = follow,
-                type = "feeds.follow.updated",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onFollowUpdated(follow.toModel()) }
-    }
-
-    @Test
-    fun `on NotificationFeedUpdatedEvent, then call onNotificationFeedUpdated`() {
-        val event =
-            NotificationFeedUpdatedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                aggregatedActivities = emptyList(),
-                notificationStatus = null,
-                type = "feeds.notification.updated",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onNotificationFeedUpdated(emptyList(), null) }
-    }
-
-    @Test
-    fun `on PollClosedFeedEvent for matching feed, then call onPollClosed`() {
-        val poll = pollResponseData()
-        val event =
-            PollClosedFeedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                poll = poll,
-                type = "feeds.poll.closed",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onPollClosed(poll.id) }
-    }
-
-    @Test
-    fun `on PollDeletedFeedEvent for matching feed, then call onPollDeleted`() {
-        val poll = pollResponseData()
-        val event =
-            PollDeletedFeedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                poll = poll,
-                type = "feeds.poll.deleted",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onPollDeleted(poll.id) }
-    }
-
-    @Test
-    fun `on PollUpdatedFeedEvent for matching feed, then call onPollUpdated`() {
-        val poll = pollResponseData()
-        val event =
-            PollUpdatedFeedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                poll = poll,
-                type = "feeds.poll.updated",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onPollUpdated(poll.toModel()) }
-    }
-
-    @Test
-    fun `on PollVoteCastedFeedEvent for matching feed, then call onPollVoteCasted`() {
-        val poll = pollResponseData()
-        val pollVote = pollVoteResponseData()
-        val event =
-            PollVoteCastedFeedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                poll = poll,
-                pollVote = pollVote,
-                type = "feeds.poll.vote.casted",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onPollVoteCasted(pollVote.toModel(), poll.id) }
-    }
-
-    @Test
-    fun `on PollVoteChangedFeedEvent for matching feed, then call onPollVoteChanged`() {
-        val poll = pollResponseData()
-        val pollVote = pollVoteResponseData()
-        val event =
-            PollVoteChangedFeedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                poll = poll,
-                pollVote = pollVote,
-                type = "feeds.poll.vote.changed",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onPollVoteChanged(pollVote.toModel(), poll.id) }
-    }
-
-    @Test
-    fun `on PollVoteRemovedFeedEvent for matching feed, then call onPollVoteRemoved`() {
-        val poll = pollResponseData()
-        val pollVote = pollVoteResponseData()
-        val event =
-            PollVoteRemovedFeedEvent(
-                createdAt = Date(),
-                fid = fid.rawValue,
-                poll = poll,
-                pollVote = pollVote,
-                type = "feeds.poll.vote.removed",
-            )
-
-        handler.onEvent(event)
-
-        verify { state.onPollVoteRemoved(pollVote.toModel(), poll.id) }
+        testEventHandling(
+            matchingEvent = matchingEvent,
+            nonMatchingEvent = nonMatchingEvent,
+            verifyBlock = { state.onPollVoteRemoved(pollVote, pollId) },
+        )
     }
 
     @Test
     fun `on unknown event, then do nothing`() {
         val unknownEvent =
-            object : WSEvent {
-                override fun getWSEventType(): String = "unknown.event"
-            }
+            StateUpdateEvent.FeedMemberAdded(
+                "other:feed",
+                io.getstream.feeds.android.client.internal.test.TestData.feedMemberData(),
+            )
 
         handler.onEvent(unknownEvent)
 
+        verify { state wasNot called }
+    }
+
+    private fun testEventHandling(
+        matchingEvent: StateUpdateEvent,
+        nonMatchingEvent: StateUpdateEvent,
+        verifyBlock: () -> Unit,
+    ) {
+        // Test matching event
+        handler.onEvent(matchingEvent)
+        verify { verifyBlock() }
+
+        // Reset mock for clean verification
+        clearMocks(state)
+
+        // Test non-matching event
+        handler.onEvent(nonMatchingEvent)
         verify { state wasNot called }
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
@@ -359,8 +359,10 @@ internal object TestData {
         targetFid: String = "user:user-2",
         createdAt: Date = Date(1000),
         updatedAt: Date = Date(1000),
-    ): FollowData =
-        FollowData(
+    ): FollowData {
+        val source = FeedId(sourceFid)
+        val target = FeedId(targetFid)
+        return FollowData(
             createdAt = createdAt,
             custom = emptyMap(),
             followerRole = "user",
@@ -370,16 +372,16 @@ internal object TestData {
             sourceFeed =
                 FeedData(
                     createdAt = createdAt,
-                    createdBy = userData(sourceFid),
+                    createdBy = userData(source.id),
                     custom = emptyMap(),
                     deletedAt = null,
                     description = "Test feed",
-                    fid = FeedId(sourceFid),
+                    fid = source,
                     filterTags = emptyList(),
                     followerCount = 0,
                     followingCount = 0,
                     groupId = "user",
-                    id = sourceFid,
+                    id = source.id,
                     memberCount = 0,
                     ownCapabilities = emptyList(),
                     ownMembership = null,
@@ -392,16 +394,16 @@ internal object TestData {
             targetFeed =
                 FeedData(
                     createdAt = createdAt,
-                    createdBy = userData(targetFid),
+                    createdBy = userData(target.id),
                     custom = emptyMap(),
                     deletedAt = null,
                     description = "Target feed",
-                    fid = FeedId(targetFid),
+                    fid = target,
                     filterTags = emptyList(),
                     followerCount = 0,
                     followingCount = 0,
                     groupId = "user",
-                    id = targetFid,
+                    id = target.id,
                     memberCount = 0,
                     ownCapabilities = emptyList(),
                     ownMembership = null,
@@ -412,6 +414,7 @@ internal object TestData {
                 ),
             updatedAt = updatedAt,
         )
+    }
 
     fun feedMemberData(
         userId: String = "user-1",

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
@@ -355,8 +355,8 @@ internal object TestData {
         )
 
     fun followData(
-        sourceUserId: String = "user-1",
-        targetUserId: String = "user-2",
+        sourceFid: String = "user:user-1",
+        targetFid: String = "user:user-2",
         createdAt: Date = Date(1000),
         updatedAt: Date = Date(1000),
     ): FollowData =
@@ -370,16 +370,16 @@ internal object TestData {
             sourceFeed =
                 FeedData(
                     createdAt = createdAt,
-                    createdBy = userData(sourceUserId),
+                    createdBy = userData(sourceFid),
                     custom = emptyMap(),
                     deletedAt = null,
                     description = "Test feed",
-                    fid = FeedId("user:$sourceUserId"),
+                    fid = FeedId(sourceFid),
                     filterTags = emptyList(),
                     followerCount = 0,
                     followingCount = 0,
                     groupId = "user",
-                    id = sourceUserId,
+                    id = sourceFid,
                     memberCount = 0,
                     ownCapabilities = emptyList(),
                     ownMembership = null,
@@ -392,16 +392,16 @@ internal object TestData {
             targetFeed =
                 FeedData(
                     createdAt = createdAt,
-                    createdBy = userData(targetUserId),
+                    createdBy = userData(targetFid),
                     custom = emptyMap(),
                     deletedAt = null,
                     description = "Target feed",
-                    fid = FeedId("user:$targetUserId"),
+                    fid = FeedId(targetFid),
                     filterTags = emptyList(),
                     followerCount = 0,
                     followingCount = 0,
                     groupId = "user",
-                    id = targetUserId,
+                    id = targetFid,
                     memberCount = 0,
                     ownCapabilities = emptyList(),
                     ownMembership = null,

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/test/TestData.kt
@@ -719,4 +719,13 @@ internal object TestData {
             models = list,
             pagination = PaginationData(next = "next-cursor", previous = null),
         )
+
+    fun activityPinResponse() =
+        PinActivityResponse(
+            activity = activityResponse(),
+            createdAt = Date(1000),
+            duration = "duration",
+            feed = "user:feed-1",
+            userId = "user-1",
+        )
 }


### PR DESCRIPTION
### Goal

Exact same story as #91, but for `Feed`. This concludes the migration from `WSEvent` to `StateUpdateEvent`, so now every "controller" object (`Activity`, `ActivityList`, etc) should be updating automatically even if we are not receiving socket events.

### Implementation

- Change handler from `WSEvent` to `StateUpdateEvent`
- Fire events from `FeedImpl` instead of updating the state directly

| Before | Now |
|---|---|
| `_state.onFeedUpdated(feed)` | `subscriptionManager.onEvent(FeedUpdated(feed))` |

- I also realized that for some operations that should result in a state update, `FeedImpl` was not updating the state (e.g. `updateBookmark`), so updated those also to fire events

### Testing

Similar instructions as #91, but this time even the feed should be updating. E.g. disable listening to the socket, test doing operations in the sample like adding a comment, voting on a poll, etc, and everything should be updating accordingly.

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
