### PR TITLE
Set required permissions for the SDK size checks

### DIFF
--- a/.github/workflows/pr-clean-stale.yaml
+++ b/.github/workflows/pr-clean-stale.yaml
@@ -8,7 +8,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  issues: write
 
 jobs:
   pr-clean-stale:

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -7,7 +7,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -3,6 +3,10 @@ name: SDK size checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
### Goal

SDK size & DB entities checks need write permissions for writing comments, so we're adding the relevant permission block. Up until now, this didn't cause problems because the token we're using has those permissions, but that doesn't work for Dependabot PRs. [They receive a read-only token](https://docs.github.com/en/code-security/reference/supply-chain-security/troubleshoot-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows) unless we declare permissions, which is why the corresponding failures in https://github.com/GetStream/stream-chat-android/pull/6394.

### Implementation

Add the permissions block

### Testing

The SDK size check should succeed in Dependabot's PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow permissions configuration for enhanced security practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->