### PR TITLE
Fix `get()` call not resetting state in paginated lists

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListImpl.kt
@@ -61,7 +61,7 @@ internal class ActivityCommentListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<ThreadedCommentData>> {
-        return queryComments(query)
+        return queryComments(query, replace = true)
     }
 
     override suspend fun queryMoreComments(limit: Int?): Result<List<ThreadedCommentData>> {
@@ -75,11 +75,12 @@ internal class ActivityCommentListImpl(
     }
 
     private suspend fun queryComments(
-        query: ActivityCommentsQuery
+        query: ActivityCommentsQuery,
+        replace: Boolean = false,
     ): Result<List<ThreadedCommentData>> {
         return commentsRepository
             .getComments(query)
-            .onSuccess { _state.onQueryMoreComments(it) }
+            .onSuccess { _state.onQueryComments(it, replace) }
             .map { it.models }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImpl.kt
@@ -65,10 +65,14 @@ internal class ActivityCommentListStateImpl(
         _comments.update { emptyList() }
     }
 
-    override fun onQueryMoreComments(result: PaginationResult<ThreadedCommentData>) {
+    override fun onQueryComments(result: PaginationResult<ThreadedCommentData>, replace: Boolean) {
         _pagination = result.pagination
-        _comments.update { current ->
-            current.mergeSorted(result.models, ThreadedCommentData::id, commentsComparator)
+        if (replace) {
+            _comments.update { result.models }
+        } else {
+            _comments.update { current ->
+                current.mergeSorted(result.models, ThreadedCommentData::id, commentsComparator)
+            }
         }
     }
 
@@ -165,9 +169,10 @@ internal interface ActivityCommentListStateUpdates {
     /**
      * Handles the result of a query for comments.
      *
-     * @param result The pagination result containing the new comments.
+     * @param result The pagination result containing the comments.
+     * @param replace If true, replaces the current state; otherwise, merges with it.
      */
-    fun onQueryMoreComments(result: PaginationResult<ThreadedCommentData>)
+    fun onQueryComments(result: PaginationResult<ThreadedCommentData>, replace: Boolean = false)
 
     /**
      * Handles the removal of a comment.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListImpl.kt
@@ -66,7 +66,7 @@ internal class ActivityListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<ActivityData>> {
-        return queryActivities(query)
+        return queryActivities(query, replace = true)
     }
 
     override suspend fun queryMoreActivities(limit: Int?): Result<List<ActivityData>> {
@@ -86,11 +86,14 @@ internal class ActivityListImpl(
         return queryActivities(nextQuery)
     }
 
-    private suspend fun queryActivities(query: ActivitiesQuery): Result<List<ActivityData>> {
+    private suspend fun queryActivities(
+        query: ActivitiesQuery,
+        replace: Boolean = false,
+    ): Result<List<ActivityData>> {
         return activitiesRepository
             .queryActivities(query)
             .onSuccess {
-                _state.onQueryMoreActivities(it, QueryConfiguration(query.filter, query.sort))
+                _state.onQueryActivities(it, QueryConfiguration(query.filter, query.sort), replace)
                 feedOwnValuesRepository.cache(it.models.mapNotNull(ActivityData::currentFeed))
             }
             .map { it.models }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImpl.kt
@@ -81,16 +81,20 @@ internal class ActivityListStateImpl(
     override val pagination: PaginationData?
         get() = _pagination
 
-    override fun onQueryMoreActivities(
+    override fun onQueryActivities(
         result: PaginationResult<ActivityData>,
         queryConfig: ActivitiesQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
-        // Update the query configuration for future queries
         this.queryConfig = queryConfig
-        // Merge the new activities with the existing ones (keeping the sort order)
-        _activities.update { current ->
-            current.mergeSorted(result.models, ActivityData::id, activitiesSorting)
+        if (replace) {
+            _activities.update { result.models }
+        } else {
+            // Merge the new activities with the existing ones (keeping the sort order)
+            _activities.update { current ->
+                current.mergeSorted(result.models, ActivityData::id, activitiesSorting)
+            }
         }
     }
 
@@ -243,14 +247,17 @@ internal interface ActivityListMutableState : ActivityListState, ActivityListSta
 internal interface ActivityListStateUpdates {
 
     /**
-     * Called when more activities are queried and received.
+     * Called when activities are queried and received.
      *
-     * @param result The result containing the new activities and pagination information.
+     * @param result The result containing the activities and pagination information.
      * @param queryConfig The configuration used for the query, including sorting and filtering.
+     * @param replace If true, replaces the current activities; if false, merges with the existing
+     *   ones keeping the sort order.
      */
-    fun onQueryMoreActivities(
+    fun onQueryActivities(
         result: PaginationResult<ActivityData>,
         queryConfig: ActivitiesQueryConfig,
+        replace: Boolean = false,
     )
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListImpl.kt
@@ -58,7 +58,7 @@ internal class ActivityReactionListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<FeedsReactionData>> {
-        return queryActivityReactions(query)
+        return queryActivityReactions(query, replace = true)
     }
 
     override suspend fun queryMoreReactions(limit: Int?): Result<List<FeedsReactionData>> {
@@ -80,14 +80,16 @@ internal class ActivityReactionListImpl(
     }
 
     private suspend fun queryActivityReactions(
-        query: ActivityReactionsQuery
+        query: ActivityReactionsQuery,
+        replace: Boolean = false,
     ): Result<List<FeedsReactionData>> {
         return activitiesRepository
             .queryActivityReactions(query.activityId, query.toRequest())
             .onSuccess {
-                _state.onQueryMoreActivityReactions(
+                _state.onQueryActivityReactions(
                     result = it,
                     queryConfig = QueryConfiguration(query.filter, query.sort),
+                    replace = replace,
                 )
             }
             .map { it.models }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListStateImpl.kt
@@ -64,16 +64,20 @@ internal class ActivityReactionListStateImpl(override val query: ActivityReactio
         _reactions.update { emptyList() }
     }
 
-    override fun onQueryMoreActivityReactions(
+    override fun onQueryActivityReactions(
         result: PaginationResult<FeedsReactionData>,
         queryConfig: ActivityReactionsQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
-        // Update the query configuration for future queries
         this.queryConfig = queryConfig
-        // Merge the new reactions with the existing ones (keeping the sort order)
-        _reactions.update { current ->
-            current.mergeSorted(result.models, FeedsReactionData::id, reactionsSorting)
+        if (replace) {
+            _reactions.update { result.models }
+        } else {
+            // Merge the new reactions with the existing ones (keeping the sort order)
+            _reactions.update { current ->
+                current.mergeSorted(result.models, FeedsReactionData::id, reactionsSorting)
+            }
         }
     }
 
@@ -110,10 +114,12 @@ internal interface ActivityReactionListStateUpdates {
      * @param result The result of the pagination query containing the reactions.
      * @param queryConfig The configuration used for the query, including filters and sorting
      *   options.
+     * @param replace Whether to replace existing reactions or merge them with the new ones.
      */
-    fun onQueryMoreActivityReactions(
+    fun onQueryActivityReactions(
         result: PaginationResult<FeedsReactionData>,
         queryConfig: ActivityReactionsQueryConfig,
+        replace: Boolean = false,
     )
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListImpl.kt
@@ -56,7 +56,7 @@ internal class BookmarkFolderListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<BookmarkFolderData>> {
-        return queryBookmarkFolders(query)
+        return queryBookmarkFolders(query, replace = true)
     }
 
     override suspend fun queryMoreBookmarkFolders(limit: Int?): Result<List<BookmarkFolderData>> {
@@ -77,12 +77,17 @@ internal class BookmarkFolderListImpl(
     }
 
     private suspend fun queryBookmarkFolders(
-        query: BookmarkFoldersQuery
+        query: BookmarkFoldersQuery,
+        replace: Boolean = false,
     ): Result<List<BookmarkFolderData>> {
         return bookmarksRepository
             .queryBookmarkFolders(query)
             .onSuccess {
-                _state.onQueryMoreBookmarkFolders(it, QueryConfiguration(query.filter, query.sort))
+                _state.onQueryBookmarkFolders(
+                    it,
+                    QueryConfiguration(query.filter, query.sort),
+                    replace,
+                )
             }
             .map { it.models }
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListStateImpl.kt
@@ -57,16 +57,21 @@ internal class BookmarkFolderListStateImpl(override val query: BookmarkFoldersQu
     override val pagination: PaginationData?
         get() = _pagination
 
-    override fun onQueryMoreBookmarkFolders(
+    override fun onQueryBookmarkFolders(
         result: PaginationResult<BookmarkFolderData>,
         queryConfig: BookmarkFoldersQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
-        // Merge the new folders with the existing ones (keeping the sort order)
-        _folders.update { current ->
-            current.mergeSorted(result.models, BookmarkFolderData::id, foldersSorting)
+        if (replace) {
+            _folders.update { result.models }
+        } else {
+            // Merge the new folders with the existing ones (keeping the sort order)
+            _folders.update { current ->
+                current.mergeSorted(result.models, BookmarkFolderData::id, foldersSorting)
+            }
         }
     }
 
@@ -96,13 +101,16 @@ internal interface BookmarkFolderListMutableState :
 internal interface BookmarkFolderListStateUpdates {
 
     /**
-     * Called when more bookmark folders are queried.
+     * Called when bookmark folders are queried.
      *
-     * @param result The result containing the new bookmark folders and pagination data.
+     * @param result The result containing the bookmark folders and pagination data.
+     * @param queryConfig The query configuration used for the query.
+     * @param replace If true, replaces the current folders; otherwise, merges with existing ones.
      */
-    fun onQueryMoreBookmarkFolders(
+    fun onQueryBookmarkFolders(
         result: PaginationResult<BookmarkFolderData>,
         queryConfig: BookmarkFoldersQueryConfig,
+        replace: Boolean = false,
     )
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListImpl.kt
@@ -55,7 +55,7 @@ internal class BookmarkListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<BookmarkData>> {
-        return queryBookmarks(query)
+        return queryBookmarks(query, replace = true)
     }
 
     override suspend fun queryMoreBookmarks(limit: Int?): Result<List<BookmarkData>> {
@@ -75,11 +75,14 @@ internal class BookmarkListImpl(
         return queryBookmarks(nextQuery)
     }
 
-    private suspend fun queryBookmarks(query: BookmarksQuery): Result<List<BookmarkData>> {
+    private suspend fun queryBookmarks(
+        query: BookmarksQuery,
+        replace: Boolean = false,
+    ): Result<List<BookmarkData>> {
         return bookmarksRepository
             .queryBookmarks(query)
             .onSuccess {
-                _state.onQueryMoreBookmarks(it, QueryConfiguration(query.filter, query.sort))
+                _state.onQueryBookmarks(it, QueryConfiguration(query.filter, query.sort), replace)
             }
             .map { it.models }
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListStateImpl.kt
@@ -59,16 +59,20 @@ internal class BookmarkListStateImpl(override val query: BookmarksQuery) :
     override val pagination: PaginationData?
         get() = _pagination
 
-    override fun onQueryMoreBookmarks(
+    override fun onQueryBookmarks(
         result: PaginationResult<BookmarkData>,
         queryConfig: BookmarksQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
-        // Update the query configuration for future queries
         this.queryConfig = queryConfig
-        // Merge the new bookmarks with the existing ones (keeping the sort order)
-        _bookmarks.update { current ->
-            current.mergeSorted(result.models, BookmarkData::id, bookmarksSorting)
+        if (replace) {
+            _bookmarks.update { result.models }
+        } else {
+            // Merge the new bookmarks with the existing ones (keeping the sort order)
+            _bookmarks.update { current ->
+                current.mergeSorted(result.models, BookmarkData::id, bookmarksSorting)
+            }
         }
     }
 
@@ -120,9 +124,10 @@ internal interface BookmarkListMutableState : BookmarkListState, BookmarkListSta
 /** An interface that defines the methods for updating the state of a bookmark list. */
 internal interface BookmarkListStateUpdates {
 
-    fun onQueryMoreBookmarks(
+    fun onQueryBookmarks(
         result: PaginationResult<BookmarkData>,
         queryConfig: BookmarksQueryConfig,
+        replace: Boolean = false,
     )
 
     fun onBookmarkFolderRemoved(folderId: String)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListImpl.kt
@@ -56,7 +56,7 @@ internal class CommentListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<CommentData>> {
-        return queryComments(query)
+        return queryComments(query, replace = true)
     }
 
     override suspend fun queryMoreComments(limit: Int?): Result<List<CommentData>> {
@@ -69,9 +69,13 @@ internal class CommentListImpl(
         return queryComments(nextQuery)
     }
 
-    private suspend fun queryComments(query: CommentsQuery): Result<List<CommentData>> {
-        return commentsRepository.queryComments(query).onSuccess(_state::onQueryMoreComments).map {
-            it.models
-        }
+    private suspend fun queryComments(
+        query: CommentsQuery,
+        replace: Boolean = false,
+    ): Result<List<CommentData>> {
+        return commentsRepository
+            .queryComments(query)
+            .onSuccess { _state.onQueryComments(it, replace) }
+            .map { it.models }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImpl.kt
@@ -66,11 +66,16 @@ internal class CommentListStateImpl(
 
     private val comparator = query.sort.toComparator()
 
-    override fun onQueryMoreComments(result: PaginationResult<CommentData>) {
+    override fun onQueryComments(result: PaginationResult<CommentData>, replace: Boolean) {
         _pagination = result.pagination
-        // Merge the new comments with the existing ones (keeping the sort order)
-        _comments.update { current ->
-            current.mergeSorted(result.models, CommentData::id, comparator)
+        if (replace) {
+            // Replace the current comments with the new ones
+            _comments.update { result.models }
+        } else {
+            // Merge the new comments with the existing ones (keeping the sort order)
+            _comments.update { current ->
+                current.mergeSorted(result.models, CommentData::id, comparator)
+            }
         }
     }
 
@@ -116,13 +121,12 @@ internal interface CommentListMutableState : CommentListState, CommentListStateU
 internal interface CommentListStateUpdates {
 
     /**
-     * Handles the result of querying more comments.
+     * Handles the result of querying comments.
      *
-     * @param result The pagination result containing the new comments.
-     * @param filter The filter used for the query, if any.
-     * @param sort The sorting configuration used for the query, if any.
+     * @param result The pagination result containing the comments.
+     * @param replace Whether to replace the current comments or merge with them.
      */
-    fun onQueryMoreComments(result: PaginationResult<CommentData>)
+    fun onQueryComments(result: PaginationResult<CommentData>, replace: Boolean = false)
 
     /**
      * Handles the addition or update of a comment in the list.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListImpl.kt
@@ -56,7 +56,7 @@ internal class CommentReactionListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<FeedsReactionData>> {
-        return queryCommentReactions(query)
+        return queryCommentReactions(query, replace = true)
     }
 
     override suspend fun queryMoreReactions(limit: Int?): Result<List<FeedsReactionData>> {
@@ -70,12 +70,17 @@ internal class CommentReactionListImpl(
     }
 
     private suspend fun queryCommentReactions(
-        query: CommentReactionsQuery
+        query: CommentReactionsQuery,
+        replace: Boolean = false,
     ): Result<List<FeedsReactionData>> {
         return commentsRepository
             .queryCommentReactions(query.commentId, query)
             .onSuccess { result ->
-                _state.onQueryMoreReactions(result, QueryConfiguration(query.filter, query.sort))
+                _state.onQueryReactions(
+                    result,
+                    QueryConfiguration(query.filter, query.sort),
+                    replace,
+                )
             }
             .map { it.models }
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListStateImpl.kt
@@ -62,16 +62,21 @@ internal class CommentReactionListStateImpl(override val query: CommentReactions
         _reactions.update { emptyList() }
     }
 
-    override fun onQueryMoreReactions(
+    override fun onQueryReactions(
         result: PaginationResult<FeedsReactionData>,
         queryConfig: CommentReactionsQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
-        // Merge the new reactions with the existing ones (keeping the sort order)
-        _reactions.update { current ->
-            current.mergeSorted(result.models, FeedsReactionData::id, reactionsSorting)
+        if (replace) {
+            _reactions.update { result.models }
+        } else {
+            // Merge the new reactions with the existing ones (keeping the sort order)
+            _reactions.update { current ->
+                current.mergeSorted(result.models, FeedsReactionData::id, reactionsSorting)
+            }
         }
     }
 
@@ -95,14 +100,16 @@ internal interface CommentReactionListStateUpdates {
     fun onCommentRemoved()
 
     /**
-     * Handles the successful loading of reactions.
+     * Handles the loading of reactions, either replacing the existing state or merging with it.
      *
      * @param result The result containing the loaded reactions and pagination data.
      * @param queryConfig The query configuration used for the request.
+     * @param replace Whether to replace the existing reactions or merge with them.
      */
-    fun onQueryMoreReactions(
+    fun onQueryReactions(
         result: PaginationResult<FeedsReactionData>,
         queryConfig: CommentReactionsQueryConfig,
+        replace: Boolean = false,
     )
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListImpl.kt
@@ -57,7 +57,7 @@ internal class CommentReplyListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<ThreadedCommentData>> {
-        return queryReplies(query)
+        return queryReplies(query, replace = true)
     }
 
     override suspend fun queryMoreReplies(limit: Int?): Result<List<ThreadedCommentData>> {
@@ -71,11 +71,12 @@ internal class CommentReplyListImpl(
     }
 
     private suspend fun queryReplies(
-        query: CommentRepliesQuery
+        query: CommentRepliesQuery,
+        replace: Boolean = false,
     ): Result<List<ThreadedCommentData>> {
         return commentsRepository
             .getCommentReplies(query)
-            .onSuccess { _state.onQueryMoreReplies(it) }
+            .onSuccess { _state.onQueryReplies(it, replace) }
             .map { it.models }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListStateImpl.kt
@@ -61,10 +61,14 @@ internal class CommentReplyListStateImpl(
 
     private val comparator = query.sort.toComparator()
 
-    override fun onQueryMoreReplies(result: PaginationResult<ThreadedCommentData>) {
+    override fun onQueryReplies(result: PaginationResult<ThreadedCommentData>, replace: Boolean) {
         _pagination = result.pagination
-        // Merge the new replies with the existing ones (keeping the sort order)
-        _replies.update { current -> current + result.models }
+        if (replace) {
+            _replies.update { result.models }
+        } else {
+            // Merge the new replies with the existing ones (keeping the sort order)
+            _replies.update { current -> current + result.models }
+        }
     }
 
     override fun onCommentRemoved(commentId: String) {
@@ -160,11 +164,14 @@ internal interface CommentReplyListMutableState :
 internal interface CommentReplyListStateUpdates {
 
     /**
-     * Handles the result of a query for replies to a comment.
+     * Handles the result of a query for replies to a comment. When [replace] is true, the current
+     * state is replaced with the new results. When [replace] is false, the new results are appended
+     * to the existing state.
      *
      * @param result The pagination result containing the replies to the comment.
+     * @param replace Whether to replace the current state or append to it.
      */
-    fun onQueryMoreReplies(result: PaginationResult<ThreadedCommentData>)
+    fun onQueryReplies(result: PaginationResult<ThreadedCommentData>, replace: Boolean = false)
 
     /**
      * Handles the removal of a comment reply.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListImpl.kt
@@ -55,7 +55,7 @@ internal class FeedListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<FeedData>> {
-        return queryFeeds(query)
+        return queryFeeds(query, replace = true)
     }
 
     override suspend fun queryMoreFeeds(limit: Int?): Result<List<FeedData>> {
@@ -76,11 +76,14 @@ internal class FeedListImpl(
         return queryFeeds(nextQuery)
     }
 
-    private suspend fun queryFeeds(query: FeedsQuery): Result<List<FeedData>> {
+    private suspend fun queryFeeds(
+        query: FeedsQuery,
+        replace: Boolean = false,
+    ): Result<List<FeedData>> {
         return feedsRepository
             .queryFeeds(query)
             .onSuccess {
-                _state.onQueryMoreFeeds(it, QueryConfiguration(query.filter, query.sort))
+                _state.onQueryFeeds(it, QueryConfiguration(query.filter, query.sort), replace)
                 feedOwnValuesRepository.cache(it.models)
             }
             .map { it.models }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedListStateImpl.kt
@@ -57,15 +57,21 @@ internal class FeedListStateImpl(override val query: FeedsQuery) : FeedListMutab
     override val pagination: PaginationData?
         get() = _pagination
 
-    override fun onQueryMoreFeeds(
+    override fun onQueryFeeds(
         result: PaginationResult<FeedData>,
         queryConfig: FeedsQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
         this.queryConfig = queryConfig
-        // Merge the new feeds with the existing ones (keeping the sort order)
-        _feeds.update { current ->
-            current.mergeSorted(result.models, { it.fid.rawValue }, feedsSorting)
+        if (replace) {
+            // Replace the feeds list with the new results
+            _feeds.update { result.models }
+        } else {
+            // Merge the new feeds with the existing ones (keeping the sort order)
+            _feeds.update { current ->
+                current.mergeSorted(result.models, { it.fid.rawValue }, feedsSorting)
+            }
         }
     }
 
@@ -94,8 +100,15 @@ internal interface FeedListMutableState : FeedListState, FeedListStateUpdates
  */
 internal interface FeedListStateUpdates {
 
-    /** Handles the result of a query for more feeds. */
-    fun onQueryMoreFeeds(result: PaginationResult<FeedData>, queryConfig: FeedsQueryConfig)
+    /**
+     * Handles the result of a query for feeds. When [replace] is true, replaces the current state;
+     * otherwise merges.
+     */
+    fun onQueryFeeds(
+        result: PaginationResult<FeedData>,
+        queryConfig: FeedsQueryConfig,
+        replace: Boolean = false,
+    )
 
     /** Handles the removal of a feed by its ID. */
     fun onFeedRemoved(feedId: String)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedStateImpl.kt
@@ -137,7 +137,7 @@ internal class FeedStateImpl(
         _notificationStatus.update { result.notificationStatus }
 
         // Members are managed by the paginated list
-        memberListState.onQueryMoreMembers(result.members, QueryConfiguration(null, null))
+        memberListState.onQueryMembers(result.members, QueryConfiguration(null, null))
     }
 
     override fun onQueryMoreActivities(

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListImpl.kt
@@ -56,7 +56,7 @@ internal class FollowListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<FollowData>> {
-        return queryFollows(query)
+        return queryFollows(query, replace = true)
     }
 
     override suspend fun queryMoreFollows(limit: Int?): Result<List<FollowData>> {
@@ -76,11 +76,14 @@ internal class FollowListImpl(
         return queryFollows(nextQuery)
     }
 
-    private suspend fun queryFollows(query: FollowsQuery): Result<List<FollowData>> {
+    private suspend fun queryFollows(
+        query: FollowsQuery,
+        replace: Boolean = false,
+    ): Result<List<FollowData>> {
         return feedsRepository
             .queryFollows(query.toRequest())
             .onSuccess {
-                _state.onQueryMoreFollows(it, QueryConfiguration(query.filter, query.sort))
+                _state.onQueryFollows(it, QueryConfiguration(query.filter, query.sort), replace)
             }
             .map { it.models }
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImpl.kt
@@ -58,15 +58,21 @@ internal class FollowListStateImpl(override val query: FollowsQuery) : FollowLis
     override val pagination: PaginationData?
         get() = _pagination
 
-    override fun onQueryMoreFollows(
+    override fun onQueryFollows(
         result: PaginationResult<FollowData>,
         queryConfig: FollowsQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
         this.queryConfig = queryConfig
-        // Merge the new follows with the existing ones (keeping the sort order)
-        _follows.update { current ->
-            current.mergeSorted(result.models, FollowData::id, followsSorting)
+        if (replace) {
+            // Replace the follows list with the new results
+            _follows.update { result.models }
+        } else {
+            // Merge the new follows with the existing ones (keeping the sort order)
+            _follows.update { current ->
+                current.mergeSorted(result.models, FollowData::id, followsSorting)
+            }
         }
     }
 
@@ -96,8 +102,15 @@ internal interface FollowListMutableState : FollowListState, FollowListStateUpda
 /** An interface for handling updates to the follow list state. */
 internal interface FollowListStateUpdates {
 
-    /** Handles the result of a query for more follows. */
-    fun onQueryMoreFollows(result: PaginationResult<FollowData>, queryConfig: FollowsQueryConfig)
+    /**
+     * Handles the result of a query for follows. When [replace] is true, replaces the state;
+     * otherwise merges with existing state.
+     */
+    fun onQueryFollows(
+        result: PaginationResult<FollowData>,
+        queryConfig: FollowsQueryConfig,
+        replace: Boolean = false,
+    )
 
     /** Handles the addition or update of a follow. */
     fun onFollowUpserted(follow: FollowData)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListImpl.kt
@@ -56,7 +56,7 @@ internal class MemberListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<FeedMemberData>> {
-        return queryMembers(query)
+        return queryMembers(query, replace = true)
     }
 
     override suspend fun queryMoreMembers(limit: Int?): Result<List<FeedMemberData>> {
@@ -81,7 +81,10 @@ internal class MemberListImpl(
     internal val mutableState: MemberListMutableState
         get() = _state
 
-    private suspend fun queryMembers(query: MembersQuery): Result<List<FeedMemberData>> {
+    private suspend fun queryMembers(
+        query: MembersQuery,
+        replace: Boolean = false,
+    ): Result<List<FeedMemberData>> {
         return feedsRepository
             .queryFeedMembers(
                 feedGroupId = query.fid.group,
@@ -89,7 +92,7 @@ internal class MemberListImpl(
                 request = query.toRequest(),
             )
             .onSuccess {
-                _state.onQueryMoreMembers(it, QueryConfiguration(query.filter, query.sort))
+                _state.onQueryMembers(it, QueryConfiguration(query.filter, query.sort), replace)
             }
             .map { it.models }
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/MemberListStateImpl.kt
@@ -58,15 +58,20 @@ internal class MemberListStateImpl(override val query: MembersQuery) : MemberLis
     override val pagination: PaginationData?
         get() = _pagination
 
-    override fun onQueryMoreMembers(
+    override fun onQueryMembers(
         result: PaginationResult<FeedMemberData>,
         queryConfig: MembersQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
         this.queryConfig = queryConfig
-        // Merge the new members with the existing ones (keeping the sort order)
-        _members.update { current ->
-            current.mergeSorted(result.models, FeedMemberData::id, membersSorting)
+        if (replace) {
+            _members.update { result.models }
+        } else {
+            // Merge the new members with the existing ones (keeping the sort order)
+            _members.update { current ->
+                current.mergeSorted(result.models, FeedMemberData::id, membersSorting)
+            }
         }
     }
 
@@ -107,10 +112,11 @@ internal interface MemberListMutableState : MemberListState, MemberListStateUpda
  */
 internal interface MemberListStateUpdates {
 
-    /** Handles the result of a query for more members. */
-    fun onQueryMoreMembers(
+    /** Handles the result of a query for members. When [replace] is true, replaces the state. */
+    fun onQueryMembers(
         result: PaginationResult<FeedMemberData>,
         queryConfig: MembersQueryConfig,
+        replace: Boolean = false,
     )
 
     /** Handles the removal of a member by their ID. */

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListImpl.kt
@@ -41,7 +41,7 @@ internal class ModerationConfigListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<ModerationConfigData>> {
-        return queryConfigs(query)
+        return queryConfigs(query, replace = true)
     }
 
     override suspend fun queryMoreConfigs(limit: Int?): Result<List<ModerationConfigData>> {
@@ -62,12 +62,13 @@ internal class ModerationConfigListImpl(
     }
 
     private suspend fun queryConfigs(
-        query: ModerationConfigsQuery
+        query: ModerationConfigsQuery,
+        replace: Boolean = false,
     ): Result<List<ModerationConfigData>> {
         return moderationRepository
             .queryModerationConfigs(query)
             .onSuccess {
-                _state.onLoadMoreConfigs(it, QueryConfiguration(query.filter, query.sort))
+                _state.onLoadConfigs(it, QueryConfiguration(query.filter, query.sort), replace)
             }
             .map { it.models }
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListStateImpl.kt
@@ -54,15 +54,20 @@ internal class ModerationConfigListStateImpl(override val query: ModerationConfi
     override val pagination: PaginationData?
         get() = _pagination
 
-    override fun onLoadMoreConfigs(
+    override fun onLoadConfigs(
         result: PaginationResult<ModerationConfigData>,
         queryConfig: ModerationConfigsQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
         this.queryConfig = queryConfig
-        // Merge the new configs with the existing ones (keeping the sort order)
-        _configs.update { current ->
-            current.mergeSorted(result.models, ModerationConfigData::id, configsSorting)
+        if (replace) {
+            _configs.update { result.models }
+        } else {
+            // Merge the new configs with the existing ones (keeping the sort order)
+            _configs.update { current ->
+                current.mergeSorted(result.models, ModerationConfigData::id, configsSorting)
+            }
         }
     }
 }
@@ -72,8 +77,9 @@ internal interface ModerationConfigListMutableState :
 
 internal interface ModerationConfigListStateUpdates {
 
-    fun onLoadMoreConfigs(
+    fun onLoadConfigs(
         result: PaginationResult<ModerationConfigData>,
         queryConfig: ModerationConfigsQueryConfig,
+        replace: Boolean = false,
     )
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListImpl.kt
@@ -57,7 +57,7 @@ internal class PollListImpl(
     }
 
     override suspend fun get(): Result<List<PollData>> {
-        return queryPolls(query)
+        return queryPolls(query, replace = true)
     }
 
     override suspend fun queryMorePolls(limit: Int?): Result<List<PollData>> {
@@ -77,10 +77,15 @@ internal class PollListImpl(
         return queryPolls(nextQuery)
     }
 
-    private suspend fun queryPolls(query: PollsQuery): Result<List<PollData>> {
+    private suspend fun queryPolls(
+        query: PollsQuery,
+        replace: Boolean = false,
+    ): Result<List<PollData>> {
         return pollsRepository
             .queryPolls(query)
-            .onSuccess { _state.onQueryMorePolls(it, QueryConfiguration(query.filter, query.sort)) }
+            .onSuccess {
+                _state.onQueryPolls(it, QueryConfiguration(query.filter, query.sort), replace)
+            }
             .map { it.models }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollListStateImpl.kt
@@ -63,15 +63,23 @@ internal class PollListStateImpl(
     override val pagination: PaginationData?
         get() = _pagination
 
-    override fun onQueryMorePolls(
+    override fun onQueryPolls(
         result: PaginationResult<PollData>,
         queryConfig: PollsQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
-        // Merge the new polls with the existing ones (keeping the sort order)
-        _polls.update { current -> current.mergeSorted(result.models, PollData::id, pollsSorting) }
+        if (replace) {
+            // Replace the polls with the new ones
+            _polls.update { result.models }
+        } else {
+            // Merge the new polls with the existing ones (keeping the sort order)
+            _polls.update { current ->
+                current.mergeSorted(result.models, PollData::id, pollsSorting)
+            }
+        }
     }
 
     override fun onPollDeleted(pollId: String) {
@@ -107,12 +115,17 @@ internal interface PollListMutableState : PollListState, PollListStateUpdates
 internal interface PollListStateUpdates {
 
     /**
-     * Handles when a new list of polls is fetched.
+     * Handles when polls are fetched, either replacing or merging with existing state.
      *
      * @param result The result containing the list of polls.
      * @param queryConfig The configuration used for the query, including sorting options.
+     * @param replace Whether to replace the existing polls or merge them.
      */
-    fun onQueryMorePolls(result: PaginationResult<PollData>, queryConfig: PollsQueryConfig)
+    fun onQueryPolls(
+        result: PaginationResult<PollData>,
+        queryConfig: PollsQueryConfig,
+        replace: Boolean = false,
+    )
 
     /**
      * Called when a poll is deleted.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListImpl.kt
@@ -56,7 +56,7 @@ internal class PollVoteListImpl(
         get() = _state
 
     override suspend fun get(): Result<List<PollVoteData>> {
-        return queryPollVotes(query)
+        return queryPollVotes(query, replace = true)
     }
 
     override suspend fun queryMorePollVotes(limit: Int?): Result<List<PollVoteData>> {
@@ -78,11 +78,14 @@ internal class PollVoteListImpl(
         return queryPollVotes(nextQuery)
     }
 
-    private suspend fun queryPollVotes(query: PollVotesQuery): Result<List<PollVoteData>> {
+    private suspend fun queryPollVotes(
+        query: PollVotesQuery,
+        replace: Boolean = false,
+    ): Result<List<PollVoteData>> {
         return repository
             .queryPollVotes(query)
             .onSuccess {
-                _state.onQueryMorePollVotes(it, QueryConfiguration(query.filter, query.sort))
+                _state.onQueryPollVotes(it, QueryConfiguration(query.filter, query.sort), replace)
             }
             .map { it.models }
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListStateImpl.kt
@@ -58,16 +58,22 @@ internal class PollVoteListStateImpl(override val query: PollVotesQuery) :
         _votes.update { emptyList() }
     }
 
-    override fun onQueryMorePollVotes(
+    override fun onQueryPollVotes(
         result: PaginationResult<PollVoteData>,
         queryConfig: PollVotesQueryConfig,
+        replace: Boolean,
     ) {
         _pagination = result.pagination
         // Update the query configuration for future queries
         this.queryConfig = queryConfig
-        // Merge the new votes with the existing ones (keeping the sort order)
-        _votes.update { current ->
-            current.mergeSorted(result.models, PollVoteData::id, votesSorting)
+        if (replace) {
+            // Replace the current votes with the new ones
+            _votes.update { result.models }
+        } else {
+            // Merge the new votes with the existing ones (keeping the sort order)
+            _votes.update { current ->
+                current.mergeSorted(result.models, PollVoteData::id, votesSorting)
+            }
         }
     }
 
@@ -95,14 +101,17 @@ internal interface PollVoteListStateUpdates {
     fun onPollDeleted()
 
     /**
-     * Handles updates to the poll vote list state when new poll votes are fetched.
+     * Handles the poll vote list query by updating the current state.
      *
-     * @param result The result containing the new poll votes and pagination information.
+     * @param result The result containing the poll votes and pagination information.
      * @param queryConfig The configuration used for the query, including sorting options.
+     * @param replace If true, replaces the current votes; otherwise, merges them with existing
+     *   ones.
      */
-    fun onQueryMorePollVotes(
+    fun onQueryPollVotes(
         result: PaginationResult<PollVoteData>,
         queryConfig: PollVotesQueryConfig,
+        replace: Boolean = false,
     )
 
     /** Handles the removal of a poll vote from the list. */

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/UserListImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/UserListImpl.kt
@@ -36,7 +36,7 @@ internal class UserListImpl(
     override val state = UserListStateImpl(query)
 
     override suspend fun get(): Result<List<UserData>> {
-        return commonRepository.queryUsers(query).onSuccess(state::onQueryUsers)
+        return queryUsers(query, replace = true)
     }
 
     override suspend fun queryMoreUsers(limit: Int?): Result<List<UserData>> {
@@ -54,7 +54,10 @@ internal class UserListImpl(
         return queryUsers(nextQuery)
     }
 
-    private suspend fun queryUsers(query: UsersQuery): Result<List<UserData>> {
-        return commonRepository.queryUsers(query).onSuccess(state::onQueryMoreUsers)
+    private suspend fun queryUsers(
+        query: UsersQuery,
+        replace: Boolean = false,
+    ): Result<List<UserData>> {
+        return commonRepository.queryUsers(query).onSuccess { state.onQueryUsers(it, replace) }
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/UserListStateImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/UserListStateImpl.kt
@@ -42,23 +42,22 @@ internal class UserListStateImpl(override val query: UsersQuery) : UserListMutab
     internal var currentOffset: Int = query.offset ?: 0
         private set
 
-    override fun onQueryUsers(users: List<UserData>) {
+    override fun onQueryUsers(users: List<UserData>, replace: Boolean) {
         canLoadMore = users.isNotEmpty()
-        currentOffset = (query.offset ?: 0) + users.size
-        _users.update { users }
-    }
-
-    override fun onQueryMoreUsers(users: List<UserData>) {
-        canLoadMore = users.isNotEmpty()
-        currentOffset += users.size
-        _users.update { current -> current.mergeSorted(users, UserData::id, query.sort.orEmpty()) }
+        if (replace) {
+            currentOffset = (query.offset ?: 0) + users.size
+            _users.update { users }
+        } else {
+            currentOffset += users.size
+            _users.update { current ->
+                current.mergeSorted(users, UserData::id, query.sort.orEmpty())
+            }
+        }
     }
 }
 
 internal interface UserListMutableState : UserListState, UserListStateUpdates
 
 internal interface UserListStateUpdates {
-    fun onQueryUsers(users: List<UserData>)
-
-    fun onQueryMoreUsers(users: List<UserData>)
+    fun onQueryUsers(users: List<UserData>, replace: Boolean = false)
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListImplTest.kt
@@ -107,6 +107,22 @@ internal class ActivityCommentListImplTest {
         coVerify { commentsRepository.getComments(any()) }
     }
 
+    @Test
+    fun `on get called twice, comments are replaced not merged`() = runTest {
+        val page1 = listOf(threadedCommentData("comment-1"), threadedCommentData("comment-2"))
+        val page2 = listOf(threadedCommentData("comment-3"))
+        coEvery { commentsRepository.getComments(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        activityCommentList.get()
+        activityCommentList.get()
+
+        assertEquals(1, activityCommentList.state.comments.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialComments = listOf(threadedCommentData("comment-1"))
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityCommentListStateImplTest.kt
@@ -41,7 +41,7 @@ internal class ActivityCommentListStateImplTest {
     private val state = ActivityCommentListStateImpl(query, currentUserId = "user-1")
 
     @Test
-    fun `onQueryMoreComments when called, then merge comments and update pagination`() {
+    fun `onQueryComments when called, then merge comments and update pagination`() {
         val batch1 =
             listOf(
                 threadedCommentData(id = "c1", createdAt = Date(1)),
@@ -62,8 +62,8 @@ internal class ActivityCommentListStateImplTest {
         val result1 = PaginationResult(models = batch1, pagination = PaginationData("next1"))
         val result2 = PaginationResult(models = batch2, pagination = PaginationData("next2"))
 
-        state.onQueryMoreComments(result1)
-        state.onQueryMoreComments(result2)
+        state.onQueryComments(result1)
+        state.onQueryComments(result2)
 
         assertEquals(result2.pagination, state.pagination)
         assertEquals(expected, state.comments.value)
@@ -333,6 +333,6 @@ internal class ActivityCommentListStateImplTest {
     }
 
     private fun setupInitialState(vararg initialComments: ThreadedCommentData) {
-        state.onQueryMoreComments(defaultPaginationResult(initialComments.toList()))
+        state.onQueryComments(defaultPaginationResult(initialComments.toList()))
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListImplTest.kt
@@ -125,6 +125,22 @@ internal class ActivityListImplTest {
         assertEquals(exception, result.exceptionOrNull())
     }
 
+    @Test
+    fun `on get called twice, activities are replaced not merged`() = runTest {
+        val page1 = listOf(activityData("activity-1"), activityData("activity-2"))
+        val page2 = listOf(activityData("activity-3"))
+        coEvery { activitiesRepository.queryActivities(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        activityList.get()
+        activityList.get()
+
+        assertEquals(1, activityList.state.activities.value.size)
+    }
+
     // Helper functions to reduce boilerplate
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialActivities = listOf(activityData("activity-1"))

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityListStateImplTest.kt
@@ -55,7 +55,7 @@ internal class ActivityListStateImplTest {
         val activity2 = activityData("activity-2")
 
         val paginationResult = defaultPaginationResult(listOf(activity1, activity2))
-        activityListState.onQueryMoreActivities(paginationResult, queryConfig)
+        activityListState.onQueryActivities(paginationResult, queryConfig)
 
         assertEquals(listOf(activity1, activity2), activityListState.activities.value)
         assertEquals("next-cursor", activityListState.pagination?.next)
@@ -436,7 +436,7 @@ internal class ActivityListStateImplTest {
 
     private fun setupInitialActivities(vararg activities: ActivityData) {
         val paginationResult = defaultPaginationResult(activities.toList())
-        activityListState.onQueryMoreActivities(paginationResult, queryConfig)
+        activityListState.onQueryActivities(paginationResult, queryConfig)
     }
 
     companion object {

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListImplTest.kt
@@ -104,6 +104,22 @@ internal class ActivityReactionListImplTest {
         coVerify { activitiesRepository.queryActivityReactions(any(), any()) }
     }
 
+    @Test
+    fun `on get called twice, reactions are replaced not merged`() = runTest {
+        val page1 = listOf(feedsReactionData(), feedsReactionData())
+        val page2 = listOf(feedsReactionData())
+        coEvery { activitiesRepository.queryActivityReactions(query.activityId, any()) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        activityReactionList.get()
+        activityReactionList.get()
+
+        assertEquals(1, activityReactionList.state.reactions.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialReactions = listOf(feedsReactionData())
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ActivityReactionListStateImplTest.kt
@@ -47,7 +47,7 @@ internal class ActivityReactionListStateImplTest {
             )
         val paginationResult = defaultPaginationResult(reactions)
 
-        activityReactionListState.onQueryMoreActivityReactions(paginationResult, queryConfig)
+        activityReactionListState.onQueryActivityReactions(paginationResult, queryConfig)
 
         assertEquals(reactions, activityReactionListState.reactions.value)
         assertEquals("next-cursor", activityReactionListState.pagination?.next)
@@ -62,7 +62,7 @@ internal class ActivityReactionListStateImplTest {
                 feedsReactionData(activityId = "activity-1", userId = "user-2"),
             )
         val paginationResult = defaultPaginationResult(initialReactions)
-        activityReactionListState.onQueryMoreActivityReactions(paginationResult, queryConfig)
+        activityReactionListState.onQueryActivityReactions(paginationResult, queryConfig)
 
         activityReactionListState.onReactionRemoved(initialReactions[0])
 
@@ -78,7 +78,7 @@ internal class ActivityReactionListStateImplTest {
             feedsReactionData(activityId = "activity-1", userId = "user-3", createdAt = Date(3000))
         val initialReactions = listOf(newerReaction, olderReaction) // newest first
         val paginationResult = defaultPaginationResult(initialReactions)
-        activityReactionListState.onQueryMoreActivityReactions(paginationResult, queryConfig)
+        activityReactionListState.onQueryActivityReactions(paginationResult, queryConfig)
 
         val middleReaction =
             feedsReactionData(activityId = "activity-1", userId = "user-2", createdAt = Date(2000))
@@ -115,7 +115,7 @@ internal class ActivityReactionListStateImplTest {
                 )
 
             val paginationResult = defaultPaginationResult(existingReactions)
-            activityReactionListState.onQueryMoreActivityReactions(paginationResult, queryConfig)
+            activityReactionListState.onQueryActivityReactions(paginationResult, queryConfig)
 
             val newReaction =
                 feedsReactionData(
@@ -140,7 +140,7 @@ internal class ActivityReactionListStateImplTest {
             )
         val paginationResult = defaultPaginationResult(reactions)
 
-        activityReactionListState.onQueryMoreActivityReactions(paginationResult, queryConfig)
+        activityReactionListState.onQueryActivityReactions(paginationResult, queryConfig)
         activityReactionListState.onActivityRemoved()
 
         assertEquals(emptyList<FeedsReactionData>(), activityReactionListState.reactions.value)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListImplTest.kt
@@ -104,6 +104,22 @@ internal class BookmarkFolderListImplTest {
         coVerify { bookmarksRepository.queryBookmarkFolders(any()) }
     }
 
+    @Test
+    fun `on get called twice, folders are replaced not merged`() = runTest {
+        val page1 = listOf(bookmarkFolderData("folder-1"), bookmarkFolderData("folder-2"))
+        val page2 = listOf(bookmarkFolderData("folder-3"))
+        coEvery { bookmarksRepository.queryBookmarkFolders(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        bookmarkFolderList.get()
+        bookmarkFolderList.get()
+
+        assertEquals(1, bookmarkFolderList.state.folders.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialFolders = listOf(bookmarkFolderData("folder-1"))
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkFolderListStateImplTest.kt
@@ -42,7 +42,7 @@ internal class BookmarkFolderListStateImplTest {
         val folders = listOf(bookmarkFolderData(), bookmarkFolderData("folder-2", "Test Folder 2"))
         val paginationResult = defaultPaginationResult(folders)
 
-        bookmarkFolderListState.onQueryMoreBookmarkFolders(paginationResult, queryConfig)
+        bookmarkFolderListState.onQueryBookmarkFolders(paginationResult, queryConfig)
 
         assertEquals(folders, bookmarkFolderListState.folders.value)
         assertEquals("next-cursor", bookmarkFolderListState.pagination?.next)
@@ -54,7 +54,7 @@ internal class BookmarkFolderListStateImplTest {
         val initialFolders =
             listOf(bookmarkFolderData(), bookmarkFolderData("folder-2", "Test Folder 2"))
         val paginationResult = defaultPaginationResult(initialFolders)
-        bookmarkFolderListState.onQueryMoreBookmarkFolders(paginationResult, queryConfig)
+        bookmarkFolderListState.onQueryBookmarkFolders(paginationResult, queryConfig)
 
         val updatedFolder = bookmarkFolderData("folder-1", "Updated Folder")
         bookmarkFolderListState.onBookmarkFolderUpdated(updatedFolder)
@@ -69,7 +69,7 @@ internal class BookmarkFolderListStateImplTest {
         val initialFolders =
             listOf(bookmarkFolderData(), bookmarkFolderData("folder-2", "Test Folder 2"))
         val paginationResult = defaultPaginationResult(initialFolders)
-        bookmarkFolderListState.onQueryMoreBookmarkFolders(paginationResult, queryConfig)
+        bookmarkFolderListState.onQueryBookmarkFolders(paginationResult, queryConfig)
 
         bookmarkFolderListState.onBookmarkFolderRemoved(initialFolders[0].id)
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListImplTest.kt
@@ -104,6 +104,22 @@ internal class BookmarkListImplTest {
         coVerify { bookmarksRepository.queryBookmarks(any()) }
     }
 
+    @Test
+    fun `on get called twice, bookmarks are replaced not merged`() = runTest {
+        val page1 = listOf(bookmarkData("bookmark-1"), bookmarkData("bookmark-2"))
+        val page2 = listOf(bookmarkData("bookmark-3"))
+        coEvery { bookmarksRepository.queryBookmarks(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        bookmarkList.get()
+        bookmarkList.get()
+
+        assertEquals(1, bookmarkList.state.bookmarks.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialBookmarks = listOf(bookmarkData("bookmark-1"))
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/BookmarkListStateImplTest.kt
@@ -43,7 +43,7 @@ internal class BookmarkListStateImplTest {
         val bookmarks = listOf(bookmarkData(), bookmarkData("bookmark-2", "user-2"))
         val paginationResult = defaultPaginationResult(bookmarks)
 
-        bookmarkListState.onQueryMoreBookmarks(paginationResult, queryConfig)
+        bookmarkListState.onQueryBookmarks(paginationResult, queryConfig)
 
         assertEquals(bookmarks, bookmarkListState.bookmarks.value)
         assertEquals("next-cursor", bookmarkListState.pagination?.next)
@@ -132,7 +132,7 @@ internal class BookmarkListStateImplTest {
 
     private fun setupInitialBookmarks(bookmarks: List<BookmarkData>) {
         val paginationResult = defaultPaginationResult(bookmarks)
-        bookmarkListState.onQueryMoreBookmarks(paginationResult, queryConfig)
+        bookmarkListState.onQueryBookmarks(paginationResult, queryConfig)
     }
 
     companion object {

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentListImplTest.kt
@@ -105,6 +105,22 @@ internal class CommentListImplTest {
         coVerify { commentsRepository.queryComments(any()) }
     }
 
+    @Test
+    fun `on get called twice, comments are replaced not merged`() = runTest {
+        val page1 = listOf(commentData("comment-1"), commentData("comment-2"))
+        val page2 = listOf(commentData("comment-3"))
+        coEvery { commentsRepository.queryComments(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        commentList.get()
+        commentList.get()
+
+        assertEquals(1, commentList.state.comments.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialComments = listOf(commentData("comment-1"))
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentListStateImplTest.kt
@@ -34,7 +34,7 @@ internal class CommentListStateImplTest {
     private val state = CommentListStateImpl(query, currentUserId)
 
     @Test
-    fun `onQueryMoreComments, merge comments and update pagination`() {
+    fun `onQueryComments, merge comments and update pagination`() {
         val comment1 = commentData("1", text = "First", createdAt = Date(1))
         val comment2 = commentData("2", text = "Second", createdAt = Date(2))
         val comment3 = commentData("3", text = "Third", createdAt = Date(3))
@@ -43,8 +43,8 @@ internal class CommentListStateImplTest {
         val result2 = PaginationResult(models = listOf(comment2, comment3), pagination = pagination)
         val expected = listOf(comment1, comment2, comment3)
 
-        state.onQueryMoreComments(result1)
-        state.onQueryMoreComments(result2)
+        state.onQueryComments(result1)
+        state.onQueryComments(result2)
 
         assertEquals(expected, state.comments.value)
         assertEquals(pagination, state.pagination)
@@ -139,6 +139,6 @@ internal class CommentListStateImplTest {
 
     private fun setupInitialComments(vararg comments: CommentData) {
         val result = PaginationResult(comments.toList(), PaginationData("next", "previous"))
-        state.onQueryMoreComments(result)
+        state.onQueryComments(result)
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListImplTest.kt
@@ -104,6 +104,23 @@ internal class CommentReactionListImplTest {
         coVerify { commentsRepository.queryCommentReactions(any(), any()) }
     }
 
+    @Test
+    fun `on get called twice, reactions are replaced not merged`() = runTest {
+        val page1 =
+            listOf(feedsReactionData(userId = "user-1"), feedsReactionData(userId = "user-2"))
+        val page2 = listOf(feedsReactionData(userId = "user-3"))
+        coEvery { commentsRepository.queryCommentReactions(query.commentId, query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        commentReactionList.get()
+        commentReactionList.get()
+
+        assertEquals(page2, commentReactionList.state.reactions.value)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialReactions = listOf(feedsReactionData())
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReactionListStateImplTest.kt
@@ -39,12 +39,12 @@ internal class CommentReactionListStateImplTest {
     }
 
     @Test
-    fun `on queryMoreReactions, then update reactions and pagination`() = runTest {
+    fun `on queryReactions, then update reactions and pagination`() = runTest {
         val reactions =
             listOf(feedsReactionData(), feedsReactionData("reaction-2", "comment-1", "user-2"))
         val paginationResult = defaultPaginationResult(reactions)
 
-        commentReactionListState.onQueryMoreReactions(paginationResult, queryConfig)
+        commentReactionListState.onQueryReactions(paginationResult, queryConfig)
 
         assertEquals(reactions, commentReactionListState.reactions.value)
         assertEquals("next-cursor", commentReactionListState.pagination?.next)
@@ -56,7 +56,7 @@ internal class CommentReactionListStateImplTest {
         val initialReactions =
             listOf(feedsReactionData(), feedsReactionData("reaction-2", "comment-1", "user-2"))
         val paginationResult = defaultPaginationResult(initialReactions)
-        commentReactionListState.onQueryMoreReactions(paginationResult, queryConfig)
+        commentReactionListState.onQueryReactions(paginationResult, queryConfig)
 
         commentReactionListState.onReactionRemoved(initialReactions[0])
 
@@ -69,7 +69,7 @@ internal class CommentReactionListStateImplTest {
         val initialReaction =
             feedsReactionData(commentId = "comment-1", userId = "user-1", createdAt = Date(2000))
         val paginationResult = defaultPaginationResult(listOf(initialReaction))
-        commentReactionListState.onQueryMoreReactions(paginationResult, queryConfig)
+        commentReactionListState.onQueryReactions(paginationResult, queryConfig)
 
         val newReaction =
             feedsReactionData(commentId = "comment-1", userId = "user-2", createdAt = Date(3000))
@@ -104,7 +104,7 @@ internal class CommentReactionListStateImplTest {
                 )
 
             val paginationResult = defaultPaginationResult(existingReactions)
-            commentReactionListState.onQueryMoreReactions(paginationResult, queryConfig)
+            commentReactionListState.onQueryReactions(paginationResult, queryConfig)
 
             val newReaction =
                 feedsReactionData(
@@ -126,7 +126,7 @@ internal class CommentReactionListStateImplTest {
             listOf(feedsReactionData(), feedsReactionData("reaction-2", "comment-1", "user-2"))
         val paginationResult = defaultPaginationResult(reactions)
 
-        commentReactionListState.onQueryMoreReactions(paginationResult, queryConfig)
+        commentReactionListState.onQueryReactions(paginationResult, queryConfig)
         commentReactionListState.onCommentRemoved()
 
         assertEquals(emptyList<FeedsReactionData>(), commentReactionListState.reactions.value)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListImplTest.kt
@@ -106,6 +106,22 @@ internal class CommentReplyListImplTest {
         coVerify { commentsRepository.getCommentReplies(any()) }
     }
 
+    @Test
+    fun `on get called twice, replies are replaced not merged`() = runTest {
+        val page1 = listOf(threadedCommentData("reply-1"), threadedCommentData("reply-2"))
+        val page2 = listOf(threadedCommentData("reply-3"))
+        coEvery { commentsRepository.getCommentReplies(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        commentReplyList.get()
+        commentReplyList.get()
+
+        assertEquals(1, commentReplyList.state.replies.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialReplies = listOf(threadedCommentData("reply-1"))
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/CommentReplyListStateImplTest.kt
@@ -37,7 +37,7 @@ internal class CommentReplyListStateImplTest {
     private val state = CommentReplyListStateImpl(query = query, currentUserId = currentUserId)
 
     @Test
-    fun `on onQueryMoreReplies, update state with new replies and pagination`() = runTest {
+    fun `on onQueryReplies, update state with new replies and pagination`() = runTest {
         val replies =
             listOf(
                 threadedCommentData("reply-1", text = "First reply"),
@@ -46,14 +46,14 @@ internal class CommentReplyListStateImplTest {
         val pagination = PaginationData(next = "next-cursor", previous = null)
         val result = PaginationResult(models = replies, pagination = pagination)
 
-        state.onQueryMoreReplies(result)
+        state.onQueryReplies(result)
 
         assertEquals(replies, state.replies.value)
         assertEquals(pagination, state.pagination)
     }
 
     @Test
-    fun `on onQueryMoreReplies with existing replies, merge new replies`() = runTest {
+    fun `on onQueryReplies with existing replies, merge new replies`() = runTest {
         val initialReply = threadedCommentData("reply-1", text = "First reply")
         setupInitialReplies(initialReply)
 
@@ -61,7 +61,7 @@ internal class CommentReplyListStateImplTest {
         val newPagination = PaginationData(next = "next-cursor-2", previous = "next-cursor")
         val newResult = PaginationResult(models = listOf(newReply), pagination = newPagination)
 
-        state.onQueryMoreReplies(newResult)
+        state.onQueryReplies(newResult)
 
         val expectedReplies = listOf(initialReply, newReply)
         assertEquals(expectedReplies, state.replies.value)
@@ -316,6 +316,6 @@ internal class CommentReplyListStateImplTest {
     private fun setupInitialReplies(vararg replies: ThreadedCommentData) {
         val result =
             PaginationResult(models = replies.toList(), pagination = PaginationData("next"))
-        state.onQueryMoreReplies(result)
+        state.onQueryReplies(result)
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedListImplTest.kt
@@ -104,6 +104,22 @@ internal class FeedListImplTest {
         coVerify { feedsRepository.queryFeeds(any()) }
     }
 
+    @Test
+    fun `on get called twice, feeds are replaced not merged`() = runTest {
+        val page1 = listOf(feedData(), feedData("feed-2", "user-2"))
+        val page2 = listOf(feedData("feed-3", "user-3"))
+        coEvery { feedsRepository.queryFeeds(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        feedList.get()
+        feedList.get()
+
+        assertEquals(1, feedList.state.feeds.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialFeeds = listOf(feedData())
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedListStateImplTest.kt
@@ -38,13 +38,13 @@ internal class FeedListStateImplTest {
     }
 
     @Test
-    fun `on queryMoreFeeds, then update feeds and pagination`() = runTest {
+    fun `on queryFeeds, then update feeds and pagination`() = runTest {
         val feed1 = feedData(id = "feed-1", groupId = "user", name = "First Feed")
         val feed2 = feedData(id = "feed-2", groupId = "user", name = "Second Feed")
         val feeds = listOf(feed1, feed2)
         val paginationResult = defaultPaginationResult(feeds)
 
-        feedListState.onQueryMoreFeeds(paginationResult, defaultQueryConfig)
+        feedListState.onQueryFeeds(paginationResult, defaultQueryConfig)
 
         assertEquals(feeds, feedListState.feeds.value)
         assertEquals("next-cursor", feedListState.pagination?.next)
@@ -57,7 +57,7 @@ internal class FeedListStateImplTest {
         val feed2 = feedData(id = "feed-2", groupId = "user", name = "Second Feed")
         val initialFeeds = listOf(feed1, feed2)
         val paginationResult = defaultPaginationResult(initialFeeds)
-        feedListState.onQueryMoreFeeds(paginationResult, defaultQueryConfig)
+        feedListState.onQueryFeeds(paginationResult, defaultQueryConfig)
 
         val updatedFeed =
             feedData(
@@ -78,7 +78,7 @@ internal class FeedListStateImplTest {
         val feed2 = feedData(id = "feed-2", groupId = "group", name = "F2", createdAt = 2000)
         val initialFeeds = listOf(feed1, feed2)
         val paginationResult = defaultPaginationResult(initialFeeds)
-        feedListState.onQueryMoreFeeds(paginationResult, defaultQueryConfig)
+        feedListState.onQueryFeeds(paginationResult, defaultQueryConfig)
 
         val newFeed = feedData(id = "feed-new", groupId = "group", name = "F1.5", createdAt = 1500)
         feedListState.onFeedUpserted(newFeed)
@@ -95,7 +95,7 @@ internal class FeedListStateImplTest {
         val initialFeeds = listOf(feed1, feed2)
         val paginationResult = defaultPaginationResult(initialFeeds)
         val queryConfig = FeedsQueryConfig(filter = null, sort = FeedsSort.Default)
-        feedListState.onQueryMoreFeeds(paginationResult, queryConfig)
+        feedListState.onQueryFeeds(paginationResult, queryConfig)
 
         feedListState.onFeedRemoved("user:feed-1")
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FollowListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FollowListImplTest.kt
@@ -101,6 +101,26 @@ internal class FollowListImplTest {
         coVerify { feedsRepository.queryFollows(any()) }
     }
 
+    @Test
+    fun `on get called twice, follows are replaced not merged`() = runTest {
+        val page1 =
+            listOf(
+                followData(sourceFid = "user:user-1", targetFid = "user:user-2"),
+                followData(sourceFid = "user:user-3", targetFid = "user:user-4"),
+            )
+        val page2 = listOf(followData(sourceFid = "user:user-5", targetFid = "user:user-6"))
+        coEvery { feedsRepository.queryFollows(any()) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        followList.get()
+        followList.get()
+
+        assertEquals(page2, followList.state.follows.value)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialFollows = listOf(followData())
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FollowListStateImplTest.kt
@@ -43,7 +43,7 @@ internal class FollowListStateImplTest {
         val follows = listOf(followData(), followData("user-2", "user-3"))
         val paginationResult = defaultPaginationResult(follows)
 
-        followListState.onQueryMoreFollows(paginationResult, queryConfig)
+        followListState.onQueryFollows(paginationResult, queryConfig)
 
         assertEquals(follows, followListState.follows.value)
         assertEquals("next-cursor", followListState.pagination?.next)
@@ -54,7 +54,7 @@ internal class FollowListStateImplTest {
     fun `on followUpserted, then update specific follow`() = runTest {
         val initialFollows = listOf(followData(), followData("user-2", "user-3"))
         val paginationResult = defaultPaginationResult(initialFollows)
-        followListState.onQueryMoreFollows(paginationResult, queryConfig)
+        followListState.onQueryFollows(paginationResult, queryConfig)
 
         val updatedFollow =
             followData(sourceFid = "user:user-1", targetFid = "user:user-2", createdAt = 1000)
@@ -71,7 +71,7 @@ internal class FollowListStateImplTest {
         val follow2 = followData("user-2", "user-3", createdAt = 1000)
         val initialFollows = listOf(follow1, follow2)
         val paginationResult = defaultPaginationResult(initialFollows)
-        followListState.onQueryMoreFollows(paginationResult, queryConfig)
+        followListState.onQueryFollows(paginationResult, queryConfig)
 
         val newFollow = followData("user-4", "user-5", createdAt = 1500)
         followListState.onFollowUpserted(newFollow)
@@ -85,7 +85,7 @@ internal class FollowListStateImplTest {
     fun `on followRemoved, then remove specific follow`() = runTest {
         val initialFollows = listOf(followData(), followData("user-2", "user-3"))
         val paginationResult = defaultPaginationResult(initialFollows)
-        followListState.onQueryMoreFollows(paginationResult, queryConfig)
+        followListState.onQueryFollows(paginationResult, queryConfig)
 
         followListState.onFollowRemoved(initialFollows[0])
 
@@ -101,7 +101,7 @@ internal class FollowListStateImplTest {
             val follow3 = followData("user-3", "user-4", createdAt = 1000)
             val initialFollows = listOf(follow1, follow2, follow3)
             val paginationResult = defaultPaginationResult(initialFollows)
-            followListState.onQueryMoreFollows(paginationResult, queryConfig)
+            followListState.onQueryFollows(paginationResult, queryConfig)
 
             val newFollow = followData("user-5", "user-6", createdAt = 2500)
             val updatedFollow2 = follow2.copy(pushPreference = "disabled")

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/MemberListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/MemberListImplTest.kt
@@ -105,6 +105,22 @@ internal class MemberListImplTest {
         coVerify { feedsRepository.queryFeedMembers(any(), any(), any()) }
     }
 
+    @Test
+    fun `on get called twice, members are replaced not merged`() = runTest {
+        val page1 = listOf(feedMemberData(), feedMemberData())
+        val page2 = listOf(feedMemberData())
+        coEvery { feedsRepository.queryFeedMembers(any(), any(), any()) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        memberList.get()
+        memberList.get()
+
+        assertEquals(1, memberList.state.members.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialMembers = listOf(feedMemberData())
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/MemberListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/MemberListStateImplTest.kt
@@ -45,7 +45,7 @@ internal class MemberListStateImplTest {
         val members = listOf(feedMemberData(), feedMemberData("user-2"))
         val paginationResult = defaultPaginationResult(members)
 
-        memberListState.onQueryMoreMembers(paginationResult, queryConfig)
+        memberListState.onQueryMembers(paginationResult, queryConfig)
 
         assertEquals(members, memberListState.members.value)
         assertEquals("next-cursor", memberListState.pagination?.next)
@@ -153,7 +153,7 @@ internal class MemberListStateImplTest {
     }
 
     private fun setupInitialState(members: List<FeedMemberData>) {
-        memberListState.onQueryMoreMembers(defaultPaginationResult(members), queryConfig)
+        memberListState.onQueryMembers(defaultPaginationResult(members), queryConfig)
     }
 
     companion object {

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListImplTest.kt
@@ -111,6 +111,24 @@ internal class ModerationConfigListImplTest {
         coVerify { moderationRepository.queryModerationConfigs(any<ModerationConfigsQuery>()) }
     }
 
+    @Test
+    fun `on get called twice, configs are replaced not merged`() = runTest {
+        val page1 =
+            listOf(moderationConfigData(), moderationConfigData(key = "config-2", team = "team-2"))
+        val page2 = listOf(moderationConfigData(key = "config-3", team = "team-3"))
+        val pagination = PaginationData(next = null, previous = null)
+        coEvery { moderationRepository.queryModerationConfigs(query) } returnsMany
+            listOf(
+                Result.success(PaginationResult(models = page1, pagination = pagination)),
+                Result.success(PaginationResult(models = page2, pagination = pagination)),
+            )
+
+        moderationConfigList.get()
+        moderationConfigList.get()
+
+        assertEquals(page2, moderationConfigList.state.configs.value)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialConfigs = listOf(moderationConfigData())
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/ModerationConfigListStateImplTest.kt
@@ -38,11 +38,11 @@ internal class ModerationConfigListStateImplTest {
     }
 
     @Test
-    fun `on loadMoreConfigs, then update configs and pagination`() = runTest {
+    fun `on loadConfigs, then update configs and pagination`() = runTest {
         val configs = listOf(moderationConfigData(), moderationConfigData("config-2", "team-2"))
         val paginationResult = defaultPaginationResult(configs)
 
-        moderationConfigListState.onLoadMoreConfigs(paginationResult, queryConfig)
+        moderationConfigListState.onLoadConfigs(paginationResult, queryConfig)
 
         assertEquals(configs, moderationConfigListState.configs.value)
         assertEquals("next-cursor", moderationConfigListState.pagination?.next)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollListImplTest.kt
@@ -102,6 +102,22 @@ internal class PollListImplTest {
         coVerify { pollsRepository.queryPolls(any()) }
     }
 
+    @Test
+    fun `on get called twice, polls are replaced not merged`() = runTest {
+        val page1 = listOf(pollData("poll-1", "Test Poll"), pollData("poll-2", "Test Poll 2"))
+        val page2 = listOf(pollData("poll-3", "Test Poll 3"))
+        coEvery { pollsRepository.queryPolls(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        pollList.get()
+        pollList.get()
+
+        assertEquals(1, pollList.state.polls.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialPolls = listOf(pollData("poll-1", "Test Poll"))
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollListStateImplTest.kt
@@ -40,11 +40,11 @@ internal class PollListStateImplTest {
     }
 
     @Test
-    fun `on queryMorePolls, then update polls and pagination`() = runTest {
+    fun `on queryPolls, then update polls and pagination`() = runTest {
         val polls = defaultPolls
         val paginationResult = defaultPaginationResult(polls)
 
-        pollListState.onQueryMorePolls(paginationResult, queryConfig)
+        pollListState.onQueryPolls(paginationResult, queryConfig)
 
         assertEquals(polls, pollListState.polls.value)
         assertEquals("next-cursor", pollListState.pagination?.next)
@@ -169,7 +169,7 @@ internal class PollListStateImplTest {
 
     private fun setupInitialState(polls: List<PollData> = defaultPolls): List<PollData> {
         val paginationResult = defaultPaginationResult(polls)
-        pollListState.onQueryMorePolls(paginationResult, queryConfig)
+        pollListState.onQueryPolls(paginationResult, queryConfig)
         return polls
     }
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListImplTest.kt
@@ -107,6 +107,22 @@ internal class PollVoteListImplTest {
         coVerify { pollsRepository.queryPollVotes(any()) }
     }
 
+    @Test
+    fun `on get called twice, votes are replaced not merged`() = runTest {
+        val page1 = listOf(pollVoteData(), pollVoteData("vote-2", "poll-1", "option-2", "user-2"))
+        val page2 = listOf(pollVoteData("vote-3", "poll-1", "option-3", "user-3"))
+        coEvery { pollsRepository.queryPollVotes(query) } returnsMany
+            listOf(
+                Result.success(createPaginationResult(page1)),
+                Result.success(createPaginationResult(page2)),
+            )
+
+        pollVoteList.get()
+        pollVoteList.get()
+
+        assertEquals(1, pollVoteList.state.votes.value.size)
+    }
+
     private suspend fun setupInitialState(nextCursor: String? = "next-cursor") {
         val initialVotes = listOf(pollVoteData())
         val initialPaginationResult =

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/PollVoteListStateImplTest.kt
@@ -38,11 +38,11 @@ internal class PollVoteListStateImplTest {
     }
 
     @Test
-    fun `on queryMorePollVotes, then update votes and pagination`() = runTest {
+    fun `on queryPollVotes, then update votes and pagination`() = runTest {
         val votes = listOf(pollVoteData(), pollVoteData("vote-2", "poll-1", "option-2", "user-2"))
         val paginationResult = defaultPaginationResult(votes)
 
-        pollVoteListState.onQueryMorePollVotes(paginationResult, queryConfig)
+        pollVoteListState.onQueryPollVotes(paginationResult, queryConfig)
 
         assertEquals(votes, pollVoteListState.votes.value)
         assertEquals("next-cursor", pollVoteListState.pagination?.next)
@@ -54,7 +54,7 @@ internal class PollVoteListStateImplTest {
         val initialVotes =
             listOf(pollVoteData(), pollVoteData("vote-2", "poll-1", "option-2", "user-2"))
         val paginationResult = defaultPaginationResult(initialVotes)
-        pollVoteListState.onQueryMorePollVotes(paginationResult, queryConfig)
+        pollVoteListState.onQueryPollVotes(paginationResult, queryConfig)
 
         pollVoteListState.pollVoteRemoved(initialVotes.first().id)
 
@@ -67,7 +67,7 @@ internal class PollVoteListStateImplTest {
         val initial =
             listOf(pollVoteData("vote-1"), pollVoteData("vote-3", "poll-1", "option-3", "user-3"))
         val pagination = defaultPaginationResult(initial)
-        pollVoteListState.onQueryMorePollVotes(pagination, queryConfig)
+        pollVoteListState.onQueryPollVotes(pagination, queryConfig)
 
         val newVote = pollVoteData("vote-2", "poll-1", "option-2", "user-2")
         pollVoteListState.pollVoteUpserted(newVote)
@@ -81,7 +81,7 @@ internal class PollVoteListStateImplTest {
         val initial =
             pollVoteData("vote-1", "poll-1", "option-1", "user-1", answerText = "Original")
         val pagination = defaultPaginationResult(listOf(initial))
-        pollVoteListState.onQueryMorePollVotes(pagination, queryConfig)
+        pollVoteListState.onQueryPollVotes(pagination, queryConfig)
 
         val updated = pollVoteData("vote-1", "poll-1", "option-1", "user-1", answerText = "Updated")
         pollVoteListState.pollVoteUpserted(updated)
@@ -94,7 +94,7 @@ internal class PollVoteListStateImplTest {
         val votes = listOf(pollVoteData(), pollVoteData("vote-2", "poll-1", "option-2", "user-2"))
         val paginationResult = defaultPaginationResult(votes)
 
-        pollVoteListState.onQueryMorePollVotes(paginationResult, queryConfig)
+        pollVoteListState.onQueryPollVotes(paginationResult, queryConfig)
         pollVoteListState.onPollDeleted()
 
         assertEquals(emptyList<PollVoteData>(), pollVoteListState.votes.value)

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/UserListStateImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/UserListStateImplTest.kt
@@ -36,10 +36,10 @@ internal class UserListStateImplTest {
     }
 
     @Test
-    fun `on queryUsers, then replace users and set offset`() = runTest {
+    fun `on queryUsers with replace, then replace users and set offset`() = runTest {
         val users = List(10) { userData("user-$it") }
 
-        state.onQueryUsers(users)
+        state.onQueryUsers(users, replace = true)
 
         assertEquals(users, state.users.value)
         assertTrue(state.canLoadMore)
@@ -47,12 +47,12 @@ internal class UserListStateImplTest {
     }
 
     @Test
-    fun `on queryUsers called twice, then replace users and reset offset`() = runTest {
+    fun `on queryUsers with replace called twice, then replace users and reset offset`() = runTest {
         val firstPage = List(10) { userData("user-$it") }
         val secondPage = List(5) { userData("user-$it") }
 
-        state.onQueryUsers(firstPage)
-        state.onQueryUsers(secondPage)
+        state.onQueryUsers(firstPage, replace = true)
+        state.onQueryUsers(secondPage, replace = true)
 
         assertEquals(secondPage, state.users.value)
         assertTrue(state.canLoadMore)
@@ -60,8 +60,8 @@ internal class UserListStateImplTest {
     }
 
     @Test
-    fun `on queryUsers with empty result, then canLoadMore false`() = runTest {
-        state.onQueryUsers(emptyList())
+    fun `on queryUsers with replace and empty result, then canLoadMore false`() = runTest {
+        state.onQueryUsers(emptyList(), replace = true)
 
         assertFalse(state.canLoadMore)
         assertEquals(0, state.currentOffset)
@@ -72,7 +72,7 @@ internal class UserListStateImplTest {
         runTest {
             val users = List(10) { userData("user-$it") }
 
-            state.onQueryMoreUsers(users)
+            state.onQueryUsers(users)
 
             assertEquals(users, state.users.value)
             assertTrue(state.canLoadMore)
@@ -81,7 +81,7 @@ internal class UserListStateImplTest {
 
     @Test
     fun `on queryMoreUsers with empty result, then canLoadMore false`() = runTest {
-        state.onQueryMoreUsers(emptyList())
+        state.onQueryUsers(emptyList())
 
         assertFalse(state.canLoadMore)
         assertEquals(0, state.currentOffset)
@@ -92,8 +92,8 @@ internal class UserListStateImplTest {
         val firstPage = List(10) { userData("user-$it") }
         val secondPage = List(5) { userData("user-${10 + it}") }
 
-        state.onQueryMoreUsers(firstPage)
-        state.onQueryMoreUsers(secondPage)
+        state.onQueryUsers(firstPage)
+        state.onQueryUsers(secondPage)
 
         assertEquals(15, state.users.value.size)
         assertTrue(state.canLoadMore)


### PR DESCRIPTION
### Goal

Fix `get()` not resetting the list state when called multiple times. Previously, calling `get()` would merge results with the existing state instead of replacing it, potentially resulting in stale or duplicated items.

### Implementation

- Add a `replace` parameter to the internal `onQuery*` methods across all paginated list state implementations
- Pass `replace = true` from `get()` so the state is fully reset, and `replace = false` (default) from `queryMore*()` to preserve the existing merge behavior
- Rename `onQueryMore*` to `onQuery*` in all list state interfaces to reflect their broader responsibility

### Testing

- Adapted existing unit tests across all list types for the renamed `onQuery*` methods and the new `replace` parameter
- Added tests to verify the behavior on consecutive `get()` calls

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management for feeds, comments, reactions, bookmarks, polls, users, and related list-based content. Lists now properly refresh with current data while maintaining correct pagination behavior, preventing data duplication issues and ensuring accurate content display after refreshes and user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->