### PR TITLE
Fix processing of updates in `MemberListState`

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListStateImpl.kt
@@ -26,7 +26,7 @@ import io.getstream.feeds.android.client.api.state.query.MembersQuery
 import io.getstream.feeds.android.client.api.state.query.MembersQueryConfig
 import io.getstream.feeds.android.client.api.state.query.MembersSort
 import io.getstream.feeds.android.client.internal.utils.mergeSorted
-import io.getstream.feeds.android.client.internal.utils.upsert
+import io.getstream.feeds.android.client.internal.utils.upsertSorted
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -70,7 +70,9 @@ internal class MemberListStateImpl(override val query: MembersQuery) : MemberLis
     }
 
     override fun onMemberAdded(member: FeedMemberData) {
-        _members.update { current -> current.upsert(member, FeedMemberData::id) }
+        _members.update { current ->
+            current.upsertSorted(member, FeedMemberData::id, membersSorting)
+        }
     }
 
     override fun onMemberRemoved(memberId: String) {
@@ -79,13 +81,7 @@ internal class MemberListStateImpl(override val query: MembersQuery) : MemberLis
 
     override fun onMemberUpdated(member: FeedMemberData) {
         _members.update { current ->
-            current.map {
-                if (it.id == member.id) {
-                    member
-                } else {
-                    it
-                }
-            }
+            current.upsertSorted(member, FeedMemberData::id, membersSorting)
         }
     }
 


### PR DESCRIPTION
### Goal

The current logic to add/update members into `MemberListState` has two flaws:
- It's not enforcing sorting
- It's not processing `added` members on batch updates
Thi PR fixes that.

### Implementation

Handle `added` members for batch updates & enforce sorting

### Testing

Testing manually it's not trivial, but there are now unit tests exercising that behavior.

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
