### PR TITLE
Use timeline feed for displaying and user feed for posting

### DIFF
--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/MainActivity.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/MainActivity.kt
@@ -38,7 +38,6 @@ import com.ramcosta.composedestinations.generated.NavGraphs
 import com.ramcosta.composedestinations.generated.destinations.FeedsScreenDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import dagger.hilt.android.AndroidEntryPoint
-import io.getstream.feeds.android.client.api.model.FeedId
 import io.getstream.feeds.android.sample.components.LoadingScreen
 import io.getstream.feeds.android.sample.feed.FeedsScreenArgs
 import io.getstream.feeds.android.sample.login.LoginScreen
@@ -87,7 +86,6 @@ fun MainScreen(navigator: DestinationsNavigator) {
                 LaunchedEffect(Unit) {
                     val args =
                         FeedsScreenArgs(
-                            feedId = FeedId("user", viewState.user.id).rawValue,
                             avatarUrl = viewState.user.imageURL,
                             userId = viewState.user.id,
                         )

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/MainActivity.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/MainActivity.kt
@@ -84,11 +84,7 @@ fun MainScreen(navigator: DestinationsNavigator) {
 
             is ViewState.LoggedIn -> {
                 LaunchedEffect(Unit) {
-                    val args =
-                        FeedsScreenArgs(
-                            avatarUrl = viewState.user.imageURL,
-                            userId = viewState.user.id,
-                        )
+                    val args = FeedsScreenArgs(avatarUrl = viewState.user.imageURL)
                     navigator.navigate(FeedsScreenDestination(args)) {
                         popUpTo(NavGraphs.root) { inclusive = true }
                     }

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedViewModel.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedViewModel.kt
@@ -281,7 +281,7 @@ constructor(
             ownFeed = userState.client.feed(userFeedId),
             timeline = userState.client.feed(timelineQuery),
             stories = userState.client.feed(storiesQuery),
-            notifications = userState.client.feed(FeedId("notification", args.userId)),
+            notifications = userState.client.feed(Feeds.notifications(args.userId)),
         )
     }
 

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
@@ -95,9 +95,8 @@ import io.getstream.feeds.android.sample.ui.util.conditional
 import io.getstream.feeds.android.sample.util.AsyncResource
 import io.getstream.feeds.android.sample.util.getOrNull
 
-data class FeedsScreenArgs(val feedId: String, val avatarUrl: String?, val userId: String) {
-    val fid = FeedId(feedId)
-}
+// TODO [G.] remove userId from args
+data class FeedsScreenArgs(val avatarUrl: String?, val userId: String)
 
 @Destination<RootGraph>(navArgs = FeedsScreenArgs::class)
 @OptIn(ExperimentalMaterial3Api::class)
@@ -198,7 +197,7 @@ private fun FeedsScreenContent(
                             onCommentClick = {
                                 navigator.navigate(
                                     CommentsBottomSheetDestination(
-                                        feedId = args.fid.rawValue,
+                                        feedId = viewState.timeline.fid.rawValue,
                                         activityId = activity.id,
                                     )
                                 )
@@ -314,7 +313,7 @@ private fun TopBarSection(
                 NotificationsScreenDestination(NotificationsScreenArgs(fid.rawValue))
             )
         },
-        onProfileClick = { navigator.navigate(ProfileScreenDestination(feedId = args.feedId)) },
+        onProfileClick = { navigator.navigate(ProfileScreenDestination) },
     )
 
     if (showLogoutConfirmation) {

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
@@ -75,7 +75,6 @@ import com.ramcosta.composedestinations.generated.destinations.NotificationsScre
 import com.ramcosta.composedestinations.generated.destinations.ProfileScreenDestination
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import io.getstream.feeds.android.client.api.model.ActivityData
-import io.getstream.feeds.android.client.api.model.FeedId
 import io.getstream.feeds.android.client.api.model.PollData
 import io.getstream.feeds.android.client.api.model.UserData
 import io.getstream.feeds.android.client.api.state.FeedState
@@ -88,7 +87,6 @@ import io.getstream.feeds.android.sample.components.LinkText
 import io.getstream.feeds.android.sample.components.LoadingScreen
 import io.getstream.feeds.android.sample.components.UserAvatar
 import io.getstream.feeds.android.sample.feed.FeedViewModel.ViewState
-import io.getstream.feeds.android.sample.notification.NotificationsScreenArgs
 import io.getstream.feeds.android.sample.story.StoryScreen
 import io.getstream.feeds.android.sample.ui.util.ScrolledToBottomEffect
 import io.getstream.feeds.android.sample.ui.util.conditional
@@ -308,10 +306,7 @@ private fun TopBarSection(
         onUserAvatarClick = { showLogoutConfirmation = true },
         onNotificationsClick = {
             // Open notifications screen
-            val fid = FeedId("notification", args.userId)
-            navigator.navigate(
-                NotificationsScreenDestination(NotificationsScreenArgs(fid.rawValue))
-            )
+            navigator.navigate(NotificationsScreenDestination)
         },
         onProfileClick = { navigator.navigate(ProfileScreenDestination) },
     )

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/feed/FeedsScreen.kt
@@ -93,8 +93,7 @@ import io.getstream.feeds.android.sample.ui.util.conditional
 import io.getstream.feeds.android.sample.util.AsyncResource
 import io.getstream.feeds.android.sample.util.getOrNull
 
-// TODO [G.] remove userId from args
-data class FeedsScreenArgs(val avatarUrl: String?, val userId: String)
+data class FeedsScreenArgs(val avatarUrl: String?)
 
 @Destination<RootGraph>(navArgs = FeedsScreenArgs::class)
 @OptIn(ExperimentalMaterial3Api::class)
@@ -132,20 +131,13 @@ fun FeedsScreen(args: FeedsScreenArgs, navigator: DestinationsNavigator) {
             }
 
             is AsyncResource.Content ->
-                FeedsScreenContent(
-                    args,
-                    navigator,
-                    state.data,
-                    viewModel,
-                    Modifier.padding(padding),
-                )
+                FeedsScreenContent(navigator, state.data, viewModel, Modifier.padding(padding))
         }
     }
 }
 
 @Composable
 private fun FeedsScreenContent(
-    args: FeedsScreenArgs,
     navigator: DestinationsNavigator,
     viewState: ViewState,
     viewModel: FeedViewModel,
@@ -191,7 +183,7 @@ private fun FeedsScreenContent(
                             text = baseActivity.text.orEmpty(),
                             attachments = baseActivity.attachments,
                             data = activity,
-                            currentUserId = args.userId,
+                            currentUserId = viewState.userId,
                             onCommentClick = {
                                 navigator.navigate(
                                     CommentsBottomSheetDestination(
@@ -210,7 +202,7 @@ private fun FeedsScreenContent(
                             pollSection = { poll ->
                                 PollSection(
                                     activityId = activity.id,
-                                    currentUserId = args.userId,
+                                    currentUserId = viewState.userId,
                                     poll = poll,
                                     controller = viewModel.pollController,
                                     navigator = navigator,

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/notification/NotificationsScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/notification/NotificationsScreen.kt
@@ -49,20 +49,12 @@ import com.ramcosta.composedestinations.annotation.RootGraph
 import com.ramcosta.composedestinations.bottomsheet.spec.DestinationStyleBottomSheet
 import com.ramcosta.composedestinations.navigation.DestinationsNavigator
 import io.getstream.feeds.android.client.api.model.AggregatedActivityData
-import io.getstream.feeds.android.client.api.model.FeedId
 import io.getstream.feeds.android.client.api.state.FeedState
 import io.getstream.feeds.android.sample.components.LoadingScreen
 import io.getstream.feeds.android.sample.components.UserAvatar
 import io.getstream.feeds.android.sample.util.AsyncResource
 
-data class NotificationsScreenArgs(val feedId: String) {
-    val fid = FeedId(feedId)
-}
-
-@Destination<RootGraph>(
-    style = DestinationStyleBottomSheet::class,
-    navArgs = NotificationsScreenArgs::class,
-)
+@Destination<RootGraph>(style = DestinationStyleBottomSheet::class)
 @Composable
 fun NotificationsScreen(navigator: DestinationsNavigator) {
     val viewModel = hiltViewModel<NotificationsViewModel>()

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/profile/ProfileScreen.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/profile/ProfileScreen.kt
@@ -59,22 +59,15 @@ import io.getstream.feeds.android.sample.components.UserAvatar
 import io.getstream.feeds.android.sample.util.AsyncResource
 import kotlinx.coroutines.flow.StateFlow
 
-data class ProfileScreenArgs(val feedId: String) {
-    val fid = FeedId(feedId)
-}
-
-@Destination<RootGraph>(
-    style = DestinationStyleBottomSheet::class,
-    navArgs = ProfileScreenArgs::class,
-)
+@Destination<RootGraph>(style = DestinationStyleBottomSheet::class)
 @Composable
 fun ProfileScreen(navigator: DestinationsNavigator) {
     val viewModel = hiltViewModel<ProfileViewModel>()
 
-    val state by viewModel.state.collectAsStateWithLifecycle()
+    val feed by viewModel.feed.collectAsStateWithLifecycle()
 
     Surface {
-        when (val state = state) {
+        when (val feed = feed) {
             AsyncResource.Loading -> LoadingScreen()
 
             AsyncResource.Error -> {
@@ -84,7 +77,7 @@ fun ProfileScreen(navigator: DestinationsNavigator) {
 
             is AsyncResource.Content ->
                 ProfileScreen(
-                    state = state.data,
+                    state = feed.data.state,
                     followSuggestions = viewModel.followSuggestions,
                     onFollowClick = viewModel::follow,
                     onUnfollowClick = viewModel::unfollow,

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/util/Feeds.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/util/Feeds.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.getstream.feeds.android.sample.util
+
+import io.getstream.feeds.android.client.api.model.FeedId
+
+object Feeds {
+    fun timeline(id: String) = FeedId("timeline", id)
+
+    fun user(id: String) = FeedId("user", id)
+}

--- a/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/util/Feeds.kt
+++ b/stream-feeds-android-sample/src/main/java/io/getstream/feeds/android/sample/util/Feeds.kt
@@ -20,5 +20,7 @@ import io.getstream.feeds.android.client.api.model.FeedId
 object Feeds {
     fun timeline(id: String) = FeedId("timeline", id)
 
+    fun notifications(id: String) = FeedId("notification", id)
+
     fun user(id: String) = FeedId("user", id)
 }


### PR DESCRIPTION
### Goal

[AND-801](https://linear.app/stream/issue/AND-801/update-sample-to-use-the-timeline-group-instead-of-user-for-the)

We've been using the user feed group wrong. `user:user_id` feeds are supposed to only contain the user's own posts and they should not follow other feeds. Instead, we should display `timeline:user_id` and have it follow user feeds.

### Implementation

- Use 2 different `Feed` instances: one with `timeline` group to display timeline & stories (which are still part of the timeline) and one with `user` group to post user's activities
- Make `timeline:user_x` auto follow `user:user_x`, otherwise the timeline wouldn't show the user's own posts
- Use a `Feed` with `user` group when querying follow suggestions, because we want to follow `user` feeds, not `timeline` ones
- Simplify args to avoid passing feed/user ID when not needed

### Testing

Launch the sample and verify everything works: interacting with the feed, follow/unfollow, notifications, etc.

Note: some follow relationship we had before might not exist after these changes, because they were like `user:user_x ->  user:user_y`, while now we have `timeline:user_x -> user:user_y`.

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
