### PR TITLE
Add workflow to publish snapshots

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,27 @@
+name: Publish Snapshot builds
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+concurrency:
+  group: snapshot-release
+  cancel-in-progress: false
+
+jobs:
+  release:
+    permissions:
+      contents: write
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.11.0
+    with:
+      bump: patch
+      snapshot: true
+    secrets:
+      github-token: ${{ secrets.STREAM_PUBLIC_BOT_TOKEN }}
+      maven-central-username: ${{ secrets.OSSRH_USERNAME }}
+      maven-central-password: ${{ secrets.OSSRH_PASSWORD }}
+      signing-key: ${{ secrets.SIGNING_KEY }}
+      signing-key-id: ${{ secrets.SIGNING_KEY_ID }}
+      signing-key-password: ${{ secrets.SIGNING_PASSWORD }}


### PR DESCRIPTION
### Goal

We have it in other products, but never added it to Feeds

### Implementation

Add workflow file 

### Testing

The snapshot should be published as soon as we merge this PR into develop

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
