### PR TITLE
Remove closed alpha note from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,6 @@ use it.
 For detailed examples and supported features, please check out
 our [docs](https://getstream.io/activity-feeds/docs/android/).
 
-Note: Activity Feeds V3 is in closed alpha — do not use it in production (just yet).
-
 ## What is Stream?
 
 Stream allows developers to rapidly deploy scalable feeds, chat messaging and video with an industry leading 99.999%
@@ -147,7 +145,7 @@ and < $10k in monthly revenue. Makers get $100 in monthly credit for video for f
 
 ## License
 
-Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
 
 Licensed under the Stream License;
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Goal

While working on the AI agents skill for Feeds, I realized we never removed the note about the product being closed alpha, which isn't anymore.

### Implementation

Remove line. Also bump copyright year.

### Testing

Check the readme 

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
