### PR TITLE
Cancel in progress PR quality checks on concurrent job

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -2,12 +2,16 @@ name: PR checklist
 
 on:
   pull_request:
-    types: [opened, edited, synchronize, labeled, unlabeled, reopened]
+    types: [ opened, edited, synchronize, labeled, unlabeled, reopened ]
 
 permissions:
   contents: read
   pull-requests: write
   issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pr-checklist:


### PR DESCRIPTION
### Goal

We're currently not canceling the PR quality checks if a new job starts, which might cause duplicated comments, like in https://github.com/GetStream/stream-feeds-android/pull/95. So addressing that.

### Implementation

Add concurrency rule.

### Testing

Trigger multiple jobs, e.g. add/remove/add labels as soon as the PR is open and verify that the check in progress is canceled and no duplicated comments appear.

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
