### PR TITLE
Propagate deleteNotificationActivity to client delete methods

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/Activity.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/Activity.kt
@@ -123,9 +123,14 @@ public interface Activity {
      * @param commentId The unique identifier of the comment to be deleted.
      * @param hardDelete If true, the comment will be permanently deleted. Otherwise, it will be
      *   soft-deleted.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] indicating success or failure of the deletion operation.
      */
-    public suspend fun deleteComment(commentId: String, hardDelete: Boolean? = null): Result<Unit>
+    public suspend fun deleteComment(
+        commentId: String,
+        hardDelete: Boolean? = null,
+        deleteNotificationActivity: Boolean? = null,
+    ): Result<Unit>
 
     /**
      * Updates an existing comment in the activity.
@@ -158,12 +163,14 @@ public interface Activity {
      *
      * @param commentId The unique identifier of the comment from which the reaction is removed.
      * @param type The type of the reaction to be removed.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] containing the updated [FeedsReactionData] if successful, or an error if
      *   the operation fails.
      */
     public suspend fun deleteCommentReaction(
         commentId: String,
         type: String,
+        deleteNotificationActivity: Boolean? = null,
     ): Result<FeedsReactionData>
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/Feed.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/Feed.kt
@@ -157,9 +157,14 @@ public interface Feed {
      * @param id The unique identifier of the activity to delete.
      * @param hardDelete If `true`, the activity will be permanently deleted. If `false`, it will be
      *   soft deleted. (default is `false`)
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] indicating success or failure of the deletion operation.
      */
-    public suspend fun deleteActivity(id: String, hardDelete: Boolean = false): Result<Unit>
+    public suspend fun deleteActivity(
+        id: String,
+        hardDelete: Boolean = false,
+        deleteNotificationActivity: Boolean? = null,
+    ): Result<Unit>
 
     /**
      * Marks an activity as read or unread.
@@ -289,9 +294,14 @@ public interface Feed {
      * @param commentId The unique identifier of the comment to remove.
      * @param hardDelete If `true`, the comment will be permanently deleted. Otherwise, it will be
      *   soft-deleted.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] indicating success or failure of the deletion operation.
      */
-    public suspend fun deleteComment(commentId: String, hardDelete: Boolean? = null): Result<Unit>
+    public suspend fun deleteComment(
+        commentId: String,
+        hardDelete: Boolean? = null,
+        deleteNotificationActivity: Boolean? = null,
+    ): Result<Unit>
 
     /**
      * Queries for feed suggestions that the current user might want to follow.
@@ -322,9 +332,13 @@ public interface Feed {
      * Unfollows another feed.
      *
      * @param targetFid The target feed identifier to unfollow.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] indicating success or failure of the unfollow operation.
      */
-    public suspend fun unfollow(targetFid: FeedId): Result<Unit>
+    public suspend fun unfollow(
+        targetFid: FeedId,
+        deleteNotificationActivity: Boolean? = null,
+    ): Result<Unit>
 
     /**
      * Accepts a follow request from another feed.
@@ -415,12 +429,14 @@ public interface Feed {
      *
      * @param activityId The unique identifier of the activity from which to delete the reaction.
      * @param type The type of reaction to delete.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] containing the deleted [FeedsReactionData] if successful, or an error if
      *   the operation fails.
      */
     public suspend fun deleteActivityReaction(
         activityId: String,
         type: String,
+        deleteNotificationActivity: Boolean? = null,
     ): Result<FeedsReactionData>
 
     /**
@@ -441,12 +457,14 @@ public interface Feed {
      *
      * @param commentId The unique identifier of the comment from which to delete the reaction.
      * @param type The type of reaction to delete.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] containing the deleted [FeedsReactionData] if successful, or an error if
      *   the operation fails.
      */
     public suspend fun deleteCommentReaction(
         commentId: String,
         type: String,
+        deleteNotificationActivity: Boolean? = null,
     ): Result<FeedsReactionData>
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepository.kt
@@ -65,9 +65,14 @@ internal interface ActivitiesRepository {
      * @param activityId The ID of the activity to be deleted.
      * @param hardDelete If true, the activity will be permanently deleted; otherwise, it will be
      *   soft-deleted.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] indicating success or failure.
      */
-    suspend fun deleteActivity(activityId: String, hardDelete: Boolean): Result<Unit>
+    suspend fun deleteActivity(
+        activityId: String,
+        hardDelete: Boolean,
+        deleteNotificationActivity: Boolean?,
+    ): Result<Unit>
 
     /**
      * Deletes multiple activities based on the provided request.
@@ -176,11 +181,13 @@ internal interface ActivitiesRepository {
      *
      * @param activityId The ID of the activity from which to delete the reaction.
      * @param type The type of the reaction to delete.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] containing the deleted [FeedsReactionData] or an error.
      */
     suspend fun deleteActivityReaction(
         activityId: String,
         type: String,
+        deleteNotificationActivity: Boolean?,
     ): Result<Pair<FeedsReactionData, ActivityData>>
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImpl.kt
@@ -76,10 +76,17 @@ internal class ActivitiesRepositoryImpl(
         api.addActivity(newActivityRequest).activity.toModel()
     }
 
-    override suspend fun deleteActivity(activityId: String, hardDelete: Boolean): Result<Unit> =
-        runSafely {
-            api.deleteActivity(activityId, hardDelete)
-        }
+    override suspend fun deleteActivity(
+        activityId: String,
+        hardDelete: Boolean,
+        deleteNotificationActivity: Boolean?,
+    ): Result<Unit> = runSafely {
+        api.deleteActivity(
+            id = activityId,
+            hardDelete = hardDelete,
+            deleteNotificationActivity = deleteNotificationActivity,
+        )
+    }
 
     override suspend fun deleteActivities(
         request: DeleteActivitiesRequest
@@ -152,8 +159,14 @@ internal class ActivitiesRepositoryImpl(
     override suspend fun deleteActivityReaction(
         activityId: String,
         type: String,
+        deleteNotificationActivity: Boolean?,
     ): Result<Pair<FeedsReactionData, ActivityData>> = runSafely {
-        val response = api.deleteActivityReaction(activityId = activityId, type = type)
+        val response =
+            api.deleteActivityReaction(
+                activityId = activityId,
+                type = type,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
         response.reaction.toModel() to response.activity.toModel()
     }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepository.kt
@@ -89,11 +89,13 @@ internal interface CommentsRepository {
      * @param commentId The unique identifier of the comment to be deleted.
      * @param hardDelete If true, the comment will be permanently deleted. Otherwise, it will be
      *   soft-deleted.
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] indicating success or failure of the deletion operation.
      */
     suspend fun deleteComment(
         commentId: String,
         hardDelete: Boolean?,
+        deleteNotificationActivity: Boolean?,
     ): Result<Pair<CommentData, ActivityData>>
 
     /**
@@ -133,11 +135,13 @@ internal interface CommentsRepository {
      *
      * @param commentId The unique identifier of the comment from which the reaction is deleted.
      * @param type The type of the reaction to be deleted (e.g., "like", "love", etc.).
+     * @param deleteNotificationActivity If `true`, removes the corresponding notification activity.
      * @return A [Result] indicating success or failure of the deletion operation.
      */
     suspend fun deleteCommentReaction(
         commentId: String,
         type: String,
+        deleteNotificationActivity: Boolean?,
     ): Result<Pair<FeedsReactionData, CommentData>>
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImpl.kt
@@ -127,8 +127,9 @@ internal class CommentsRepositoryImpl(
     override suspend fun deleteComment(
         commentId: String,
         hardDelete: Boolean?,
+        deleteNotificationActivity: Boolean?,
     ): Result<Pair<CommentData, ActivityData>> = runSafely {
-        val response = api.deleteComment(commentId, hardDelete)
+        val response = api.deleteComment(commentId, hardDelete, deleteNotificationActivity)
         response.comment.toModel() to response.activity.toModel()
     }
 
@@ -152,8 +153,14 @@ internal class CommentsRepositoryImpl(
     override suspend fun deleteCommentReaction(
         commentId: String,
         type: String,
+        deleteNotificationActivity: Boolean?,
     ): Result<Pair<FeedsReactionData, CommentData>> = runSafely {
-        val response = api.deleteCommentReaction(id = commentId, type = type)
+        val response =
+            api.deleteCommentReaction(
+                id = commentId,
+                type = type,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
         Pair(response.reaction.toModel(), response.comment.toModel())
     }
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepository.kt
@@ -84,7 +84,11 @@ internal interface FeedsRepository {
 
     suspend fun follow(request: FollowRequest): Result<FollowData>
 
-    suspend fun unfollow(source: FeedId, target: FeedId): Result<FollowData>
+    suspend fun unfollow(
+        source: FeedId,
+        target: FeedId,
+        deleteNotificationActivity: Boolean?,
+    ): Result<FollowData>
 
     suspend fun getOrCreateFollows(request: FollowBatchRequest): Result<BatchFollowData>
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImpl.kt
@@ -135,8 +135,18 @@ internal class FeedsRepositoryImpl(private val api: FeedsApi) : FeedsRepository 
         api.follow(request).follow.toModel()
     }
 
-    override suspend fun unfollow(source: FeedId, target: FeedId): Result<FollowData> = runSafely {
-        api.unfollow(source = source.rawValue, target = target.rawValue).follow.toModel()
+    override suspend fun unfollow(
+        source: FeedId,
+        target: FeedId,
+        deleteNotificationActivity: Boolean?,
+    ): Result<FollowData> = runSafely {
+        api.unfollow(
+                source = source.rawValue,
+                target = target.rawValue,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
+            .follow
+            .toModel()
     }
 
     override suspend fun getOrCreateFollows(request: FollowBatchRequest): Result<BatchFollowData> =

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImpl.kt
@@ -142,9 +142,17 @@ internal class ActivityImpl(
         }
     }
 
-    override suspend fun deleteComment(commentId: String, hardDelete: Boolean?): Result<Unit> {
+    override suspend fun deleteComment(
+        commentId: String,
+        hardDelete: Boolean?,
+        deleteNotificationActivity: Boolean?,
+    ): Result<Unit> {
         return commentsRepository
-            .deleteComment(commentId, hardDelete)
+            .deleteComment(
+                commentId = commentId,
+                hardDelete = hardDelete,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
             .onSuccess { (comment, activity) ->
                 subscriptionManager.onEvent(
                     StateUpdateEvent.CommentDeleted(FidScope.unknown, comment)
@@ -187,9 +195,10 @@ internal class ActivityImpl(
     override suspend fun deleteCommentReaction(
         commentId: String,
         type: String,
+        deleteNotificationActivity: Boolean?,
     ): Result<FeedsReactionData> {
         return commentsRepository
-            .deleteCommentReaction(commentId, type)
+            .deleteCommentReaction(commentId, type, deleteNotificationActivity)
             .onSuccess { (reaction, comment) ->
                 subscriptionManager.onEvent(
                     StateUpdateEvent.CommentReactionDeleted(FidScope.unknown, comment, reaction)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
@@ -202,10 +202,20 @@ internal class FeedImpl(
         }
     }
 
-    override suspend fun deleteActivity(id: String, hardDelete: Boolean): Result<Unit> {
-        return activitiesRepository.deleteActivity(id, hardDelete).onSuccess {
-            subscriptionManager.onEvent(StateUpdateEvent.ActivityDeleted(FidScope.unknown, id))
-        }
+    override suspend fun deleteActivity(
+        id: String,
+        hardDelete: Boolean,
+        deleteNotificationActivity: Boolean?,
+    ): Result<Unit> {
+        return activitiesRepository
+            .deleteActivity(
+                activityId = id,
+                hardDelete = hardDelete,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
+            .onSuccess {
+                subscriptionManager.onEvent(StateUpdateEvent.ActivityDeleted(FidScope.unknown, id))
+            }
     }
 
     override suspend fun markActivity(request: MarkActivityRequest): Result<Unit> {
@@ -314,9 +324,17 @@ internal class FeedImpl(
         }
     }
 
-    override suspend fun deleteComment(commentId: String, hardDelete: Boolean?): Result<Unit> {
+    override suspend fun deleteComment(
+        commentId: String,
+        hardDelete: Boolean?,
+        deleteNotificationActivity: Boolean?,
+    ): Result<Unit> {
         return commentsRepository
-            .deleteComment(commentId, hardDelete)
+            .deleteComment(
+                commentId = commentId,
+                hardDelete = hardDelete,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
             .onSuccess { (comment, activity) ->
                 subscriptionManager.onEvent(
                     StateUpdateEvent.CommentDeleted(FidScope.unknown, comment)
@@ -351,9 +369,16 @@ internal class FeedImpl(
         }
     }
 
-    override suspend fun unfollow(targetFid: FeedId): Result<Unit> {
+    override suspend fun unfollow(
+        targetFid: FeedId,
+        deleteNotificationActivity: Boolean?,
+    ): Result<Unit> {
         return feedsRepository
-            .unfollow(source = fid, target = targetFid)
+            .unfollow(
+                source = fid,
+                target = targetFid,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
             .onSuccess { subscriptionManager.onEvent(StateUpdateEvent.FollowDeleted(it)) }
             .map {}
     }
@@ -431,9 +456,14 @@ internal class FeedImpl(
     override suspend fun deleteActivityReaction(
         activityId: String,
         type: String,
+        deleteNotificationActivity: Boolean?,
     ): Result<FeedsReactionData> {
         return activitiesRepository
-            .deleteActivityReaction(activityId = activityId, type = type)
+            .deleteActivityReaction(
+                activityId = activityId,
+                type = type,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
             .onSuccess { (reaction, activity) ->
                 subscriptionManager.onEvent(
                     StateUpdateEvent.ActivityReactionDeleted(FidScope.unknown, activity, reaction)
@@ -464,9 +494,14 @@ internal class FeedImpl(
     override suspend fun deleteCommentReaction(
         commentId: String,
         type: String,
+        deleteNotificationActivity: Boolean?,
     ): Result<FeedsReactionData> {
         return commentsRepository
-            .deleteCommentReaction(commentId = commentId, type = type)
+            .deleteCommentReaction(
+                commentId = commentId,
+                type = type,
+                deleteNotificationActivity = deleteNotificationActivity,
+            )
             .onSuccess { (reaction, comment) ->
                 subscriptionManager.onEvent(
                     StateUpdateEvent.CommentReactionDeleted(FidScope.unknown, comment, reaction)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImplTest.kt
@@ -141,8 +141,8 @@ internal class ActivitiesRepositoryImplTest {
     @Test
     fun `on deleteActivity, delegate to api`() {
         testDelegation(
-            apiFunction = { feedsApi.deleteActivity("id", true) },
-            repositoryCall = { repository.deleteActivity("id", true) },
+            apiFunction = { feedsApi.deleteActivity("id", true, true) },
+            repositoryCall = { repository.deleteActivity("id", true, true) },
             apiResult = DeleteActivityResponse("duration"),
             repositoryResult = Unit,
         )
@@ -271,8 +271,8 @@ internal class ActivitiesRepositoryImplTest {
             DeleteActivityReactionResponse("duration", activityResponse(), feedsReactionResponse())
 
         testDelegation(
-            apiFunction = { feedsApi.deleteActivityReaction("activityId", "type") },
-            repositoryCall = { repository.deleteActivityReaction("activityId", "type") },
+            apiFunction = { feedsApi.deleteActivityReaction("activityId", "type", true) },
+            repositoryCall = { repository.deleteActivityReaction("activityId", "type", true) },
             apiResult = apiResult,
             repositoryResult = apiResult.reaction.toModel() to apiResult.activity.toModel(),
         )

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/CommentsRepositoryImplTest.kt
@@ -290,8 +290,8 @@ internal class CommentsRepositoryImplTest {
     fun `on deleteComment, delegate to api`() {
         val apiResult = deleteCommentResponse()
         testDelegation(
-            apiFunction = { feedsApi.deleteComment("commentId", true) },
-            repositoryCall = { repository.deleteComment("commentId", true) },
+            apiFunction = { feedsApi.deleteComment("commentId", true, true) },
+            repositoryCall = { repository.deleteComment("commentId", true, true) },
             apiResult = apiResult,
             repositoryResult = apiResult.comment.toModel() to apiResult.activity.toModel(),
         )
@@ -352,8 +352,8 @@ internal class CommentsRepositoryImplTest {
             )
 
         testDelegation(
-            apiFunction = { feedsApi.deleteCommentReaction("commentId", "like") },
-            repositoryCall = { repository.deleteCommentReaction("commentId", "like") },
+            apiFunction = { feedsApi.deleteCommentReaction("commentId", "like", true) },
+            repositoryCall = { repository.deleteCommentReaction("commentId", "like", true) },
             apiResult = apiResult,
             repositoryResult = Pair(apiResult.reaction.toModel(), apiResult.comment.toModel()),
         )

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImplTest.kt
@@ -202,8 +202,8 @@ internal class FeedsRepositoryImplTest {
         val unfollowResponse = UnfollowResponse(duration = "duration", follow = followResponseData)
 
         testDelegation(
-            apiFunction = { feedsApi.unfollow("user:user-1", "user:user-2") },
-            repositoryCall = { repository.unfollow(source, target) },
+            apiFunction = { feedsApi.unfollow("user:user-1", "user:user-2", true) },
+            repositoryCall = { repository.unfollow(source, target, true) },
             apiResult = unfollowResponse,
             repositoryResult = unfollowResponse.follow.toModel(),
         )

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityImplTest.kt
@@ -174,7 +174,7 @@ internal class ActivityImplTest {
         val hardDelete = true
         val expectedActivity = activityData(id = "activityId", text = "Updated activity")
         val deleteData = commentData(commentId) to expectedActivity
-        coEvery { commentsRepository.deleteComment(commentId, hardDelete) } returns
+        coEvery { commentsRepository.deleteComment(commentId, hardDelete, any()) } returns
             Result.success(deleteData)
 
         val result = activity.deleteComment(commentId, hardDelete)
@@ -231,7 +231,7 @@ internal class ActivityImplTest {
         val type = "like"
         val reactionData = feedsReactionData(type = type)
         val commentData = commentData(commentId)
-        coEvery { commentsRepository.deleteCommentReaction(commentId, type) } returns
+        coEvery { commentsRepository.deleteCommentReaction(commentId, type, any()) } returns
             Result.success(Pair(reactionData, commentData))
 
         val result = activity.deleteCommentReaction(commentId, type)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
@@ -271,7 +271,7 @@ internal class FeedImplTest {
         // Set up initial state with activity
         setupInitialState(feed, activities = listOf(activity))
 
-        coEvery { activitiesRepository.deleteActivity(activityId, hardDelete) } returns
+        coEvery { activitiesRepository.deleteActivity(activityId, hardDelete, null) } returns
             Result.success(Unit)
 
         val result = feed.deleteActivity(activityId, hardDelete)
@@ -374,7 +374,7 @@ internal class FeedImplTest {
         // Set up initial state with follow
         setupInitialState(feed, following = listOf(follow))
 
-        coEvery { feedsRepository.unfollow(any(), any()) } returns Result.success(follow)
+        coEvery { feedsRepository.unfollow(any(), any(), any()) } returns Result.success(follow)
 
         val result = feed.unfollow(targetFid)
 
@@ -537,7 +537,7 @@ internal class FeedImplTest {
         // Set up initial state with the original activity
         setupInitialState(feed, activities = listOf(originalActivity))
 
-        coEvery { commentsRepository.deleteComment(commentId, hardDelete) } returns
+        coEvery { commentsRepository.deleteComment(commentId, hardDelete, any()) } returns
             Result.success(deleteData)
 
         val result = feed.deleteComment(commentId, hardDelete)
@@ -713,7 +713,7 @@ internal class FeedImplTest {
         setupInitialState(feed, activities = listOf(activityWithReaction))
 
         val updatedActivity = activityData(activityId, text = "Updated activity")
-        coEvery { activitiesRepository.deleteActivityReaction(activityId, type) } returns
+        coEvery { activitiesRepository.deleteActivityReaction(activityId, type, any()) } returns
             Result.success(reaction to updatedActivity)
 
         val result = feed.deleteActivityReaction(activityId, type)
@@ -761,7 +761,7 @@ internal class FeedImplTest {
         val reaction = feedsReactionData()
         val comment = commentData(commentId)
 
-        coEvery { commentsRepository.deleteCommentReaction(commentId, type) } returns
+        coEvery { commentsRepository.deleteCommentReaction(commentId, type, any()) } returns
             Result.success(Pair(reaction, comment))
 
         val result = feed.deleteCommentReaction(commentId, type)


### PR DESCRIPTION
### Goal

Some API methods allow passing a `deleteNotificationActivity` param to tell the backend to delete the notification activity related to the request. In this PR we allow passing that param from the relevant functions.

### Implementation

Add `deleteNotificationActivity` to several function and forward it to the API methods

### Testing

Unit tests verify that `deleteNotificationActivity` is correctly forwarded through each layer (state → repository → API) for all affected methods.

To test manually in the sample app:                                                                                                                                                                                                                                               
  1. Take an action that generates a notification activity, e.g. react to an activity or add a comment                                                                                                                                                                              
  2. Update the sample code to pass `deleteNotificationActivity = true` (e.g. in `FeedViewModel.onReactionClick` or `CommentsSheetViewModel.delete`)                                                                                                                                
  3. Undo the action (tap the reaction again or long-press delete the comment)                                                                                                                                                                                                      
  4. Verify the corresponding notification activity is removed from the notification feed


### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Delete operations for activities, comments, and reactions now support an optional parameter to control whether associated notifications are automatically removed.
  * Unfollow operations now include an optional parameter to manage notification removal behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->