### PR TITLE
Bump AGP to version 8.10.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ compileSdk = "36"
 targetSdk = "36"
 minSdk = "21"
 
-agp = "8.9.3"
+agp = "8.10.1"
 firebaseBom = "33.16.0"
 hilt = "2.57"
 hiltNavigationCompose = "1.2.0"


### PR DESCRIPTION
### Goal

Bump AGP, addressing this warning:

> WARNING: D8: An error occurred when parsing kotlin metadata. This normally happens when using a newer version of kotlin than the kotlin version released when this version of R8 was created. To find compatible kotlin versions, please see: https://developer.android.com/studio/build/kotlin-d8-r8-versions

### Implementation

Bump version

### Testing

Everything should build as before

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tooling to a newer stable version for enhanced compatibility and build stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->