### PR TITLE
Bump Stream conventions to v0.12.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@ updates:
       interval: daily
     labels:
       - "pr:ci"
+    groups:
+      stream-conventions:
+        patterns:
+          - "GetStream/stream-build-conventions-android"
 
   - package-ecosystem: gradle
     directory: /
@@ -21,3 +25,7 @@ updates:
       - dependency-name: "io.getstream.java.library"
       - dependency-name: "io.getstream.java.platform"
       - dependency-name: "io.getstream.publish"
+    groups:
+      stream-conventions:
+        patterns:
+          - "io.getstream.*"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.11.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.12.0
     secrets: inherit
     with:
       api-check: false

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.12.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.12.1
     secrets: inherit
     with:
       api-check: false

--- a/.github/workflows/pr-clean-stale.yaml
+++ b/.github/workflows/pr-clean-stale.yaml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   pr-clean-stale:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.11.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.12.0
     secrets: inherit

--- a/.github/workflows/pr-clean-stale.yaml
+++ b/.github/workflows/pr-clean-stale.yaml
@@ -11,5 +11,5 @@ permissions:
 
 jobs:
   pr-clean-stale:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.12.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-clean-stale.yaml@v0.12.1
     secrets: inherit

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -14,5 +14,5 @@ concurrency:
 
 jobs:
   pr-checklist:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.12.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.12.1
     secrets: inherit

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -14,5 +14,5 @@ concurrency:
 
 jobs:
   pr-checklist:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.11.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.12.0
     secrets: inherit

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     needs: pre_release_check
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.11.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.12.0
     with:
       bump: ${{ inputs.bump }}
     secrets:

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -40,3 +40,4 @@ jobs:
       signing-key: ${{ secrets.SIGNING_KEY }}
       signing-key-id: ${{ secrets.SIGNING_KEY_ID }}
       signing-key-password: ${{ secrets.SIGNING_PASSWORD }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_ANDROID_CICD }}

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -30,7 +30,7 @@ jobs:
     permissions:
       contents: write
     needs: pre_release_check
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.12.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.12.1
     with:
       bump: ${{ inputs.bump }}
     secrets:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     permissions:
       contents: write
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.12.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.12.1
     with:
       bump: patch
       snapshot: true

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -14,7 +14,7 @@ jobs:
   release:
     permissions:
       contents: write
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.11.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.12.0
     with:
       bump: patch
       snapshot: true

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -25,3 +25,4 @@ jobs:
       signing-key: ${{ secrets.SIGNING_KEY }}
       signing-key-id: ${{ secrets.SIGNING_KEY_ID }}
       signing-key-password: ${{ secrets.SIGNING_PASSWORD }}
+      slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_ANDROID_CICD }}

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   compare-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-checks.yml@v0.12.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-checks.yml@v0.12.1
     with:
       modules: "stream-feeds-android-client"
       metrics-project: "stream-feeds-android-metrics"

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   compare-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-checks.yml@v0.11.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-checks.yml@v0.12.0
     with:
       modules: "stream-feeds-android-client"
       metrics-project: "stream-feeds-android-metrics"

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   update-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.12.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.12.1
     with:
       modules: "stream-feeds-android-client"
       metrics-project: "stream-feeds-android-metrics"

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   update-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.11.0
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.12.0
     with:
       modules: "stream-feeds-android-client"
       metrics-project: "stream-feeds-android-metrics"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ streamAndroidCore = "4.0.0"
 symbolProcessingApi = "2.2.0-2.0.2"
 lifecycleProcess = "2.9.1"
 lifecycleViewModelCompose = "2.4.0"
-streamConventions = "0.12.0"
+streamConventions = "0.12.1"
 turbine = "1.2.1"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ streamAndroidCore = "4.0.0"
 symbolProcessingApi = "2.2.0-2.0.2"
 lifecycleProcess = "2.9.1"
 lifecycleViewModelCompose = "2.4.0"
-streamConventions = "0.11.0"
+streamConventions = "0.12.0"
 turbine = "1.2.1"
 
 [libraries]


### PR DESCRIPTION
### Goal

Pick up build-conventions v0.12.1. v0.12.0 made `slack-webhook-url` a required input on `release.yml`; v0.12.1 dropped an unused `issues: write` permission from a few reusable workflows. Also configure Dependabot to bundle all `stream-build-conventions-android` bumps into one PR.

### Implementation

- `streamConventions` 0.11.0 → 0.12.1 in `gradle/libs.versions.toml`.
- All `GetStream/stream-build-conventions-android/.github/workflows/...@v0.11.0` refs → `@v0.12.1`.
- Pass `slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_ANDROID_CICD }}` to `release.yml` in `publish-new-version.yml` and `publish-snapshot.yml`.
- Add `groups.stream-conventions` to both ecosystems in `.github/dependabot.yml`.

### Testing

- Yaml validation via the PR-quality workflow.
- Slack notifications and grouped Dependabot PRs validated on the next runs.

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)
