### PR TITLE
Fix error responses not logged properly

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
@@ -87,7 +87,7 @@ internal fun createStreamCoreClient(
     wsUrl: StreamWsUrl,
     clientInfoHeader: StreamHttpClientInfoHeader,
     tokenProvider: StreamTokenProvider,
-    okHttpClient: OkHttpClient.Builder,
+    httpConfig: StreamHttpConfig,
     feedsMoshiJsonParser: FeedsMoshiJsonParser,
     logProvider: StreamLoggerProvider,
 ): StreamClient {
@@ -135,7 +135,7 @@ internal fun createStreamCoreClient(
         connectionIdHolder = connectionIdHolder,
         socketFactory = socketFactory,
         healthMonitor = healthMonitor,
-        httpConfig = StreamHttpConfig(httpBuilder = okHttpClient, automaticInterceptors = true),
+        httpConfig = httpConfig,
         serializationConfig =
             StreamClientSerializationConfig.default(
                 object : StreamEventSerialization<WSEvent> {
@@ -189,11 +189,14 @@ internal fun createFeedsClient(
             deviceModel = Build.MODEL,
         )
     // HTTP Configuration
-    val okHttpBuilder =
-        OkHttpClient.Builder()
-            .addInterceptor(
-                createLoggingInterceptor(logProvider, config.loggingConfig.httpLoggingLevel)
-            )
+    val okHttpBuilder = OkHttpClient.Builder()
+    val httpConfig =
+        StreamHttpConfig(
+            httpBuilder = okHttpBuilder,
+            automaticInterceptors = true,
+            configuredInterceptors =
+                setOf(createLoggingInterceptor(logProvider, config.loggingConfig.httpLoggingLevel)),
+        )
 
     val client =
         createStreamCoreClient(
@@ -203,7 +206,7 @@ internal fun createFeedsClient(
             StreamWsUrl.fromString(endpointConfig.wsUrl),
             clientInfoHeader,
             tokenProvider,
-            okHttpBuilder,
+            httpConfig,
             FeedsMoshiJsonParser(Serializer.moshi),
             logProvider,
         )


### PR DESCRIPTION
### Goal

Error responses are not logged properly, i.e. we log a generic message instead of the backend error response, i.e. effectively we're not honoring the HTTP call logging strategy that the client configured.

### Implementation

Pass the logging interceptor as a `configuredInterceptor` so it's added after auto-added interceptors

### Testing

Launch the sample and trigger an api call failure* and verify that the error response is logged to the LogCat.

*what I did was changing the reaction logic in `FeedsViewModel` to always delete a reaction, which errors if we're trying to delete a reaction that doesn't exist.

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
