### PR TITLE
Expose missing parameters and getOg operation

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/FeedsClient.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/FeedsClient.kt
@@ -72,6 +72,7 @@ import io.getstream.feeds.android.network.models.CreateCollectionsRequest
 import io.getstream.feeds.android.network.models.DeleteActivitiesRequest
 import io.getstream.feeds.android.network.models.DeleteActivitiesResponse
 import io.getstream.feeds.android.network.models.FollowBatchRequest
+import io.getstream.feeds.android.network.models.GetOGResponse
 import io.getstream.feeds.android.network.models.ListDevicesResponse
 import io.getstream.feeds.android.network.models.UnfollowBatchRequest
 import io.getstream.feeds.android.network.models.UpdateCollectionsRequest
@@ -445,6 +446,21 @@ public interface FeedsClient {
      * @return A [Result] containing the [AppData] if successful, or an error if the request fails.
      */
     public suspend fun getApp(): Result<AppData>
+
+    /**
+     * Fetches Open Graph metadata for a URL.
+     *
+     * This is useful for showing URL enrichment to users before an activity or comment is sent. You
+     * can then persist the OG data in `attachments` when sending the activity or comment (set
+     * `skipEnrichUrl` to avoid duplicate previews).
+     *
+     * @param url The URL to fetch OG metadata for.
+     * @return A [Result] containing the [GetOGResponse] if successful, or an error if the request
+     *   fails. Use
+     *   [GetOGResponse.toAttachment][io.getstream.feeds.android.client.api.model.toAttachment] to
+     *   convert the response to an [io.getstream.feeds.android.network.models.Attachment].
+     */
+    public suspend fun getOG(url: String): Result<GetOGResponse>
 
     /**
      * Read collections, filtering by collection references. By default, users can only read their

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/Attachment.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/Attachment.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.feeds.android.client.api.model
+
+import io.getstream.feeds.android.network.models.Attachment
+import io.getstream.feeds.android.network.models.GetOGResponse
+
+/** Converts a [GetOGResponse] to an [Attachment]. */
+public fun GetOGResponse.toAttachment(): Attachment =
+    Attachment(
+        assetUrl = assetUrl,
+        authorIcon = authorIcon,
+        authorLink = authorLink,
+        authorName = authorName,
+        color = color,
+        fallback = fallback,
+        footer = footer,
+        footerIcon = footerIcon,
+        imageUrl = imageUrl,
+        ogScrapeUrl = ogScrapeUrl,
+        originalHeight = originalHeight,
+        originalWidth = originalWidth,
+        pretext = pretext,
+        text = text,
+        thumbUrl = thumbUrl,
+        title = title,
+        titleLink = titleLink,
+        type = type,
+        actions = actions,
+        fields = fields,
+        giphy = giphy,
+    )

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/FeedAddActivityRequest.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/FeedAddActivityRequest.kt
@@ -32,6 +32,7 @@ internal constructor(
         attachments: List<Attachment>? = null,
         attachmentUploads: List<FeedUploadPayload>? = null,
         collectionRefs: List<String>? = null,
+        createNotificationActivity: Boolean? = null,
         custom: Map<String, Any>? = null,
         expiresAt: String? = null,
         filterTags: List<String>? = null,
@@ -52,6 +53,7 @@ internal constructor(
             AddActivityRequest(
                 attachments = attachments,
                 collectionRefs = collectionRefs,
+                createNotificationActivity = createNotificationActivity,
                 custom = custom,
                 expiresAt = expiresAt,
                 filterTags = filterTags,

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest.kt
@@ -32,11 +32,14 @@ internal constructor(
      * Creates a request to add a comment to an activity.
      *
      * @param comment The content of the comment to be added.
+     * @param activityId The ID of the activity to comment on.
      * @param attachments Optional list of attachments to include with the comment.
      * @param createNotificationActivity Optional flag to create a notification activity.
      * @param custom Optional custom data to include with the comment.
+     * @param id Optional custom ID for the comment. Must be unique. Auto-generated if not provided.
      * @param mentionedUserIds Optional list of user IDs to mention in the comment.
      * @param parentId Optional ID of the parent comment if this is a reply.
+     * @param skipEnrichUrl Optional flag to skip URL enrichment for the comment.
      */
     public constructor(
         comment: String,
@@ -44,8 +47,10 @@ internal constructor(
         attachments: List<Attachment>? = emptyList(),
         createNotificationActivity: Boolean? = null,
         custom: Map<String, Any?>? = emptyMap(),
+        id: String? = null,
         mentionedUserIds: List<String>? = emptyList(),
         parentId: String? = null,
+        skipEnrichUrl: Boolean? = null,
         attachmentUploads: List<FeedUploadPayload> = emptyList(),
     ) : this(
         AddCommentRequest(
@@ -53,10 +58,12 @@ internal constructor(
             attachments = attachments,
             createNotificationActivity = createNotificationActivity,
             custom = custom,
+            id = id,
             mentionedUserIds = mentionedUserIds,
             objectId = activityId,
             objectType = "activity",
             parentId = parentId,
+            skipEnrichUrl = skipEnrichUrl,
         ),
         attachmentUploads = attachmentUploads,
     )

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/Create.kt
@@ -53,10 +53,10 @@ import io.getstream.feeds.android.client.internal.http.createHttpConfig
 import io.getstream.feeds.android.client.internal.http.createRetrofit
 import io.getstream.feeds.android.client.internal.logging.createLoggerProvider
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepositoryImpl
-import io.getstream.feeds.android.client.internal.repository.AppRepositoryImpl
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepositoryImpl
 import io.getstream.feeds.android.client.internal.repository.CollectionsRepositoryImpl
 import io.getstream.feeds.android.client.internal.repository.CommentsRepositoryImpl
+import io.getstream.feeds.android.client.internal.repository.CommonRepositoryImpl
 import io.getstream.feeds.android.client.internal.repository.DevicesRepositoryImpl
 import io.getstream.feeds.android.client.internal.repository.FeedOwnValuesRepositoryImpl
 import io.getstream.feeds.android.client.internal.repository.FeedsRepositoryImpl
@@ -226,7 +226,7 @@ internal fun createFeedsClient(
         )
 
     val activitiesRepository = ActivitiesRepositoryImpl(feedsApi, uploader)
-    val appRepository = AppRepositoryImpl(feedsApi)
+    val commonRepository = CommonRepositoryImpl(feedsApi)
     val bookmarksRepository = BookmarksRepositoryImpl(feedsApi)
     val commentsRepository = CommentsRepositoryImpl(feedsApi, uploader)
     val devicesRepository = DevicesRepositoryImpl(feedsApi)
@@ -261,7 +261,7 @@ internal fun createFeedsClient(
         apiKey = apiKey,
         user = user,
         activitiesRepository = activitiesRepository,
-        appRepository = appRepository,
+        commonRepository = commonRepository,
         bookmarksRepository = bookmarksRepository,
         commentsRepository = commentsRepository,
         devicesRepository = devicesRepository,

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -66,10 +66,10 @@ import io.getstream.feeds.android.client.api.state.query.PollVotesQuery
 import io.getstream.feeds.android.client.api.state.query.PollsQuery
 import io.getstream.feeds.android.client.internal.client.reconnect.FeedWatchHandler
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
-import io.getstream.feeds.android.client.internal.repository.AppRepository
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepository
 import io.getstream.feeds.android.client.internal.repository.CollectionsRepository
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
+import io.getstream.feeds.android.client.internal.repository.CommonRepository
 import io.getstream.feeds.android.client.internal.repository.DevicesRepository
 import io.getstream.feeds.android.client.internal.repository.FeedOwnValuesRepository
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
@@ -123,7 +123,7 @@ internal class FeedsClientImpl(
     override val apiKey: StreamApiKey,
     override val user: User,
     private val activitiesRepository: ActivitiesRepository,
-    private val appRepository: AppRepository,
+    private val commonRepository: CommonRepository,
     private val bookmarksRepository: BookmarksRepository,
     private val commentsRepository: CommentsRepository,
     private val devicesRepository: DevicesRepository,
@@ -141,7 +141,7 @@ internal class FeedsClientImpl(
     errorBus: Flow<StreamClientException>,
 ) :
     FeedsClient,
-    AppRepository by appRepository,
+    CommonRepository by commonRepository,
     CollectionsRepository by collectionsRepository,
     DevicesRepository by devicesRepository,
     FilesRepository by filesRepository {

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommonRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommonRepository.kt
@@ -17,14 +17,13 @@
 package io.getstream.feeds.android.client.internal.repository
 
 import io.getstream.feeds.android.client.api.model.AppData
+import io.getstream.feeds.android.network.models.GetOGResponse
 
 /**
- * An interface for a repository that provides application configuration data.
- *
- * This repository is responsible for fetching the application configuration data, which includes
- * settings like URL enrichment, translation, and file upload configurations.
+ * A repository for common operations that are not specific to a single domain (feeds, comments,
+ * polls, etc.). This includes app configuration, Open Graph metadata, and user queries.
  */
-internal interface AppRepository {
+internal interface CommonRepository {
 
     /**
      * Fetches the application configuration data.
@@ -32,4 +31,13 @@ internal interface AppRepository {
      * @return A [Result] containing the [AppData] if successful, or an error if the request fails.
      */
     suspend fun getApp(): Result<AppData>
+
+    /**
+     * Fetches Open Graph metadata for a URL.
+     *
+     * @param url The URL to fetch OG metadata for.
+     * @return A [Result] containing the [GetOGResponse] if successful, or an error if the request
+     *   fails.
+     */
+    suspend fun getOG(url: String): Result<GetOGResponse>
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommonRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/CommonRepositoryImpl.kt
@@ -20,14 +20,14 @@ import io.getstream.android.core.result.runSafely
 import io.getstream.feeds.android.client.api.model.AppData
 import io.getstream.feeds.android.client.internal.model.toModel
 import io.getstream.feeds.android.network.apis.FeedsApi
+import io.getstream.feeds.android.network.models.GetOGResponse
 
 /**
- * Default implementation of the [AppRepository]. Uses the [FeedsApi] to fetch application
- * configuration data. Caches the result to avoid multiple network calls for the same data.
+ * Default implementation of [CommonRepository].
  *
- * @property api The API service used to fetch application data.
+ * @property api The API service used to execute requests.
  */
-internal class AppRepositoryImpl(private val api: FeedsApi) : AppRepository {
+internal class CommonRepositoryImpl(private val api: FeedsApi) : CommonRepository {
 
     private var cachedAppData: AppData? = null
 
@@ -37,4 +37,6 @@ internal class AppRepositoryImpl(private val api: FeedsApi) : AppRepository {
         }
         api.getApp().app.toModel().also { cachedAppData = it }
     }
+
+    override suspend fun getOG(url: String): Result<GetOGResponse> = runSafely { api.getOG(url) }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/api/model/AttachmentTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/api/model/AttachmentTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-feeds-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.feeds.android.client.api.model
+
+import io.getstream.feeds.android.network.models.Action
+import io.getstream.feeds.android.network.models.Attachment
+import io.getstream.feeds.android.network.models.Field
+import io.getstream.feeds.android.network.models.GetOGResponse
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class AttachmentTest {
+
+    @Test
+    fun `toAttachment maps all fields correctly`() {
+        // Given
+        val actions = listOf(Action(name = "action1", text = "Action 1", type = "button"))
+        val fields = listOf(Field(short = true, title = "Field 1", value = "Value 1"))
+        val response =
+            GetOGResponse(
+                duration = "100ms",
+                assetUrl = "https://example.com/asset.mp4",
+                authorIcon = "https://example.com/icon.png",
+                authorLink = "https://example.com/author",
+                authorName = "Author",
+                color = "#FF0000",
+                fallback = "Fallback text",
+                footer = "Footer text",
+                footerIcon = "https://example.com/footer-icon.png",
+                imageUrl = "https://example.com/image.png",
+                ogScrapeUrl = "https://example.com",
+                originalHeight = 600,
+                originalWidth = 800,
+                pretext = "Pretext",
+                text = "Description text",
+                thumbUrl = "https://example.com/thumb.png",
+                title = "Page Title",
+                titleLink = "https://example.com/page",
+                type = "article",
+                actions = actions,
+                fields = fields,
+            )
+
+        // When
+        val attachment = response.toAttachment()
+
+        // Then
+        val expected =
+            Attachment(
+                assetUrl = "https://example.com/asset.mp4",
+                authorIcon = "https://example.com/icon.png",
+                authorLink = "https://example.com/author",
+                authorName = "Author",
+                color = "#FF0000",
+                fallback = "Fallback text",
+                footer = "Footer text",
+                footerIcon = "https://example.com/footer-icon.png",
+                imageUrl = "https://example.com/image.png",
+                ogScrapeUrl = "https://example.com",
+                originalHeight = 600,
+                originalWidth = 800,
+                pretext = "Pretext",
+                text = "Description text",
+                thumbUrl = "https://example.com/thumb.png",
+                title = "Page Title",
+                titleLink = "https://example.com/page",
+                type = "article",
+                actions = actions,
+                fields = fields,
+            )
+        assertEquals(expected, attachment)
+    }
+}

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImplTest.kt
@@ -44,10 +44,10 @@ import io.getstream.feeds.android.client.api.state.query.PollVotesQuery
 import io.getstream.feeds.android.client.api.state.query.PollsQuery
 import io.getstream.feeds.android.client.internal.client.reconnect.FeedWatchHandler
 import io.getstream.feeds.android.client.internal.repository.ActivitiesRepository
-import io.getstream.feeds.android.client.internal.repository.AppRepository
 import io.getstream.feeds.android.client.internal.repository.BookmarksRepository
 import io.getstream.feeds.android.client.internal.repository.CollectionsRepository
 import io.getstream.feeds.android.client.internal.repository.CommentsRepository
+import io.getstream.feeds.android.client.internal.repository.CommonRepository
 import io.getstream.feeds.android.client.internal.repository.DevicesRepository
 import io.getstream.feeds.android.client.internal.repository.FeedOwnValuesRepository
 import io.getstream.feeds.android.client.internal.repository.FeedsRepository
@@ -88,7 +88,7 @@ internal class FeedsClientImplTest {
     private val apiKey: StreamApiKey = StreamApiKey.fromString("test-api-key")
     private val user: User = User(id = "test-user")
     private val activitiesRepository: ActivitiesRepository = mockk(relaxed = true)
-    private val appRepository: AppRepository = mockk(relaxed = true)
+    private val commonRepository: CommonRepository = mockk(relaxed = true)
     private val bookmarksRepository: BookmarksRepository = mockk(relaxed = true)
     private val commentsRepository: CommentsRepository = mockk(relaxed = true)
     private val devicesRepository: DevicesRepository = mockk(relaxed = true)
@@ -117,7 +117,7 @@ internal class FeedsClientImplTest {
             apiKey = apiKey,
             user = user,
             activitiesRepository = activitiesRepository,
-            appRepository = appRepository,
+            commonRepository = commonRepository,
             bookmarksRepository = bookmarksRepository,
             commentsRepository = commentsRepository,
             devicesRepository = devicesRepository,

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/CommonRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/CommonRepositoryImplTest.kt
@@ -16,11 +16,13 @@
 
 package io.getstream.feeds.android.client.internal.repository
 
+import io.getstream.feeds.android.client.internal.repository.RepositoryTestUtils.testDelegation
 import io.getstream.feeds.android.client.internal.test.TestData.appData
 import io.getstream.feeds.android.network.apis.FeedsApi
 import io.getstream.feeds.android.network.models.AppResponseFields
 import io.getstream.feeds.android.network.models.FileUploadConfig
 import io.getstream.feeds.android.network.models.GetApplicationResponse
+import io.getstream.feeds.android.network.models.GetOGResponse
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -28,9 +30,9 @@ import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
-internal class AppRepositoryImplTest {
+internal class CommonRepositoryImplTest {
     private val api: FeedsApi = mockk(relaxed = true)
-    private val repository: AppRepositoryImpl = AppRepositoryImpl(api)
+    private val repository: CommonRepositoryImpl = CommonRepositoryImpl(api)
 
     @Test
     fun `getApp when called multiple times, fetch from api once and cache result`() = runTest {
@@ -66,5 +68,18 @@ internal class AppRepositoryImplTest {
 
         // Verify API was called exactly once (not three times)
         coVerify(exactly = 1) { api.getApp() }
+    }
+
+    @Test
+    fun `on getOG, delegate to api`() {
+        val url = "https://example.com/article"
+        val apiResult =
+            GetOGResponse(duration = "50ms", title = "Example Article", ogScrapeUrl = url)
+
+        testDelegation(
+            apiFunction = { api.getOG(url) },
+            repositoryCall = { repository.getOG(url) },
+            apiResult = apiResult,
+        )
     }
 }


### PR DESCRIPTION
### Goal

Expose missing operations and parameters.

### Implementation

- Add `id`, `skipEnrichUrl` to `ActivityAddCommentRequest` public constructor
- Add `createNotificationActivity` to `FeedAddActivityRequest` public constructor
- Expose `getOG(url)` on `FeedsClient`
- Add `GetOGResponse.toAttachment()` extension for converting OG metadata to an `Attachment`
- Rename `AppRepository` to `CommonRepository` since it now holds more than app config

### Testing

- Added unit tests for `getOG` in `CommonRepositoryImplTest`
- All existing tests pass

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Open Graph metadata fetching for URLs
  * Added ability to convert Open Graph data to attachments
  * Added optional parameter to control notification activity creation when adding activities
  * Added optional parameters for ID and URL enrichment control when adding comments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->