### PR TITLE
Expose missing operations on existing entities

### DIFF
--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/FeedsClient.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/FeedsClient.kt
@@ -25,6 +25,7 @@ import io.getstream.feeds.android.client.api.file.FeedUploader
 import io.getstream.feeds.android.client.api.model.ActivityData
 import io.getstream.feeds.android.client.api.model.AppData
 import io.getstream.feeds.android.client.api.model.BatchFollowData
+import io.getstream.feeds.android.client.api.model.BookmarkFolderData
 import io.getstream.feeds.android.client.api.model.CollectionData
 import io.getstream.feeds.android.client.api.model.FeedId
 import io.getstream.feeds.android.client.api.model.FeedsConfig
@@ -77,6 +78,7 @@ import io.getstream.feeds.android.network.models.FollowBatchRequest
 import io.getstream.feeds.android.network.models.GetOGResponse
 import io.getstream.feeds.android.network.models.ListDevicesResponse
 import io.getstream.feeds.android.network.models.UnfollowBatchRequest
+import io.getstream.feeds.android.network.models.UpdateBookmarkFolderRequest
 import io.getstream.feeds.android.network.models.UpdateCollectionsRequest
 import io.getstream.feeds.android.network.models.UpsertPushPreferencesRequest
 import io.getstream.feeds.android.network.models.UpsertPushPreferencesResponse
@@ -317,6 +319,27 @@ public interface FeedsClient {
      *   bookmark folders.
      */
     public fun bookmarkFolderList(query: BookmarkFoldersQuery): BookmarkFolderList
+
+    /**
+     * Updates a bookmark folder by its ID.
+     *
+     * @param folderId The unique identifier of the bookmark folder to update.
+     * @param request The request containing the updated folder data.
+     * @return A [Result] containing the updated [BookmarkFolderData] if successful, or an error if
+     *   the operation fails.
+     */
+    public suspend fun updateBookmarkFolder(
+        folderId: String,
+        request: UpdateBookmarkFolderRequest,
+    ): Result<BookmarkFolderData>
+
+    /**
+     * Deletes a bookmark folder by its ID. All bookmarks in the folder will also be deleted.
+     *
+     * @param folderId The unique identifier of the bookmark folder to delete.
+     * @return A [Result] indicating success or failure of the deletion operation.
+     */
+    public suspend fun deleteBookmarkFolder(folderId: String): Result<Unit>
 
     /**
      * Creates a comment list instance based on the provided query.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/Feed.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/Feed.kt
@@ -41,6 +41,7 @@ import io.getstream.feeds.android.network.models.UpdateBookmarkRequest
 import io.getstream.feeds.android.network.models.UpdateCommentRequest
 import io.getstream.feeds.android.network.models.UpdateFeedMembersRequest
 import io.getstream.feeds.android.network.models.UpdateFeedRequest
+import io.getstream.feeds.android.network.models.UpdateFollowRequest
 
 /**
  * A feed represents a collection of activities and provides methods to interact with them.
@@ -165,6 +166,18 @@ public interface Feed {
         hardDelete: Boolean = false,
         deleteNotificationActivity: Boolean? = null,
     ): Result<Unit>
+
+    /**
+     * Restores a soft-deleted activity.
+     *
+     * Only the activity owner can restore their own activities (for client-side requests).
+     * Hard-deleted activities cannot be restored.
+     *
+     * @param id The unique identifier of the activity to restore.
+     * @return A [Result] containing the restored [ActivityData] if successful, or an error if the
+     *   operation fails.
+     */
+    public suspend fun restoreActivity(id: String): Result<ActivityData>
 
     /**
      * Marks an activity as read or unread.
@@ -326,6 +339,21 @@ public interface Feed {
         createNotificationActivity: Boolean? = null,
         custom: Map<String, Any>? = null,
         pushPreference: FollowRequest.PushPreference? = null,
+    ): Result<FollowData>
+
+    /**
+     * Updates a follow relationship with new custom data or push preferences.
+     *
+     * @param targetFid The target feed identifier of the follow to update.
+     * @param custom Additional data for the follow relationship.
+     * @param pushPreference Push notification preferences for the follow.
+     * @return A [Result] containing the updated [FollowData] if successful, or an error if the
+     *   operation fails.
+     */
+    public suspend fun updateFollow(
+        targetFid: FeedId,
+        custom: Map<String, Any>? = null,
+        pushPreference: UpdateFollowRequest.PushPreference? = null,
     ): Result<FollowData>
 
     /**

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/client/FeedsClientImpl.kt
@@ -29,6 +29,7 @@ import io.getstream.feeds.android.client.api.Moderation
 import io.getstream.feeds.android.client.api.file.FeedUploader
 import io.getstream.feeds.android.client.api.model.ActivityData
 import io.getstream.feeds.android.client.api.model.BatchFollowData
+import io.getstream.feeds.android.client.api.model.BookmarkFolderData
 import io.getstream.feeds.android.client.api.model.FeedId
 import io.getstream.feeds.android.client.api.model.FollowData
 import io.getstream.feeds.android.client.api.model.ModelUpdates
@@ -96,6 +97,7 @@ import io.getstream.feeds.android.client.internal.state.PollListImpl
 import io.getstream.feeds.android.client.internal.state.PollVoteListImpl
 import io.getstream.feeds.android.client.internal.state.UserListImpl
 import io.getstream.feeds.android.client.internal.state.event.StateEventEnricher
+import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent
 import io.getstream.feeds.android.client.internal.state.event.StateUpdateEvent.FollowBatchUpdate
 import io.getstream.feeds.android.client.internal.state.event.handler.OnNewActivity
 import io.getstream.feeds.android.client.internal.state.event.toModel
@@ -109,6 +111,7 @@ import io.getstream.feeds.android.network.models.DeleteActivitiesRequest
 import io.getstream.feeds.android.network.models.DeleteActivitiesResponse
 import io.getstream.feeds.android.network.models.FollowBatchRequest
 import io.getstream.feeds.android.network.models.UnfollowBatchRequest
+import io.getstream.feeds.android.network.models.UpdateBookmarkFolderRequest
 import io.getstream.feeds.android.network.models.WSEvent
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.BufferOverflow
@@ -307,6 +310,21 @@ internal class FeedsClientImpl(
             bookmarksRepository = bookmarksRepository,
             subscriptionManager = stateEventsSubscriptionManager,
         )
+
+    override suspend fun updateBookmarkFolder(
+        folderId: String,
+        request: UpdateBookmarkFolderRequest,
+    ): Result<BookmarkFolderData> {
+        return bookmarksRepository.updateBookmarkFolder(folderId, request).onSuccess {
+            stateEventsSubscriptionManager.onEvent(StateUpdateEvent.BookmarkFolderUpdated(it))
+        }
+    }
+
+    override suspend fun deleteBookmarkFolder(folderId: String): Result<Unit> {
+        return bookmarksRepository.deleteBookmarkFolder(folderId).onSuccess {
+            stateEventsSubscriptionManager.onEvent(StateUpdateEvent.BookmarkFolderDeleted(folderId))
+        }
+    }
 
     override fun commentList(query: CommentsQuery): CommentList =
         CommentListImpl(

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepository.kt
@@ -83,6 +83,14 @@ internal interface ActivitiesRepository {
     suspend fun deleteActivities(request: DeleteActivitiesRequest): Result<DeleteActivitiesResponse>
 
     /**
+     * Restores a soft-deleted activity.
+     *
+     * @param activityId The ID of the activity to restore.
+     * @return A [Result] containing the restored [ActivityData] or an error.
+     */
+    suspend fun restoreActivity(activityId: String): Result<ActivityData>
+
+    /**
      * Retrieves an activity by its ID.
      *
      * @param activityId The ID of the activity to retrieve.

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImpl.kt
@@ -92,6 +92,10 @@ internal class ActivitiesRepositoryImpl(
         request: DeleteActivitiesRequest
     ): Result<DeleteActivitiesResponse> = runSafely { api.deleteActivities(request) }
 
+    override suspend fun restoreActivity(activityId: String): Result<ActivityData> = runSafely {
+        api.restoreActivity(id = activityId).activity.toModel()
+    }
+
     override suspend fun getActivity(activityId: String): Result<ActivityData> = runSafely {
         api.getActivity(activityId).activity.toModel()
     }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/BookmarksRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/BookmarksRepository.kt
@@ -22,6 +22,7 @@ import io.getstream.feeds.android.client.api.state.query.BookmarkFoldersQuery
 import io.getstream.feeds.android.client.api.state.query.BookmarksQuery
 import io.getstream.feeds.android.client.internal.model.PaginationResult
 import io.getstream.feeds.android.network.models.AddBookmarkRequest
+import io.getstream.feeds.android.network.models.UpdateBookmarkFolderRequest
 import io.getstream.feeds.android.network.models.UpdateBookmarkRequest
 
 internal interface BookmarksRepository {
@@ -40,4 +41,11 @@ internal interface BookmarksRepository {
     suspend fun queryBookmarkFolders(
         query: BookmarkFoldersQuery
     ): Result<PaginationResult<BookmarkFolderData>>
+
+    suspend fun updateBookmarkFolder(
+        folderId: String,
+        request: UpdateBookmarkFolderRequest,
+    ): Result<BookmarkFolderData>
+
+    suspend fun deleteBookmarkFolder(folderId: String): Result<Unit>
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/BookmarksRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/BookmarksRepositoryImpl.kt
@@ -27,6 +27,7 @@ import io.getstream.feeds.android.client.internal.model.toModel
 import io.getstream.feeds.android.client.internal.state.query.toRequest
 import io.getstream.feeds.android.network.apis.FeedsApi
 import io.getstream.feeds.android.network.models.AddBookmarkRequest
+import io.getstream.feeds.android.network.models.UpdateBookmarkFolderRequest
 import io.getstream.feeds.android.network.models.UpdateBookmarkRequest
 
 /**
@@ -75,5 +76,16 @@ internal class BookmarksRepositoryImpl(private val api: FeedsApi) : BookmarksRep
             models = response.bookmarkFolders.map { it.toModel() },
             pagination = PaginationData(response.next, response.prev),
         )
+    }
+
+    override suspend fun updateBookmarkFolder(
+        folderId: String,
+        request: UpdateBookmarkFolderRequest,
+    ): Result<BookmarkFolderData> = runSafely {
+        api.updateBookmarkFolder(folderId, request).bookmarkFolder.toModel()
+    }
+
+    override suspend fun deleteBookmarkFolder(folderId: String): Result<Unit> = runSafely {
+        api.deleteBookmarkFolder(folderId)
     }
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepository.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepository.kt
@@ -40,6 +40,7 @@ import io.getstream.feeds.android.network.models.RejectFollowRequest
 import io.getstream.feeds.android.network.models.UnfollowBatchRequest
 import io.getstream.feeds.android.network.models.UpdateFeedMembersRequest
 import io.getstream.feeds.android.network.models.UpdateFeedRequest
+import io.getstream.feeds.android.network.models.UpdateFollowRequest
 
 /**
  * Represents the repository for managing feeds. Performs requests and transforms API models to
@@ -97,6 +98,8 @@ internal interface FeedsRepository {
     suspend fun acceptFollow(request: AcceptFollowRequest): Result<FollowData>
 
     suspend fun rejectFollow(request: RejectFollowRequest): Result<FollowData>
+
+    suspend fun updateFollow(request: UpdateFollowRequest): Result<FollowData>
 
     // END: Follows
 

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImpl.kt
@@ -44,6 +44,7 @@ import io.getstream.feeds.android.network.models.RejectFollowRequest
 import io.getstream.feeds.android.network.models.UnfollowBatchRequest
 import io.getstream.feeds.android.network.models.UpdateFeedMembersRequest
 import io.getstream.feeds.android.network.models.UpdateFeedRequest
+import io.getstream.feeds.android.network.models.UpdateFollowRequest
 
 /**
  * Default implementation of the [FeedsRepository] interface.
@@ -173,6 +174,11 @@ internal class FeedsRepositoryImpl(private val api: FeedsApi) : FeedsRepository 
     override suspend fun rejectFollow(request: RejectFollowRequest): Result<FollowData> =
         runSafely {
             api.rejectFollow(request).follow.toModel()
+        }
+
+    override suspend fun updateFollow(request: UpdateFollowRequest): Result<FollowData> =
+        runSafely {
+            api.updateFollow(request).follow.toModel()
         }
 
     override suspend fun updateFeedMembers(

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/internal/state/FeedImpl.kt
@@ -65,6 +65,7 @@ import io.getstream.feeds.android.network.models.UpdateBookmarkRequest
 import io.getstream.feeds.android.network.models.UpdateCommentRequest
 import io.getstream.feeds.android.network.models.UpdateFeedMembersRequest
 import io.getstream.feeds.android.network.models.UpdateFeedRequest
+import io.getstream.feeds.android.network.models.UpdateFollowRequest
 
 /**
  * A feed represents a collection of activities and provides methods to interact with them.
@@ -218,6 +219,10 @@ internal class FeedImpl(
             }
     }
 
+    override suspend fun restoreActivity(id: String): Result<ActivityData> {
+        return activitiesRepository.restoreActivity(id)
+    }
+
     override suspend fun markActivity(request: MarkActivityRequest): Result<Unit> {
         return activitiesRepository.markActivity(
             feedGroupId = group,
@@ -366,6 +371,23 @@ internal class FeedImpl(
             )
         return feedsRepository.follow(request).onSuccess {
             subscriptionManager.onEvent(StateUpdateEvent.FollowAdded(it))
+        }
+    }
+
+    override suspend fun updateFollow(
+        targetFid: FeedId,
+        custom: Map<String, Any>?,
+        pushPreference: UpdateFollowRequest.PushPreference?,
+    ): Result<FollowData> {
+        val request =
+            UpdateFollowRequest(
+                source = fid.rawValue,
+                target = targetFid.rawValue,
+                custom = custom,
+                pushPreference = pushPreference,
+            )
+        return feedsRepository.updateFollow(request).onSuccess {
+            subscriptionManager.onEvent(StateUpdateEvent.FollowUpdated(it))
         }
     }
 

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/ActivitiesRepositoryImplTest.kt
@@ -49,6 +49,7 @@ import io.getstream.feeds.android.network.models.MarkActivityRequest
 import io.getstream.feeds.android.network.models.QueryActivitiesResponse
 import io.getstream.feeds.android.network.models.QueryActivityReactionsRequest
 import io.getstream.feeds.android.network.models.QueryActivityReactionsResponse
+import io.getstream.feeds.android.network.models.RestoreActivityResponse
 import io.getstream.feeds.android.network.models.UpdateActivityPartialRequest
 import io.getstream.feeds.android.network.models.UpdateActivityPartialResponse
 import io.getstream.feeds.android.network.models.UpdateActivityRequest
@@ -334,6 +335,18 @@ internal class ActivitiesRepositoryImplTest {
             repositoryCall = { repository.activityFeedback("activityId", request) },
             apiResult = Unit,
             repositoryResult = Unit,
+        )
+    }
+
+    @Test
+    fun `on restoreActivity, delegate to api`() {
+        val apiResult = RestoreActivityResponse("duration", activityResponse())
+
+        testDelegation(
+            apiFunction = { feedsApi.restoreActivity("activityId") },
+            repositoryCall = { repository.restoreActivity("activityId") },
+            apiResult = apiResult,
+            repositoryResult = apiResult.activity.toModel(),
         )
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/BookmarksRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/BookmarksRepositoryImplTest.kt
@@ -31,6 +31,8 @@ import io.getstream.feeds.android.network.models.AddBookmarkResponse
 import io.getstream.feeds.android.network.models.DeleteBookmarkResponse
 import io.getstream.feeds.android.network.models.QueryBookmarkFoldersResponse
 import io.getstream.feeds.android.network.models.QueryBookmarksResponse
+import io.getstream.feeds.android.network.models.UpdateBookmarkFolderRequest
+import io.getstream.feeds.android.network.models.UpdateBookmarkFolderResponse
 import io.getstream.feeds.android.network.models.UpdateBookmarkRequest
 import io.getstream.feeds.android.network.models.UpdateBookmarkResponse
 import io.mockk.mockk
@@ -138,6 +140,29 @@ internal class BookmarksRepositoryImplTest {
                     models = listOf(bookmarkFolderResponse().toModel()),
                     pagination = PaginationData(next = "next", previous = "prev"),
                 ),
+        )
+    }
+
+    @Test
+    fun `on updateBookmarkFolder, delegate to api`() = runTest {
+        val request = UpdateBookmarkFolderRequest()
+        val apiResult = UpdateBookmarkFolderResponse("duration", bookmarkFolderResponse())
+
+        testDelegation(
+            apiFunction = { feedsApi.updateBookmarkFolder("folder-1", request) },
+            repositoryCall = { repository.updateBookmarkFolder("folder-1", request) },
+            apiResult = apiResult,
+            repositoryResult = apiResult.bookmarkFolder.toModel(),
+        )
+    }
+
+    @Test
+    fun `on deleteBookmarkFolder, delegate to api`() = runTest {
+        testDelegation(
+            apiFunction = { feedsApi.deleteBookmarkFolder("folder-1") },
+            repositoryCall = { repository.deleteBookmarkFolder("folder-1") },
+            apiResult = Unit,
+            repositoryResult = Unit,
         )
     }
 }

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/repository/FeedsRepositoryImplTest.kt
@@ -58,6 +58,8 @@ import io.getstream.feeds.android.network.models.UnfollowPair
 import io.getstream.feeds.android.network.models.UnfollowResponse
 import io.getstream.feeds.android.network.models.UpdateFeedMembersRequest
 import io.getstream.feeds.android.network.models.UpdateFeedRequest
+import io.getstream.feeds.android.network.models.UpdateFollowRequest
+import io.getstream.feeds.android.network.models.UpdateFollowResponse
 import io.mockk.mockk
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -230,6 +232,24 @@ internal class FeedsRepositoryImplTest {
         testDelegation(
             apiFunction = { feedsApi.rejectFollow(request) },
             repositoryCall = { repository.rejectFollow(request) },
+            apiResult = apiResult,
+            repositoryResult = apiResult.follow.toModel(),
+        )
+    }
+
+    @Test
+    fun `on updateFollow, delegate to api`() = runTest {
+        val request =
+            UpdateFollowRequest(
+                source = "source",
+                target = "target",
+                custom = mapOf("key" to "value"),
+            )
+        val apiResult = UpdateFollowResponse("duration", followResponse())
+
+        testDelegation(
+            apiFunction = { feedsApi.updateFollow(request) },
+            repositoryCall = { repository.updateFollow(request) },
             apiResult = apiResult,
             repositoryResult = apiResult.follow.toModel(),
         )

--- a/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
+++ b/stream-feeds-android-client/src/test/kotlin/io/getstream/feeds/android/client/internal/state/FeedImplTest.kt
@@ -70,6 +70,7 @@ import io.getstream.feeds.android.network.models.UpdateBookmarkRequest
 import io.getstream.feeds.android.network.models.UpdateCommentRequest
 import io.getstream.feeds.android.network.models.UpdateFeedMembersRequest
 import io.getstream.feeds.android.network.models.UpdateFeedRequest
+import io.getstream.feeds.android.network.models.UpdateFollowRequest
 import io.mockk.called
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -282,6 +283,20 @@ internal class FeedImplTest {
     }
 
     @Test
+    fun `on restoreActivity, delegate to repository`() = runTest {
+        val feed = createFeed()
+        val activityId = "activity-1"
+        val restoredActivity = activityData(activityId)
+
+        coEvery { activitiesRepository.restoreActivity(activityId) } returns
+            Result.success(restoredActivity)
+
+        val result = feed.restoreActivity(activityId)
+
+        assertEquals(restoredActivity, result.getOrNull())
+    }
+
+    @Test
     fun `on repost, delegate to repository and fire event`() = runTest {
         val feed = createFeed()
         val parentActivityId = "parent-activity"
@@ -399,6 +414,25 @@ internal class FeedImplTest {
 
         assertEquals(follow, result.getOrNull())
         assertEquals(listOf(follow), feed.state.followers.value)
+    }
+
+    @Test
+    fun `on updateFollow, delegate to repository and fire event`() = runTest {
+        val feed = createFeed()
+        val targetFid = FeedId("user:target")
+        val custom = mapOf("key" to "value")
+        val pushPreference = UpdateFollowRequest.PushPreference.All
+        val follow = followData(sourceFid = "group:id", targetFid = "user:target")
+
+        // Set up initial state with existing follow
+        setupInitialState(feed, following = listOf(follow))
+
+        coEvery { feedsRepository.updateFollow(any()) } returns Result.success(follow)
+
+        val result = feed.updateFollow(targetFid, custom, pushPreference)
+
+        assertEquals(follow, result.getOrNull())
+        verify { stateEventListener.onEvent(StateUpdateEvent.FollowUpdated(follow)) }
     }
 
     @Test


### PR DESCRIPTION
### Goal

Expose missing operations on existing entities: restore activity, update follow, update/delete bookmark folder.

### Implementation

- Add `restoreActivity(id)` to `Feed` for restoring soft-deleted activities
- Add `updateFollow(targetFid, custom, pushPreference)` to `Feed` for updating follow relationships
- Add `updateBookmarkFolder(folderId, request)` and `deleteBookmarkFolder(folderId)` to `FeedsClient`

### Testing

Added unit tests for all new operations across repository and state layers.

For testing manually, you'd need to add some code to the sample to exercise the new operations (e.g. in `FeedViewModel`),  as none are currently implemented in the sample.

### Checklist
- [ ] Issue linked (if any)
- [x] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bookmark folder management: update existing bookmark folders with new details and delete folders as needed
  * Activity restoration: recover and restore previously soft-deleted activities back to your feed
  * Enhanced follow relationships: update follows with support for custom data and granular push notification preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->