### PR TITLE
Add dependabot configuration to bump Stream conventions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "pr:ci"
+
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: daily
+    labels:
+      - "pr:ci"
+    allow:
+      - dependency-name: "io.getstream.project"
+      - dependency-name: "io.getstream.android.library"
+      - dependency-name: "io.getstream.android.application"
+      - dependency-name: "io.getstream.android.test"
+      - dependency-name: "io.getstream.java.library"
+      - dependency-name: "io.getstream.java.platform"
+      - dependency-name: "io.getstream.publish"


### PR DESCRIPTION
### Goal

Add dependabot configuration so that PRs bumping Stream conventions will be created automatically by dependabot.

### Implementation

Add `.github/dependabot.yml` with configuration to only update workflows/actions & stream plugins

### Testing

We'll enable dependabot in the repo settings & check that PRs are opened properly

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured automated daily dependency update checks for GitHub Actions and Gradle ecosystem dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->