### PR TITLE
Add `updateActivityPartial` function to Feed

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/Feed.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/Feed.kt
@@ -35,6 +35,7 @@ import io.getstream.feeds.android.network.models.AddReactionRequest
 import io.getstream.feeds.android.network.models.CreatePollRequest
 import io.getstream.feeds.android.network.models.FollowRequest
 import io.getstream.feeds.android.network.models.MarkActivityRequest
+import io.getstream.feeds.android.network.models.UpdateActivityPartialRequest
 import io.getstream.feeds.android.network.models.UpdateActivityRequest
 import io.getstream.feeds.android.network.models.UpdateBookmarkRequest
 import io.getstream.feeds.android.network.models.UpdateCommentRequest
@@ -132,6 +133,22 @@ public interface Feed {
     public suspend fun updateActivity(
         id: String,
         request: UpdateActivityRequest,
+    ): Result<ActivityData>
+
+    /**
+     * Partially updates an existing activity in the feed.
+     *
+     * Use 'set' to update specific fields and 'unset' to remove fields. This allows you to update
+     * only the fields you need without replacing the entire activity.
+     *
+     * @param id The unique identifier of the activity to update.
+     * @param request The request containing the fields to set or unset.
+     * @return A [Result] containing the updated [ActivityData] if successful, or an error if the
+     *   operation fails.
+     */
+    public suspend fun updateActivityPartial(
+        id: String,
+        request: UpdateActivityPartialRequest,
     ): Result<ActivityData>
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepository.kt
@@ -31,6 +31,7 @@ import io.getstream.feeds.android.network.models.DeleteActivitiesRequest
 import io.getstream.feeds.android.network.models.DeleteActivitiesResponse
 import io.getstream.feeds.android.network.models.MarkActivityRequest
 import io.getstream.feeds.android.network.models.QueryActivityReactionsRequest
+import io.getstream.feeds.android.network.models.UpdateActivityPartialRequest
 import io.getstream.feeds.android.network.models.UpdateActivityRequest
 
 /**
@@ -94,6 +95,20 @@ internal interface ActivitiesRepository {
     suspend fun updateActivity(
         activityId: String,
         request: UpdateActivityRequest,
+    ): Result<ActivityData>
+
+    /**
+     * Partially updates an existing activity.
+     *
+     * Use 'set' to update specific fields and 'unset' to remove fields.
+     *
+     * @param activityId The ID of the activity to update.
+     * @param request The request containing the fields to set or unset.
+     * @return A [Result] containing the updated [ActivityData] or an error.
+     */
+    suspend fun updateActivityPartial(
+        activityId: String,
+        request: UpdateActivityPartialRequest,
     ): Result<ActivityData>
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImpl.kt
@@ -38,6 +38,7 @@ import io.getstream.feeds.android.network.models.DeleteActivitiesRequest
 import io.getstream.feeds.android.network.models.DeleteActivitiesResponse
 import io.getstream.feeds.android.network.models.MarkActivityRequest
 import io.getstream.feeds.android.network.models.QueryActivityReactionsRequest
+import io.getstream.feeds.android.network.models.UpdateActivityPartialRequest
 import io.getstream.feeds.android.network.models.UpdateActivityRequest
 import io.getstream.feeds.android.network.models.UpsertActivitiesRequest
 
@@ -93,6 +94,13 @@ internal class ActivitiesRepositoryImpl(
         request: UpdateActivityRequest,
     ): Result<ActivityData> = runSafely {
         api.updateActivity(activityId, request).activity.toModel()
+    }
+
+    override suspend fun updateActivityPartial(
+        activityId: String,
+        request: UpdateActivityPartialRequest,
+    ): Result<ActivityData> = runSafely {
+        api.updateActivityPartial(activityId, request).activity.toModel()
     }
 
     override suspend fun upsertActivities(

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
@@ -59,6 +59,7 @@ import io.getstream.feeds.android.network.models.CreatePollRequest
 import io.getstream.feeds.android.network.models.FollowRequest
 import io.getstream.feeds.android.network.models.MarkActivityRequest
 import io.getstream.feeds.android.network.models.RejectFollowRequest
+import io.getstream.feeds.android.network.models.UpdateActivityPartialRequest
 import io.getstream.feeds.android.network.models.UpdateActivityRequest
 import io.getstream.feeds.android.network.models.UpdateBookmarkRequest
 import io.getstream.feeds.android.network.models.UpdateCommentRequest
@@ -188,6 +189,15 @@ internal class FeedImpl(
         request: UpdateActivityRequest,
     ): Result<ActivityData> {
         return activitiesRepository.updateActivity(id, request).onSuccess {
+            subscriptionManager.onEvent(StateUpdateEvent.ActivityUpdated(FidScope.unknown, it))
+        }
+    }
+
+    override suspend fun updateActivityPartial(
+        id: String,
+        request: UpdateActivityPartialRequest,
+    ): Result<ActivityData> {
+        return activitiesRepository.updateActivityPartial(id, request).onSuccess {
             subscriptionManager.onEvent(StateUpdateEvent.ActivityUpdated(FidScope.unknown, it))
         }
     }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImplTest.kt
@@ -49,6 +49,8 @@ import io.getstream.feeds.android.network.models.MarkActivityRequest
 import io.getstream.feeds.android.network.models.QueryActivitiesResponse
 import io.getstream.feeds.android.network.models.QueryActivityReactionsRequest
 import io.getstream.feeds.android.network.models.QueryActivityReactionsResponse
+import io.getstream.feeds.android.network.models.UpdateActivityPartialRequest
+import io.getstream.feeds.android.network.models.UpdateActivityPartialResponse
 import io.getstream.feeds.android.network.models.UpdateActivityRequest
 import io.getstream.feeds.android.network.models.UpdateActivityResponse
 import io.getstream.feeds.android.network.models.UpsertActivitiesRequest
@@ -177,6 +179,19 @@ internal class ActivitiesRepositoryImplTest {
         testDelegation(
             apiFunction = { feedsApi.updateActivity("id", request) },
             repositoryCall = { repository.updateActivity("id", request) },
+            apiResult = apiResult,
+            repositoryResult = apiResult.activity.toModel(),
+        )
+    }
+
+    @Test
+    fun `on updateActivityPartial, delegate to api`() {
+        val request = UpdateActivityPartialRequest(set = mapOf("text" to "Updated"))
+        val apiResult = UpdateActivityPartialResponse("duration", activityResponse())
+
+        testDelegation(
+            apiFunction = { feedsApi.updateActivityPartial("id", request) },
+            repositoryCall = { repository.updateActivityPartial("id", request) },
             apiResult = apiResult,
             repositoryResult = apiResult.activity.toModel(),
         )


### PR DESCRIPTION
### Goal

Expose the partial activity update API from the `Feed` class, allowing users to update specific fields of an activity without replacing the entire object.

### Implementation

- Add `updateActivityPartial` to `Feed` interface
- Add `updateActivityPartial` to `ActivitiesRepository` interface
- Implement the method in `FeedImpl` and `ActivitiesRepositoryImpl`
- The method follows the same pattern as `updateActivity`, emitting `StateUpdateEvent.ActivityUpdated` on success

### Testing

- Added unit tests for `FeedImpl.updateActivityPartial`
- Added unit tests for `ActivitiesRepositoryImpl.updateActivityPartial`

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added partial activity update capability, allowing selective updates to specific fields without replacing entire activities. This enables more efficient modifications for targeted changes.

* **Tests**
  * Added comprehensive test coverage for partial updates across all layers, including state event handling and repository delegation verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->