### PR TITLE
Introduce API check and fill in missing KDoc

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -20,5 +20,3 @@ jobs:
   android-ci:
     uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.12.1
     secrets: inherit
-    with:
-      api-check: false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.arturbosch.detekt) apply true
+    alias(libs.plugins.binary.compatibility.validator)
     id("com.google.gms.google-services") version "4.4.3" apply false
 }
 
@@ -33,4 +34,15 @@ detekt {
     toolVersion = "1.23.8"
     config.setFrom(file("config/detekt/detekt.yml"))
     buildUponDefaultConfig = true
+}
+
+apiValidation {
+    ignoredProjects += listOf(
+        "stream-feeds-android-sample",
+        "stream-feeds-android-metrics",
+    )
+
+    nonPublicMarkers += listOf(
+        "io.getstream.android.core.annotations.StreamInternalApi",
+    )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ firebaseBom = "33.16.0"
 hilt = "2.57"
 hiltNavigationCompose = "1.2.0"
 kotlin = "2.2.0"
+kotlinBinaryValidator = "0.16.3"
 kotlinxCoroutines = "1.10.2"
 kotlinpoet = "2.2.0"
 ksp = "2.2.0-2.0.2"
@@ -98,6 +99,7 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 arturbosch-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
+binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version.ref = "kotlinBinaryValidator" }
 stream-project = { id = "io.getstream.project", version.ref = "streamConventions" }
 stream-android-library = { id = "io.getstream.android.library", version.ref = "streamConventions" }
 stream-android-application = { id = "io.getstream.android.application", version.ref = "streamConventions" }

--- a/stream-feeds-android-client/api/stream-feeds-android-client.api
+++ b/stream-feeds-android-client/api/stream-feeds-android-client.api
@@ -1,0 +1,3044 @@
+public abstract interface class io/getstream/android/core/network/NetworkStateProvider$NetworkStateListener {
+	public abstract fun onConnected (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onDisconnected (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/getstream/android/core/result/ResultUtilsKt {
+	public static final fun runSafely (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/BuildConfig {
+	public static final field BUILD_TYPE Ljava/lang/String;
+	public static final field DEBUG Z
+	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
+	public static final field PRODUCT_NAME Ljava/lang/String;
+	public static final field PRODUCT_VERSION Ljava/lang/String;
+	public fun <init> ()V
+}
+
+public final class io/getstream/feeds/android/client/GKt {
+	public static final field tag Ljava/lang/String;
+	public static final fun gol (Ljava/lang/Object;[Ljava/lang/Object;)V
+	public static final fun trace (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/FeedsClient {
+	public abstract fun activity (Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedId;)Lio/getstream/feeds/android/client/api/state/Activity;
+	public abstract fun activityCommentList (Lio/getstream/feeds/android/client/api/state/query/ActivityCommentsQuery;)Lio/getstream/feeds/android/client/api/state/ActivityCommentList;
+	public abstract fun activityFeedback-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityFeedbackRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun activityList (Lio/getstream/feeds/android/client/api/state/query/ActivitiesQuery;)Lio/getstream/feeds/android/client/api/state/ActivityList;
+	public abstract fun activityReactionList (Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsQuery;)Lio/getstream/feeds/android/client/api/state/ActivityReactionList;
+	public abstract fun addActivity-gIAlu-s (Lio/getstream/feeds/android/network/models/AddActivityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun bookmarkFolderList (Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersQuery;)Lio/getstream/feeds/android/client/api/state/BookmarkFolderList;
+	public abstract fun bookmarkList (Lio/getstream/feeds/android/client/api/state/query/BookmarksQuery;)Lio/getstream/feeds/android/client/api/state/BookmarkList;
+	public abstract fun commentList (Lio/getstream/feeds/android/client/api/state/query/CommentsQuery;)Lio/getstream/feeds/android/client/api/state/CommentList;
+	public abstract fun commentReactionList (Lio/getstream/feeds/android/client/api/state/query/CommentReactionsQuery;)Lio/getstream/feeds/android/client/api/state/CommentReactionList;
+	public abstract fun commentReplyList (Lio/getstream/feeds/android/client/api/state/query/CommentRepliesQuery;)Lio/getstream/feeds/android/client/api/state/CommentReplyList;
+	public abstract fun connect-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createCollections-gIAlu-s (Lio/getstream/feeds/android/network/models/CreateCollectionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createDevice-BWLJW6A (Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/PushNotificationsProvider;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteActivities-gIAlu-s (Lio/getstream/feeds/android/network/models/DeleteActivitiesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteBookmarkFolder-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteCollections-gIAlu-s (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteDevice-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteFile-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteImage-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun disconnect-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun feed (Lio/getstream/feeds/android/client/api/model/FeedId;Lkotlin/jvm/functions/Function3;)Lio/getstream/feeds/android/client/api/state/Feed;
+	public abstract fun feed (Lio/getstream/feeds/android/client/api/state/query/FeedQuery;Lkotlin/jvm/functions/Function3;)Lio/getstream/feeds/android/client/api/state/Feed;
+	public abstract fun feed (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function3;)Lio/getstream/feeds/android/client/api/state/Feed;
+	public static synthetic fun feed$default (Lio/getstream/feeds/android/client/api/FeedsClient;Lio/getstream/feeds/android/client/api/model/FeedId;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/Feed;
+	public static synthetic fun feed$default (Lio/getstream/feeds/android/client/api/FeedsClient;Lio/getstream/feeds/android/client/api/state/query/FeedQuery;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/Feed;
+	public static synthetic fun feed$default (Lio/getstream/feeds/android/client/api/FeedsClient;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/Feed;
+	public abstract fun feedList (Lio/getstream/feeds/android/client/api/state/query/FeedsQuery;)Lio/getstream/feeds/android/client/api/state/FeedList;
+	public abstract fun followList (Lio/getstream/feeds/android/client/api/state/query/FollowsQuery;)Lio/getstream/feeds/android/client/api/state/FollowList;
+	public abstract fun getApiKey-i8_L6so ()Ljava/lang/String;
+	public abstract fun getApp-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getEvents ()Lkotlinx/coroutines/flow/Flow;
+	public abstract fun getModeration ()Lio/getstream/feeds/android/client/api/Moderation;
+	public abstract fun getOG-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getOrCreateFollows-gIAlu-s (Lio/getstream/feeds/android/network/models/FollowBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getOrCreateUnfollows-gIAlu-s (Lio/getstream/feeds/android/network/models/UnfollowBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getState ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getUploader ()Lio/getstream/feeds/android/client/api/file/Uploader;
+	public abstract fun getUser ()Lio/getstream/feeds/android/client/api/model/User;
+	public abstract fun memberList (Lio/getstream/feeds/android/client/api/state/query/MembersQuery;)Lio/getstream/feeds/android/client/api/state/MemberList;
+	public abstract fun moderationConfigList (Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsQuery;)Lio/getstream/feeds/android/client/api/state/ModerationConfigList;
+	public abstract fun pollList (Lio/getstream/feeds/android/client/api/state/query/PollsQuery;)Lio/getstream/feeds/android/client/api/state/PollList;
+	public abstract fun pollVoteList (Lio/getstream/feeds/android/client/api/state/query/PollVotesQuery;)Lio/getstream/feeds/android/client/api/state/PollVoteList;
+	public abstract fun queryDevices-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun readCollections-gIAlu-s (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateBookmarkFolder-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateBookmarkFolderRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateCollections-gIAlu-s (Lio/getstream/feeds/android/network/models/UpdateCollectionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePushNotificationPreferences-gIAlu-s (Lio/getstream/feeds/android/network/models/UpsertPushPreferencesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun upsertActivities-gIAlu-s (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun userList (Lio/getstream/feeds/android/client/api/state/query/UsersQuery;)Lio/getstream/feeds/android/client/api/state/UserList;
+}
+
+public final class io/getstream/feeds/android/client/api/FeedsClient$DefaultImpls {
+	public static synthetic fun feed$default (Lio/getstream/feeds/android/client/api/FeedsClient;Lio/getstream/feeds/android/client/api/model/FeedId;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/Feed;
+	public static synthetic fun feed$default (Lio/getstream/feeds/android/client/api/FeedsClient;Lio/getstream/feeds/android/client/api/state/query/FeedQuery;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/Feed;
+	public static synthetic fun feed$default (Lio/getstream/feeds/android/client/api/FeedsClient;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/Feed;
+}
+
+public final class io/getstream/feeds/android/client/api/FeedsClientKt {
+	public static final fun FeedsClient-fI5YsnY (Landroid/content/Context;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/User;Lio/getstream/android/core/api/authentication/StreamTokenProvider;Lio/getstream/feeds/android/client/api/model/FeedsConfig;)Lio/getstream/feeds/android/client/api/FeedsClient;
+	public static synthetic fun FeedsClient-fI5YsnY$default (Landroid/content/Context;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/User;Lio/getstream/android/core/api/authentication/StreamTokenProvider;Lio/getstream/feeds/android/client/api/model/FeedsConfig;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/FeedsClient;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/Moderation {
+	public abstract fun ban-gIAlu-s (Lio/getstream/feeds/android/network/models/BanRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun blockUser-gIAlu-s (Lio/getstream/feeds/android/network/models/BlockUsersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteConfig-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteConfig-0E7RQCE$default (Lio/getstream/feeds/android/client/api/Moderation;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun flag-gIAlu-s (Lio/getstream/feeds/android/network/models/FlagRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getBlockedUsers-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getConfig-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getConfig-0E7RQCE$default (Lio/getstream/feeds/android/client/api/Moderation;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun mute-gIAlu-s (Lio/getstream/feeds/android/network/models/MuteRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryModerationConfigs-gIAlu-s (Lio/getstream/feeds/android/network/models/QueryModerationConfigsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryReviewQueue-gIAlu-s (Lio/getstream/feeds/android/network/models/QueryReviewQueueRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun submitAction-gIAlu-s (Lio/getstream/feeds/android/network/models/SubmitActionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun unblockUser-gIAlu-s (Lio/getstream/feeds/android/network/models/UnblockUsersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun upsertConfig-gIAlu-s (Lio/getstream/feeds/android/network/models/UpsertConfigRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/Moderation$DefaultImpls {
+	public static synthetic fun deleteConfig-0E7RQCE$default (Lio/getstream/feeds/android/client/api/Moderation;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getConfig-0E7RQCE$default (Lio/getstream/feeds/android/client/api/Moderation;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/file/EmptyFeedUploadContext : io/getstream/feeds/android/client/api/file/FeedUploadContext {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/file/EmptyFeedUploadContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/file/FeedUploadContext : io/getstream/feeds/android/client/api/file/UploadContext {
+}
+
+public final class io/getstream/feeds/android/client/api/file/FeedUploadContextKt {
+	public static final fun FeedUploadPayload (Ljava/io/File;Lio/getstream/feeds/android/client/api/file/FileType;)Lio/getstream/feeds/android/client/api/file/UploadPayload;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/file/FileType {
+}
+
+public final class io/getstream/feeds/android/client/api/file/FileType$Image : io/getstream/feeds/android/client/api/file/FileType {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/file/FileType$Image;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/file/FileType$Other : io/getstream/feeds/android/client/api/file/FileType {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/file/FileType$Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/file/UploadContext {
+}
+
+public final class io/getstream/feeds/android/client/api/file/UploadPayload {
+	public fun <init> (Ljava/io/File;Lio/getstream/feeds/android/client/api/file/FileType;Lio/getstream/feeds/android/client/api/file/UploadContext;)V
+	public final fun component1 ()Ljava/io/File;
+	public final fun component2 ()Lio/getstream/feeds/android/client/api/file/FileType;
+	public final fun component3 ()Lio/getstream/feeds/android/client/api/file/UploadContext;
+	public final fun copy (Ljava/io/File;Lio/getstream/feeds/android/client/api/file/FileType;Lio/getstream/feeds/android/client/api/file/UploadContext;)Lio/getstream/feeds/android/client/api/file/UploadPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/file/UploadPayload;Ljava/io/File;Lio/getstream/feeds/android/client/api/file/FileType;Lio/getstream/feeds/android/client/api/file/UploadContext;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/file/UploadPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContext ()Lio/getstream/feeds/android/client/api/file/UploadContext;
+	public final fun getFile ()Ljava/io/File;
+	public final fun getType ()Lio/getstream/feeds/android/client/api/file/FileType;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/file/UploadedFile {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/file/UploadedFile;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/file/UploadedFile;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/file/UploadedFile;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFileUrl ()Ljava/lang/String;
+	public final fun getThumbnailUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/file/Uploader {
+	public abstract fun upload-0E7RQCE (Lio/getstream/feeds/android/client/api/file/UploadPayload;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun upload-0E7RQCE$default (Lio/getstream/feeds/android/client/api/file/Uploader;Lio/getstream/feeds/android/client/api/file/UploadPayload;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/file/Uploader$DefaultImpls {
+	public static synthetic fun upload-0E7RQCE$default (Lio/getstream/feeds/android/client/api/file/Uploader;Lio/getstream/feeds/android/client/api/file/UploadPayload;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/logging/HttpLoggingLevel : java/lang/Enum {
+	public static final field Basic Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;
+	public static final field Body Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;
+	public static final field Headers Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;
+	public static final field None Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;
+	public static fun values ()[Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/logging/Logger {
+	public abstract fun log (Lio/getstream/feeds/android/client/api/logging/Logger$Level;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun log$default (Lio/getstream/feeds/android/client/api/logging/Logger;Lio/getstream/feeds/android/client/api/logging/Logger$Level;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/client/api/logging/Logger$DefaultImpls {
+	public static synthetic fun log$default (Lio/getstream/feeds/android/client/api/logging/Logger;Lio/getstream/feeds/android/client/api/logging/Logger$Level;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/client/api/logging/Logger$Level : java/lang/Enum {
+	public static final field Debug Lio/getstream/feeds/android/client/api/logging/Logger$Level;
+	public static final field Error Lio/getstream/feeds/android/client/api/logging/Logger$Level;
+	public static final field Info Lio/getstream/feeds/android/client/api/logging/Logger$Level;
+	public static final field Verbose Lio/getstream/feeds/android/client/api/logging/Logger$Level;
+	public static final field Warning Lio/getstream/feeds/android/client/api/logging/Logger$Level;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/logging/Logger$Level;
+	public static fun values ()[Lio/getstream/feeds/android/client/api/logging/Logger$Level;
+}
+
+public final class io/getstream/feeds/android/client/api/logging/LoggingConfig {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/feeds/android/client/api/logging/Logger;Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/client/api/logging/Logger;Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCustomLogger ()Lio/getstream/feeds/android/client/api/logging/Logger;
+	public final fun getHttpLoggingLevel ()Lio/getstream/feeds/android/client/api/logging/HttpLoggingLevel;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ActivityData {
+	public fun <init> (Ljava/util/List;ILjava/util/Map;ILjava/util/List;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;ZLjava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lio/getstream/feeds/android/network/models/Location;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Lio/getstream/feeds/android/network/models/NotificationContext;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/ActivityData;Lio/getstream/feeds/android/client/api/model/PollData;IZILjava/util/Map;Lio/getstream/feeds/android/client/api/model/RestrictReplies;FLjava/util/Map;Ljava/util/Map;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component11 ()Ljava/util/Date;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Z
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()I
+	public final fun component20 ()Ljava/lang/Boolean;
+	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Ljava/util/Map;
+	public final fun component26 ()Lio/getstream/feeds/android/client/api/model/Moderation;
+	public final fun component27 ()Ljava/lang/String;
+	public final fun component28 ()Lio/getstream/feeds/android/network/models/NotificationContext;
+	public final fun component29 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component30 ()Ljava/util/List;
+	public final fun component31 ()Lio/getstream/feeds/android/client/api/model/ActivityData;
+	public final fun component32 ()Lio/getstream/feeds/android/client/api/model/PollData;
+	public final fun component33 ()I
+	public final fun component34 ()Z
+	public final fun component35 ()I
+	public final fun component36 ()Ljava/util/Map;
+	public final fun component37 ()Lio/getstream/feeds/android/client/api/model/RestrictReplies;
+	public final fun component38 ()F
+	public final fun component39 ()Ljava/util/Map;
+	public final fun component4 ()I
+	public final fun component40 ()Ljava/util/Map;
+	public final fun component41 ()Ljava/lang/String;
+	public final fun component42 ()I
+	public final fun component43 ()Ljava/lang/String;
+	public final fun component44 ()Ljava/lang/String;
+	public final fun component45 ()Ljava/util/Date;
+	public final fun component46 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun component47 ()Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility;
+	public final fun component48 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Lio/getstream/feeds/android/client/api/model/FeedData;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/List;ILjava/util/Map;ILjava/util/List;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;ZLjava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lio/getstream/feeds/android/network/models/Location;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Lio/getstream/feeds/android/network/models/NotificationContext;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/ActivityData;Lio/getstream/feeds/android/client/api/model/PollData;IZILjava/util/Map;Lio/getstream/feeds/android/client/api/model/RestrictReplies;FLjava/util/Map;Ljava/util/Map;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/ActivityData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/ActivityData;Ljava/util/List;ILjava/util/Map;ILjava/util/List;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/lang/Integer;Ljava/util/List;ZLjava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Lio/getstream/feeds/android/network/models/Location;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Lio/getstream/feeds/android/network/models/NotificationContext;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/ActivityData;Lio/getstream/feeds/android/client/api/model/PollData;IZILjava/util/Map;Lio/getstream/feeds/android/client/api/model/RestrictReplies;FLjava/util/Map;Ljava/util/Map;Ljava/lang/String;ILjava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility;Ljava/lang/String;IILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/ActivityData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getBookmarkCount ()I
+	public final fun getCollections ()Ljava/util/Map;
+	public final fun getCommentCount ()I
+	public final fun getComments ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCurrentFeed ()Lio/getstream/feeds/android/client/api/model/FeedData;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getEditedAt ()Ljava/util/Date;
+	public final fun getExpiresAt ()Ljava/util/Date;
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getFriendReactionCount ()Ljava/lang/Integer;
+	public final fun getFriendReactions ()Ljava/util/List;
+	public final fun getHidden ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInterestTags ()Ljava/util/List;
+	public final fun getLatestReactions ()Ljava/util/List;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMentionedUsers ()Ljava/util/List;
+	public final fun getMetrics ()Ljava/util/Map;
+	public final fun getModeration ()Lio/getstream/feeds/android/client/api/model/Moderation;
+	public final fun getModerationAction ()Ljava/lang/String;
+	public final fun getNotificationContext ()Lio/getstream/feeds/android/network/models/NotificationContext;
+	public final fun getOwnBookmarks ()Ljava/util/List;
+	public final fun getOwnReactions ()Ljava/util/List;
+	public final fun getParent ()Lio/getstream/feeds/android/client/api/model/ActivityData;
+	public final fun getPoll ()Lio/getstream/feeds/android/client/api/model/PollData;
+	public final fun getPopularity ()I
+	public final fun getPreview ()Z
+	public final fun getReactionCount ()I
+	public final fun getReactionGroups ()Ljava/util/Map;
+	public final fun getRestrictReplies ()Lio/getstream/feeds/android/client/api/model/RestrictReplies;
+	public final fun getScore ()F
+	public final fun getScoreVars ()Ljava/util/Map;
+	public final fun getSearchData ()Ljava/util/Map;
+	public final fun getSelectorSource ()Ljava/lang/String;
+	public final fun getShareCount ()I
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun getVisibility ()Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility;
+	public final fun getVisibilityTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isRead ()Ljava/lang/Boolean;
+	public final fun isSeen ()Ljava/lang/Boolean;
+	public final fun isWatched ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/client/api/model/ActivityDataVisibility {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ActivityDataVisibility$Private : io/getstream/feeds/android/client/api/model/ActivityDataVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility$Private;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ActivityDataVisibility$Public : io/getstream/feeds/android/client/api/model/ActivityDataVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility$Public;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ActivityDataVisibility$Tag : io/getstream/feeds/android/client/api/model/ActivityDataVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility$Tag;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ActivityDataVisibility$Unknown : io/getstream/feeds/android/client/api/model/ActivityDataVisibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/ActivityDataVisibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ActivityPinData {
+	public fun <init> (Lio/getstream/feeds/android/client/api/model/ActivityData;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/Date;Ljava/lang/String;)V
+	public final fun component1 ()Lio/getstream/feeds/android/client/api/model/ActivityData;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/feeds/android/client/api/model/ActivityData;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/Date;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/ActivityPinData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/ActivityPinData;Lio/getstream/feeds/android/client/api/model/ActivityData;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/Date;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/ActivityPinData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/client/api/model/ActivityData;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getFid ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/AggregatedActivityData {
+	public fun <init> (Ljava/util/List;ILjava/util/Date;Ljava/lang/String;FLjava/util/Date;IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()F
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()I
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;ILjava/util/Date;Ljava/lang/String;FLjava/util/Date;IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/client/api/model/AggregatedActivityData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/AggregatedActivityData;Ljava/util/List;ILjava/util/Date;Ljava/lang/String;FLjava/util/Date;IZLjava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/AggregatedActivityData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivities ()Ljava/util/List;
+	public final fun getActivityCount ()I
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getScore ()F
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserCount ()I
+	public final fun getUserCountTruncated ()Z
+	public fun hashCode ()I
+	public final fun isRead ()Ljava/lang/Boolean;
+	public final fun isSeen ()Ljava/lang/Boolean;
+	public final fun isWatched ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/AppData {
+	public fun <init> (ZZLio/getstream/feeds/android/client/api/model/FileUploadConfigData;Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;Ljava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;
+	public final fun component4 ()Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (ZZLio/getstream/feeds/android/client/api/model/FileUploadConfigData;Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/AppData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/AppData;ZZLio/getstream/feeds/android/client/api/model/FileUploadConfigData;Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/AppData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsyncUrlEnrichEnabled ()Z
+	public final fun getAutoTranslationEnabled ()Z
+	public final fun getFileUploadConfig ()Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;
+	public final fun getImageUploadConfig ()Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/AttachmentKt {
+	public static final fun toAttachment (Lio/getstream/feeds/android/network/models/GetOGResponse;)Lio/getstream/feeds/android/network/models/Attachment;
+}
+
+public final class io/getstream/feeds/android/client/api/model/BatchFollowData {
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/client/api/model/BatchFollowData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/BatchFollowData;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/BatchFollowData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreated ()Ljava/util/List;
+	public final fun getFollows ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/BookmarkData {
+	public fun <init> (Lio/getstream/feeds/android/client/api/model/ActivityData;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/CommentData;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/client/api/model/BookmarkFolderData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;)V
+	public final fun component1 ()Lio/getstream/feeds/android/client/api/model/ActivityData;
+	public final fun component10 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/client/api/model/CommentData;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Lio/getstream/feeds/android/client/api/model/BookmarkFolderData;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Lio/getstream/feeds/android/client/api/model/ActivityData;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/CommentData;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/client/api/model/BookmarkFolderData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;)Lio/getstream/feeds/android/client/api/model/BookmarkData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/BookmarkData;Lio/getstream/feeds/android/client/api/model/ActivityData;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/CommentData;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/client/api/model/BookmarkFolderData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/BookmarkData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/client/api/model/ActivityData;
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getComment ()Lio/getstream/feeds/android/client/api/model/CommentData;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFolder ()Lio/getstream/feeds/android/client/api/model/BookmarkFolderData;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/BookmarkFolderData {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;)Lio/getstream/feeds/android/client/api/model/BookmarkFolderData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/BookmarkFolderData;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/BookmarkFolderData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CollectionData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/CollectionStatus;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/CollectionStatus;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/client/api/model/CollectionStatus;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/CollectionStatus;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/client/api/model/CollectionData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/CollectionData;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/CollectionStatus;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/CollectionData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStatus ()Lio/getstream/feeds/android/client/api/model/CollectionStatus;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/client/api/model/CollectionStatus {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CollectionStatus$NotFound : io/getstream/feeds/android/client/api/model/CollectionStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/CollectionStatus$NotFound;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CollectionStatus$Ok : io/getstream/feeds/android/client/api/model/CollectionStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/CollectionStatus$Ok;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CollectionStatus$Unknown : io/getstream/feeds/android/client/api/model/CollectionStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/CollectionStatus$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/CollectionStatus$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/CollectionStatus$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CommentData : io/getstream/feeds/android/client/api/state/query/CommentsSortDataFields {
+	public fun <init> (Ljava/util/List;IFLjava/lang/Float;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;ILjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;IILio/getstream/feeds/android/client/api/model/CommentStatus;Ljava/lang/String;Ljava/util/Date;ILio/getstream/feeds/android/client/api/model/UserData;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Lio/getstream/feeds/android/client/api/model/Moderation;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()I
+	public final fun component19 ()Ljava/util/Map;
+	public final fun component2 ()I
+	public final fun component20 ()I
+	public final fun component21 ()I
+	public final fun component22 ()Lio/getstream/feeds/android/client/api/model/CommentStatus;
+	public final fun component23 ()Ljava/lang/String;
+	public final fun component24 ()Ljava/util/Date;
+	public final fun component25 ()I
+	public final fun component26 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun component3 ()F
+	public final fun component4 ()Ljava/lang/Float;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()I
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/List;IFLjava/lang/Float;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;ILjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;IILio/getstream/feeds/android/client/api/model/CommentStatus;Ljava/lang/String;Ljava/util/Date;ILio/getstream/feeds/android/client/api/model/UserData;)Lio/getstream/feeds/android/client/api/model/CommentData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/CommentData;Ljava/util/List;IFLjava/lang/Float;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;ILjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;IILio/getstream/feeds/android/client/api/model/CommentStatus;Ljava/lang/String;Ljava/util/Date;ILio/getstream/feeds/android/client/api/model/UserData;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/CommentData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getBookmarkCount ()I
+	public fun getConfidenceScore ()F
+	public fun getControversyScore ()Ljava/lang/Float;
+	public fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDownvoteCount ()I
+	public final fun getEditedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLatestReactions ()Ljava/util/List;
+	public final fun getMentionedUsers ()Ljava/util/List;
+	public final fun getModeration ()Lio/getstream/feeds/android/client/api/model/Moderation;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getOwnReactions ()Ljava/util/List;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getReactionCount ()I
+	public final fun getReactionGroups ()Ljava/util/Map;
+	public final fun getReplyCount ()I
+	public fun getScore ()I
+	public final fun getStatus ()Lio/getstream/feeds/android/client/api/model/CommentStatus;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUpvoteCount ()I
+	public final fun getUser ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/client/api/model/CommentStatus {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CommentStatus$Active : io/getstream/feeds/android/client/api/model/CommentStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/CommentStatus$Active;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CommentStatus$Deleted : io/getstream/feeds/android/client/api/model/CommentStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/CommentStatus$Deleted;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CommentStatus$Hidden : io/getstream/feeds/android/client/api/model/CommentStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/CommentStatus$Hidden;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CommentStatus$Removed : io/getstream/feeds/android/client/api/model/CommentStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/CommentStatus$Removed;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CommentStatus$ShadowBlocked : io/getstream/feeds/android/client/api/model/CommentStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/CommentStatus$ShadowBlocked;
+}
+
+public final class io/getstream/feeds/android/client/api/model/CommentStatus$Unknown : io/getstream/feeds/android/client/api/model/CommentStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/CommentStatus$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/CommentStatus$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/CommentStatus$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedAddActivityRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/Location;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/Location;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/AddActivityRequest;
+	public final fun component2 ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachmentUploads ()Ljava/util/List;
+	public final fun getRequest ()Lio/getstream/feeds/android/network/models/AddActivityRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedData {
+	public fun <init> (ILjava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/util/Map;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/List;IILjava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/Location;ILjava/util/Set;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/FeedMemberData;Ljava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedVisibility;)V
+	public final fun component1 ()I
+	public final fun component10 ()I
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component14 ()I
+	public final fun component15 ()Ljava/util/Set;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Lio/getstream/feeds/android/client/api/model/FeedMemberData;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component20 ()I
+	public final fun component21 ()Ljava/util/Date;
+	public final fun component22 ()Lio/getstream/feeds/android/client/api/model/FeedVisibility;
+	public final fun component3 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()I
+	public final fun copy (ILjava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/util/Map;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/List;IILjava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/Location;ILjava/util/Set;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/FeedMemberData;Ljava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedVisibility;)Lio/getstream/feeds/android/client/api/model/FeedData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedData;ILjava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/util/Map;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/List;IILjava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/Location;ILjava/util/Set;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/client/api/model/FeedMemberData;Ljava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedVisibility;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityCount ()I
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getFid ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getFollowerCount ()I
+	public final fun getFollowingCount ()I
+	public final fun getGroupId ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMemberCount ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOwnCapabilities ()Ljava/util/Set;
+	public final fun getOwnFollowings ()Ljava/util/List;
+	public final fun getOwnFollows ()Ljava/util/List;
+	public final fun getOwnMembership ()Lio/getstream/feeds/android/client/api/model/FeedMemberData;
+	public final fun getPinCount ()I
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getVisibility ()Lio/getstream/feeds/android/client/api/model/FeedVisibility;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedId {
+	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/FeedId;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedId;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getRawValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedInputData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedVisibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedVisibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/client/api/model/FeedVisibility;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedVisibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/client/api/model/FeedInputData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedInputData;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedVisibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedInputData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVisibility ()Lio/getstream/feeds/android/client/api/model/FeedVisibility;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedMemberData {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedMemberStatus;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/getstream/feeds/android/client/api/model/FeedMemberStatus;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedMemberStatus;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;)Lio/getstream/feeds/android/client/api/model/FeedMemberData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedMemberData;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedMemberStatus;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedMemberData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInviteAcceptedAt ()Ljava/util/Date;
+	public final fun getInviteRejectedAt ()Ljava/util/Date;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getStatus ()Lio/getstream/feeds/android/client/api/model/FeedMemberStatus;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedMemberRequestData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/client/api/model/FeedMemberRequestData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedMemberRequestData;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedMemberRequestData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getInvite ()Ljava/lang/Boolean;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/client/api/model/FeedMemberStatus {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedMemberStatus$Member : io/getstream/feeds/android/client/api/model/FeedMemberStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FeedMemberStatus$Member;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedMemberStatus$Pending : io/getstream/feeds/android/client/api/model/FeedMemberStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FeedMemberStatus$Pending;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedMemberStatus$Rejected : io/getstream/feeds/android/client/api/model/FeedMemberStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FeedMemberStatus$Rejected;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedMemberStatus$Unknown : io/getstream/feeds/android/client/api/model/FeedMemberStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/FeedMemberStatus$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedMemberStatus$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedMemberStatus$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedSuggestionData {
+	public fun <init> (Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Float;)V
+	public final fun component1 ()Lio/getstream/feeds/android/client/api/model/FeedData;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Float;
+	public final fun copy (Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Float;)Lio/getstream/feeds/android/client/api/model/FeedSuggestionData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedSuggestionData;Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Float;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedSuggestionData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlgorithmScores ()Ljava/util/Map;
+	public final fun getFeed ()Lio/getstream/feeds/android/client/api/model/FeedData;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getRecommendationScore ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/client/api/model/FeedVisibility {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedVisibility$Followers : io/getstream/feeds/android/client/api/model/FeedVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FeedVisibility$Followers;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedVisibility$Members : io/getstream/feeds/android/client/api/model/FeedVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FeedVisibility$Members;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedVisibility$Private : io/getstream/feeds/android/client/api/model/FeedVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FeedVisibility$Private;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedVisibility$Public : io/getstream/feeds/android/client/api/model/FeedVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FeedVisibility$Public;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedVisibility$Unknown : io/getstream/feeds/android/client/api/model/FeedVisibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/FeedVisibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedVisibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedVisibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedVisibility$Visible : io/getstream/feeds/android/client/api/model/FeedVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FeedVisibility$Visible;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedsConfig {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/feeds/android/client/api/file/Uploader;Lio/getstream/feeds/android/client/api/logging/LoggingConfig;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/client/api/file/Uploader;Lio/getstream/feeds/android/client/api/logging/LoggingConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getCustomUploader ()Lio/getstream/feeds/android/client/api/file/Uploader;
+	public final fun getLoggingConfig ()Lio/getstream/feeds/android/client/api/logging/LoggingConfig;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FeedsReactionData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;)Lio/getstream/feeds/android/client/api/model/FeedsReactionData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FeedsReactionData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FeedsReactionData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getCommentId ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FileUploadConfigData {
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;I)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()I
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;I)Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;IILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FileUploadConfigData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowedFileExtensions ()Ljava/util/List;
+	public final fun getAllowedMimeTypes ()Ljava/util/List;
+	public final fun getBlockedFileExtensions ()Ljava/util/List;
+	public final fun getBlockedMimeTypes ()Ljava/util/List;
+	public final fun getSizeLimit ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FollowData {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedData;Lio/getstream/feeds/android/client/api/model/FollowStatus;Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedData;Lio/getstream/feeds/android/client/api/model/FollowStatus;Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Lio/getstream/feeds/android/client/api/model/FeedData;
+	public final fun component8 ()Lio/getstream/feeds/android/client/api/model/FollowStatus;
+	public final fun component9 ()Lio/getstream/feeds/android/client/api/model/FeedData;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedData;Lio/getstream/feeds/android/client/api/model/FollowStatus;Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Date;)Lio/getstream/feeds/android/client/api/model/FollowData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FollowData;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/FeedData;Lio/getstream/feeds/android/client/api/model/FollowStatus;Lio/getstream/feeds/android/client/api/model/FeedData;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FollowData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFollowerRole ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPushPreference ()Ljava/lang/String;
+	public final fun getRequestAcceptedAt ()Ljava/util/Date;
+	public final fun getRequestRejectedAt ()Ljava/util/Date;
+	public final fun getSourceFeed ()Lio/getstream/feeds/android/client/api/model/FeedData;
+	public final fun getStatus ()Lio/getstream/feeds/android/client/api/model/FollowStatus;
+	public final fun getTargetFeed ()Lio/getstream/feeds/android/client/api/model/FeedData;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/client/api/model/FollowStatus {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FollowStatus$Accepted : io/getstream/feeds/android/client/api/model/FollowStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FollowStatus$Accepted;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FollowStatus$Pending : io/getstream/feeds/android/client/api/model/FollowStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FollowStatus$Pending;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FollowStatus$Rejected : io/getstream/feeds/android/client/api/model/FollowStatus {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/FollowStatus$Rejected;
+}
+
+public final class io/getstream/feeds/android/client/api/model/FollowStatus$Unknown : io/getstream/feeds/android/client/api/model/FollowStatus {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/FollowStatus$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/FollowStatus$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/FollowStatus$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ModelUpdates {
+	public fun <init> (Ljava/util/List;Ljava/util/Set;Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/Set;Ljava/util/List;)Lio/getstream/feeds/android/client/api/model/ModelUpdates;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/ModelUpdates;Ljava/util/List;Ljava/util/Set;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/ModelUpdates;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdded ()Ljava/util/List;
+	public final fun getRemovedIds ()Ljava/util/Set;
+	public final fun getUpdated ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/Moderation {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/client/api/model/Moderation;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/Moderation;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Ljava/lang/String;
+	public final fun getBlocklistMatched ()Ljava/lang/String;
+	public final fun getImageHarms ()Ljava/util/List;
+	public final fun getOriginalText ()Ljava/lang/String;
+	public final fun getPlatformCircumvented ()Ljava/lang/Boolean;
+	public final fun getSemanticFilterMatched ()Ljava/lang/String;
+	public final fun getTextHarms ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ModerationConfigData {
+	public fun <init> (Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;ZLio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/VelocityFilterConfig;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/AITextConfig;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/AIVideoConfig;
+	public final fun component4 ()Z
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/BlockListConfig;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;ZLio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;)Lio/getstream/feeds/android/client/api/model/ModerationConfigData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/ModerationConfigData;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;ZLio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/ModerationConfigData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiImageConfig ()Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public final fun getAiTextConfig ()Lio/getstream/feeds/android/network/models/AITextConfig;
+	public final fun getAiVideoConfig ()Lio/getstream/feeds/android/network/models/AIVideoConfig;
+	public final fun getAsync ()Z
+	public final fun getAutomodPlatformCircumventionConfig ()Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;
+	public final fun getAutomodSemanticFiltersConfig ()Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;
+	public final fun getAutomodToxicityConfig ()Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;
+	public final fun getBlockListConfig ()Lio/getstream/feeds/android/network/models/BlockListConfig;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getTeam ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getVelocityFilterConfig ()Lio/getstream/feeds/android/network/models/VelocityFilterConfig;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/PaginationData {
+	public static final field Companion Lio/getstream/feeds/android/client/api/model/PaginationData$Companion;
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/PaginationData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/PaginationData$Companion {
+	public final fun getEMPTY ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+}
+
+public final class io/getstream/feeds/android/client/api/model/PollData {
+	public fun <init> (ZZILjava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;ILjava/util/Map;Ljava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Z
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/util/Map;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/Date;
+	public final fun component19 ()I
+	public final fun component2 ()Z
+	public final fun component20 ()Ljava/util/Map;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Z
+	public final fun copy (ZZILjava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;ILjava/util/Map;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/PollData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/PollData;ZZILjava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ZLjava/lang/String;ZLjava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Date;ILjava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/PollData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowAnswers ()Z
+	public final fun getAllowUserSuggestedOptions ()Z
+	public final fun getAnswersCount ()I
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun getCreatedById ()Ljava/lang/String;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEnforceUniqueVote ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLatestAnswers ()Ljava/util/List;
+	public final fun getLatestVotesByOption ()Ljava/util/Map;
+	public final fun getMaxVotesAllowed ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getOwnVotes ()Ljava/util/List;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getVoteCount ()I
+	public final fun getVoteCountsByOption ()Ljava/util/Map;
+	public final fun getVotingVisibility ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isClosed ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/PollOptionData {
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/PollOptionData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/PollOptionData;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/PollOptionData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/PollVoteData {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/PollVoteData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/PollVoteData;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/client/api/model/UserData;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/PollVoteData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnswerText ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getOptionId ()Ljava/lang/String;
+	public final fun getPollId ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isAnswer ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/PushNotificationsProvider : java/lang/Enum {
+	public static final field FIREBASE Lio/getstream/feeds/android/client/api/model/PushNotificationsProvider;
+	public static final field HUAWEI Lio/getstream/feeds/android/client/api/model/PushNotificationsProvider;
+	public static final field XIAOMI Lio/getstream/feeds/android/client/api/model/PushNotificationsProvider;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/PushNotificationsProvider;
+	public static fun values ()[Lio/getstream/feeds/android/client/api/model/PushNotificationsProvider;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ReactionGroupData {
+	public fun <init> (ILjava/util/Date;Ljava/util/Date;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun copy (ILjava/util/Date;Ljava/util/Date;)Lio/getstream/feeds/android/client/api/model/ReactionGroupData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/ReactionGroupData;ILjava/util/Date;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/ReactionGroupData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public final fun getFirstReactionAt ()Ljava/util/Date;
+	public final fun getLastReactionAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/client/api/model/RestrictReplies {
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/RestrictReplies$Everyone : io/getstream/feeds/android/client/api/model/RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/RestrictReplies$Everyone;
+}
+
+public final class io/getstream/feeds/android/client/api/model/RestrictReplies$Nobody : io/getstream/feeds/android/client/api/model/RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/RestrictReplies$Nobody;
+}
+
+public final class io/getstream/feeds/android/client/api/model/RestrictReplies$PeopleIFollow : io/getstream/feeds/android/client/api/model/RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/model/RestrictReplies$PeopleIFollow;
+}
+
+public final class io/getstream/feeds/android/client/api/model/RestrictReplies$Unknown : io/getstream/feeds/android/client/api/model/RestrictReplies {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/model/RestrictReplies$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/RestrictReplies$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/RestrictReplies$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/ThreadedCommentData : io/getstream/feeds/android/client/api/state/query/CommentsSortDataFields {
+	public fun <init> (Lio/getstream/feeds/android/client/api/model/CommentData;)V
+	public fun <init> (Ljava/util/List;IFLjava/lang/Float;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;ILjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/RepliesMeta;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;Ljava/util/List;IILio/getstream/feeds/android/client/api/model/CommentStatus;Ljava/lang/String;Ljava/util/Date;ILio/getstream/feeds/android/client/api/model/UserData;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/RepliesMeta;
+	public final fun component14 ()Lio/getstream/feeds/android/client/api/model/Moderation;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()I
+	public final fun component2 ()I
+	public final fun component20 ()Ljava/util/Map;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()I
+	public final fun component23 ()I
+	public final fun component24 ()Lio/getstream/feeds/android/client/api/model/CommentStatus;
+	public final fun component25 ()Ljava/lang/String;
+	public final fun component26 ()Ljava/util/Date;
+	public final fun component27 ()I
+	public final fun component28 ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public final fun component3 ()F
+	public final fun component4 ()Ljava/lang/Float;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()I
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/List;IFLjava/lang/Float;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;ILjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/RepliesMeta;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;Ljava/util/List;IILio/getstream/feeds/android/client/api/model/CommentStatus;Ljava/lang/String;Ljava/util/Date;ILio/getstream/feeds/android/client/api/model/UserData;)Lio/getstream/feeds/android/client/api/model/ThreadedCommentData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/ThreadedCommentData;Ljava/util/List;IFLjava/lang/Float;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;ILjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/RepliesMeta;Lio/getstream/feeds/android/client/api/model/Moderation;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/util/Map;Ljava/util/List;IILio/getstream/feeds/android/client/api/model/CommentStatus;Ljava/lang/String;Ljava/util/Date;ILio/getstream/feeds/android/client/api/model/UserData;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/ThreadedCommentData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getBookmarkCount ()I
+	public fun getConfidenceScore ()F
+	public fun getControversyScore ()Ljava/lang/Float;
+	public fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDownvoteCount ()I
+	public final fun getEditedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLatestReactions ()Ljava/util/List;
+	public final fun getMentionedUsers ()Ljava/util/List;
+	public final fun getMeta ()Lio/getstream/feeds/android/network/models/RepliesMeta;
+	public final fun getModeration ()Lio/getstream/feeds/android/client/api/model/Moderation;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getOwnReactions ()Ljava/util/List;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getReactionCount ()I
+	public final fun getReactionGroups ()Ljava/util/Map;
+	public final fun getReplies ()Ljava/util/List;
+	public final fun getReplyCount ()I
+	public fun getScore ()I
+	public final fun getStatus ()Lio/getstream/feeds/android/client/api/model/CommentStatus;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUpvoteCount ()I
+	public final fun getUser ()Lio/getstream/feeds/android/client/api/model/UserData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/User {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/client/api/model/User;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/User;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomData ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImageURL ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/UserData {
+	public fun <init> (ZLjava/util/List;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;ZLjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Z
+	public final fun component13 ()Ljava/util/Date;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (ZLjava/util/List;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;ZLjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;)Lio/getstream/feeds/android/client/api/model/UserData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/model/UserData;ZLjava/util/List;Ljava/util/Date;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;ZLjava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/model/UserData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBanned ()Z
+	public final fun getBlockedUserIds ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeactivatedAt ()Ljava/util/Date;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLastActive ()Ljava/util/Date;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOnline ()Z
+	public final fun getRevokeTokensIssuedBefore ()Ljava/util/Date;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTeams ()Ljava/util/List;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/util/Map;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/AddCommentRequest;
+	public final fun component2 ()Ljava/util/List;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachmentUploads ()Ljava/util/List;
+	public final fun getRequest ()Lio/getstream/feeds/android/network/models/AddCommentRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/Activity {
+	public abstract fun activityFeedback-gIAlu-s (Lio/getstream/feeds/android/network/models/ActivityFeedbackRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addComment-0E7RQCE (Lio/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addComment-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Lio/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun addCommentReaction-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddCommentReactionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addCommentsBatch-0E7RQCE (Ljava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addCommentsBatch-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun castPollVote-gIAlu-s (Lio/getstream/feeds/android/network/models/CastPollVoteRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun closePoll-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createPollOption-gIAlu-s (Lio/getstream/feeds/android/network/models/CreatePollOptionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteComment-BWLJW6A (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteComment-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteCommentReaction-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteCommentReaction-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deletePoll-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deletePoll-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deletePollOption-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deletePollOption-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deletePollVote-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deletePollVote-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getActivityId ()Ljava/lang/String;
+	public abstract fun getComment-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getFid ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public abstract fun getPoll-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPoll-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getPollOption-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPollOption-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/ActivityState;
+	public abstract fun pin-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryComments-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryMoreComments-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreComments-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun unpin-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateComment-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateCommentRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePoll-gIAlu-s (Lio/getstream/feeds/android/network/models/UpdatePollRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePollOption-gIAlu-s (Lio/getstream/feeds/android/network/models/UpdatePollOptionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePollPartial-gIAlu-s (Lio/getstream/feeds/android/network/models/UpdatePollPartialRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/Activity$DefaultImpls {
+	public static synthetic fun addComment-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Lio/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun addCommentsBatch-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/util/List;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteComment-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteCommentReaction-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deletePoll-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deletePollOption-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deletePollVote-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getPoll-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getPollOption-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryMoreComments-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Activity;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ActivityCommentList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/ActivityCommentsQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/ActivityCommentListState;
+	public abstract fun queryMoreComments-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreComments-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/ActivityCommentList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/ActivityCommentList$DefaultImpls {
+	public static synthetic fun queryMoreComments-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/ActivityCommentList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ActivityCommentListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getComments ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/ActivityCommentsQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/ActivityCommentListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/ActivityCommentListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ActivityList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/ActivityListState;
+	public abstract fun queryMoreActivities-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreActivities-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/ActivityList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/ActivityList$DefaultImpls {
+	public static synthetic fun queryMoreActivities-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/ActivityList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ActivityListState {
+	public abstract fun getActivities ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getCanLoadMore ()Z
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/ActivityListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/ActivityListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ActivityReactionList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/ActivityReactionListState;
+	public abstract fun queryMoreReactions-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreReactions-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/ActivityReactionList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/ActivityReactionList$DefaultImpls {
+	public static synthetic fun queryMoreReactions-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/ActivityReactionList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ActivityReactionListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsQuery;
+	public abstract fun getReactions ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class io/getstream/feeds/android/client/api/state/ActivityReactionListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/ActivityReactionListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ActivityState {
+	public abstract fun getActivity ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getComments ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPoll ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/BookmarkFolderList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/BookmarkFolderListState;
+	public abstract fun queryMoreBookmarkFolders-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreBookmarkFolders-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/BookmarkFolderList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/BookmarkFolderList$DefaultImpls {
+	public static synthetic fun queryMoreBookmarkFolders-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/BookmarkFolderList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/BookmarkFolderListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getFolders ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/BookmarkFolderListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/BookmarkFolderListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/BookmarkList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/BookmarksQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/BookmarkListState;
+	public abstract fun queryMoreBookmarks-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreBookmarks-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/BookmarkList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/BookmarkList$DefaultImpls {
+	public static synthetic fun queryMoreBookmarks-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/BookmarkList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/BookmarkListState {
+	public abstract fun getBookmarks ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getCanLoadMore ()Z
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/BookmarksQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/BookmarkListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/BookmarkListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/CommentList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/CommentsQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/CommentListState;
+	public abstract fun queryMoreComments-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreComments-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/CommentList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/CommentList$DefaultImpls {
+	public static synthetic fun queryMoreComments-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/CommentList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/CommentListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getComments ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/CommentsQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/CommentListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/CommentListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/CommentReactionList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/CommentReactionsQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/CommentReactionListState;
+	public abstract fun queryMoreReactions-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreReactions-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/CommentReactionList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/CommentReactionList$DefaultImpls {
+	public static synthetic fun queryMoreReactions-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/CommentReactionList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/CommentReactionListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/CommentReactionsQuery;
+	public abstract fun getReactions ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class io/getstream/feeds/android/client/api/state/CommentReactionListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/CommentReactionListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/CommentReplyList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/CommentRepliesQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/CommentReplyListState;
+	public abstract fun queryMoreReplies-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreReplies-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/CommentReplyList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/CommentReplyList$DefaultImpls {
+	public static synthetic fun queryMoreReplies-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/CommentReplyList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/CommentReplyListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/CommentRepliesQuery;
+	public abstract fun getReplies ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class io/getstream/feeds/android/client/api/state/CommentReplyListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/CommentReplyListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/Feed {
+	public abstract fun acceptFeedMember-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun acceptFollow-0E7RQCE (Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun acceptFollow-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun addActivity-0E7RQCE (Lio/getstream/feeds/android/client/api/model/FeedAddActivityRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addActivity-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedAddActivityRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun addActivityReaction-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddReactionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addBookmark-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addBookmark-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddBookmarkRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun addComment-0E7RQCE (Lio/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun addComment-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun addCommentReaction-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddCommentReactionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createPoll-0E7RQCE (Lio/getstream/feeds/android/network/models/CreatePollRequest;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteActivity-BWLJW6A (Ljava/lang/String;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteActivity-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteActivityReaction-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteActivityReaction-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteBookmark-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteBookmark-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteComment-BWLJW6A (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteComment-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteCommentReaction-BWLJW6A (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteCommentReaction-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteFeed-gIAlu-s (ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteFeed-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Feed;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun follow-yxL6bBk (Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/Boolean;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun follow-yxL6bBk$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/Boolean;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getComment-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getFid ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public abstract fun getOrCreate-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/FeedState;
+	public abstract fun markActivity-gIAlu-s (Lio/getstream/feeds/android/network/models/MarkActivityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryFeedMembers-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryFollowSuggestions-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryMoreActivities-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreActivities-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun queryMoreFeedMembers-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreFeedMembers-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun rejectFeedMember-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun rejectFollow-gIAlu-s (Lio/getstream/feeds/android/client/api/model/FeedId;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun repost-0E7RQCE (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun restoreActivity-gIAlu-s (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun stopWatching-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun unfollow-0E7RQCE (Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unfollow-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun updateActivity-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateActivityPartial-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityPartialRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateBookmark-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateComment-0E7RQCE (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateCommentRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateFeed-gIAlu-s (Lio/getstream/feeds/android/network/models/UpdateFeedRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateFeedMembers-gIAlu-s (Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateFollow-BWLJW6A (Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun updateFollow-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/Feed$DefaultImpls {
+	public static synthetic fun acceptFollow-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun addActivity-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedAddActivityRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun addBookmark-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddBookmarkRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun addComment-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/request/ActivityAddCommentRequest;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteActivity-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;ZLjava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteActivityReaction-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteBookmark-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteComment-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteCommentReaction-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteFeed-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Feed;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun follow-yxL6bBk$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/Boolean;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryMoreActivities-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryMoreFeedMembers-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/Feed;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun unfollow-0E7RQCE$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun updateFollow-BWLJW6A$default (Lio/getstream/feeds/android/client/api/state/Feed;Lio/getstream/feeds/android/client/api/model/FeedId;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/FeedList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/FeedsQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/FeedListState;
+	public abstract fun queryMoreFeeds-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreFeeds-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/FeedList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/FeedList$DefaultImpls {
+	public static synthetic fun queryMoreFeeds-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/FeedList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/FeedListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getFeeds ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/FeedsQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/FeedListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/FeedListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/FeedState {
+	public abstract fun getActivities ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getActivitiesPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getAggregatedActivities ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getCanLoadMoreActivities ()Z
+	public abstract fun getFeed ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getFeedQuery ()Lio/getstream/feeds/android/client/api/state/query/FeedQuery;
+	public abstract fun getFid ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public abstract fun getFollowRequests ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getFollowers ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getFollowing ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getMembers ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getNotificationStatus ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPinnedActivities ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class io/getstream/feeds/android/client/api/state/FeedState$DefaultImpls {
+	public static fun getCanLoadMoreActivities (Lio/getstream/feeds/android/client/api/state/FeedState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/FollowList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/FollowsQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/FollowListState;
+	public abstract fun queryMoreFollows-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreFollows-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/FollowList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/FollowList$DefaultImpls {
+	public static synthetic fun queryMoreFollows-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/FollowList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/FollowListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getFollows ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/FollowsQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/FollowListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/FollowListState;)Z
+}
+
+public final class io/getstream/feeds/android/client/api/state/InsertionAction : java/lang/Enum {
+	public static final field AddToEnd Lio/getstream/feeds/android/client/api/state/InsertionAction;
+	public static final field AddToStart Lio/getstream/feeds/android/client/api/state/InsertionAction;
+	public static final field Ignore Lio/getstream/feeds/android/client/api/state/InsertionAction;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/feeds/android/client/api/state/InsertionAction;
+	public static fun values ()[Lio/getstream/feeds/android/client/api/state/InsertionAction;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/MemberList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/MembersQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/MemberListState;
+	public abstract fun queryMoreMembers-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreMembers-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/MemberList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/MemberList$DefaultImpls {
+	public static synthetic fun queryMoreMembers-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/MemberList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/MemberListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getMembers ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/MembersQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/MemberListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/MemberListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ModerationConfigList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/ModerationConfigListState;
+	public abstract fun queryMoreConfigs-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreConfigs-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/ModerationConfigList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/ModerationConfigList$DefaultImpls {
+	public static synthetic fun queryMoreConfigs-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/ModerationConfigList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/ModerationConfigListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getConfigs ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/ModerationConfigListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/ModerationConfigListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/PollList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/PollsQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/PollListState;
+	public abstract fun queryMorePolls-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMorePolls-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/PollList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/PollList$DefaultImpls {
+	public static synthetic fun queryMorePolls-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/PollList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/PollListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getPolls ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/PollsQuery;
+}
+
+public final class io/getstream/feeds/android/client/api/state/PollListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/PollListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/PollVoteList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/PollVotesQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/PollVoteListState;
+	public abstract fun queryMorePollVotes-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMorePollVotes-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/PollVoteList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/PollVoteList$DefaultImpls {
+	public static synthetic fun queryMorePollVotes-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/PollVoteList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/PollVoteListState {
+	public fun getCanLoadMore ()Z
+	public abstract fun getPagination ()Lio/getstream/feeds/android/client/api/model/PaginationData;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/PollVotesQuery;
+	public abstract fun getVotes ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class io/getstream/feeds/android/client/api/state/PollVoteListState$DefaultImpls {
+	public static fun getCanLoadMore (Lio/getstream/feeds/android/client/api/state/PollVoteListState;)Z
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/UserList {
+	public abstract fun get-IoAF18A (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/UsersQuery;
+	public abstract fun getState ()Lio/getstream/feeds/android/client/api/state/UserListState;
+	public abstract fun queryMoreUsers-gIAlu-s (Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryMoreUsers-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/UserList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/client/api/state/UserList$DefaultImpls {
+	public static synthetic fun queryMoreUsers-gIAlu-s$default (Lio/getstream/feeds/android/client/api/state/UserList;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/UserListState {
+	public abstract fun getCanLoadMore ()Z
+	public abstract fun getQuery ()Lio/getstream/feeds/android/client/api/state/query/UsersQuery;
+	public abstract fun getUsers ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivitiesFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivitiesFilterField$Companion {
+	public final fun getActivityType ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getExpiresAt ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getFeed ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getFilterTags ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getId ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getInterestTags ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getNear ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getPopularity ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getSearchData ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getText ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getUserId ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+	public final fun getWithinBounds ()Lio/getstream/feeds/android/client/api/state/query/ActivitiesFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivitiesQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/state/query/ActivitiesQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/ActivitiesQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/ActivitiesQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivitiesSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/ActivitiesSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/ActivitiesSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivitiesSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/ActivitiesSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivitiesSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/ActivitiesSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/ActivitiesSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivitiesSortField$Popularity : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/ActivitiesSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/ActivitiesSortField$Popularity;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivityCommentsQuery {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Lio/getstream/feeds/android/client/api/state/query/CommentsSort;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;)Lio/getstream/feeds/android/client/api/state/query/ActivityCommentsQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/ActivityCommentsQuery;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/ActivityCommentsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDepth ()Ljava/lang/Integer;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getRepliesLimit ()Ljava/lang/Integer;
+	public final fun getSort ()Lio/getstream/feeds/android/client/api/state/query/CommentsSort;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField$Companion {
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField;
+	public final fun getReactionType ()Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField;
+	public final fun getUserId ()Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivityReactionsQuery {
+	public fun <init> (Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsQuery;Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivityReactionsSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivityReactionsSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/ActivityReactionsSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ActivityReactionsSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/ActivityReactionsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/ActivityReactionsSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField$Companion {
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField;
+	public final fun getFolderName ()Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarkFoldersQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarkFoldersSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarkFoldersSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/BookmarkFoldersSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarkFoldersSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/BookmarkFoldersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarkFoldersSortField$UpdatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/BookmarkFoldersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/BookmarkFoldersSortField$UpdatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarksFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarksFilterField$Companion {
+	public final fun getActivityId ()Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField;
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField;
+	public final fun getFolderId ()Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField;
+	public final fun getUserId ()Lio/getstream/feeds/android/client/api/state/query/BookmarksFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarksQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/state/query/BookmarksQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/BookmarksQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/BookmarksQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarksSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/BookmarksSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/BookmarksSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarksSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/BookmarksSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarksSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/BookmarksSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/BookmarksSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/BookmarksSortField$UpdatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/BookmarksSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/BookmarksSortField$UpdatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/CommentReactionSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentReactionSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/CommentReactionSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/CommentReactionSortField$CreatedAt;
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField$Companion {
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField;
+	public final fun getReactionType ()Lio/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField;
+	public final fun getUserId ()Lio/getstream/feeds/android/client/api/state/query/CommentReactionsFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentReactionsQuery {
+	public fun <init> (Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/client/api/state/query/CommentReactionsQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/CommentReactionsQuery;Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/CommentReactionsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommentId ()Ljava/lang/String;
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentReactionsSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/CommentReactionsSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/CommentReactionSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentReactionsSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentRepliesQuery {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Lio/getstream/feeds/android/client/api/state/query/CommentsSort;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;)Lio/getstream/feeds/android/client/api/state/query/CommentRepliesQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/CommentRepliesQuery;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/CommentRepliesQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCommentId ()Ljava/lang/String;
+	public final fun getDepth ()Ljava/lang/Integer;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getRepliesLimit ()Ljava/lang/Integer;
+	public final fun getSort ()Lio/getstream/feeds/android/client/api/state/query/CommentsSort;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentsFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentsFilterField$Companion {
+	public final fun getCommentText ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getConfidenceScore ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getControversyScore ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getDownvoteCount ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getId ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getObjectId ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getObjectType ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getParentId ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getReplyCount ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getScore ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getStatus ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getUpvoteCount ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+	public final fun getUserId ()Lio/getstream/feeds/android/client/api/state/query/CommentsFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentsQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lio/getstream/feeds/android/client/api/state/query/CommentsSort;
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;)Lio/getstream/feeds/android/client/api/state/query/CommentsQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/CommentsQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/state/query/CommentsSort;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/CommentsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Lio/getstream/feeds/android/client/api/state/query/CommentsSort;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/CommentsSort {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentsSort$Best : io/getstream/feeds/android/client/api/state/query/CommentsSort {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/CommentsSort$Best;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentsSort$Controversial : io/getstream/feeds/android/client/api/state/query/CommentsSort {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/CommentsSort$Controversial;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentsSort$First : io/getstream/feeds/android/client/api/state/query/CommentsSort {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/CommentsSort$First;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentsSort$Last : io/getstream/feeds/android/client/api/state/query/CommentsSort {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/CommentsSort$Last;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/CommentsSort$Top : io/getstream/feeds/android/client/api/state/query/CommentsSort {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/CommentsSort$Top;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedQuery {
+	public fun <init> (Lio/getstream/feeds/android/client/api/model/FeedId;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedInputData;Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/client/api/model/FeedId;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedInputData;Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedInputData;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedInputData;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public final fun component10 ()Ljava/lang/Integer;
+	public final fun component11 ()Ljava/util/Map;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Z
+	public final fun component2 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/getstream/feeds/android/client/api/model/FeedInputData;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/EnrichmentOptions;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Lio/getstream/feeds/android/client/api/model/FeedId;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedInputData;Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;Z)Lio/getstream/feeds/android/client/api/state/query/FeedQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/FeedQuery;Lio/getstream/feeds/android/client/api/model/FeedId;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedInputData;Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/util/Map;Ljava/lang/Integer;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/FeedQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getActivityLimit ()Ljava/lang/Integer;
+	public final fun getActivityNext ()Ljava/lang/String;
+	public final fun getActivityPrevious ()Ljava/lang/String;
+	public final fun getData ()Lio/getstream/feeds/android/client/api/model/FeedInputData;
+	public final fun getEnrichmentOptions ()Lio/getstream/feeds/android/network/models/EnrichmentOptions;
+	public final fun getExternalRanking ()Ljava/util/Map;
+	public final fun getFid ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public final fun getFollowerLimit ()Ljava/lang/Integer;
+	public final fun getFollowingLimit ()Ljava/lang/Integer;
+	public final fun getInterestWeights ()Ljava/util/Map;
+	public final fun getMemberLimit ()Ljava/lang/Integer;
+	public final fun getView ()Ljava/lang/String;
+	public final fun getWatch ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsFilterField$Companion {
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getCreatedById ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getCreatedByName ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getDescription ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getFeed ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getFilterTags ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getFollowerCount ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getFollowingCount ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getFollowingFeeds ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getGroupId ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getId ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getMemberCount ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getMembers ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getName ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+	public final fun getVisibility ()Lio/getstream/feeds/android/client/api/state/query/FeedsFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Z)Lio/getstream/feeds/android/client/api/state/query/FeedsQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/FeedsQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/FeedsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public final fun getWatch ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/FeedsSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/FeedsSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/FeedsSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/FeedsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/FeedsSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsSortField$FollowerCount : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/FeedsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/FeedsSortField$FollowerCount;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsSortField$FollowingCount : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/FeedsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/FeedsSortField$FollowingCount;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsSortField$MemberCount : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/FeedsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/FeedsSortField$MemberCount;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FeedsSortField$UpdatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/FeedsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/FeedsSortField$UpdatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FollowsFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/FollowsFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/FollowsFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/FollowsFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/FollowsFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FollowsFilterField$Companion {
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/FollowsFilterField;
+	public final fun getSourceFeed ()Lio/getstream/feeds/android/client/api/state/query/FollowsFilterField;
+	public final fun getStatus ()Lio/getstream/feeds/android/client/api/state/query/FollowsFilterField;
+	public final fun getTargetFeed ()Lio/getstream/feeds/android/client/api/state/query/FollowsFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FollowsQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/state/query/FollowsQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/FollowsQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/FollowsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FollowsSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/FollowsSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/FollowsSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FollowsSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/FollowsSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/FollowsSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/FollowsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/FollowsSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/MembersFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/MembersFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/MembersFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/MembersFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/MembersFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/MembersFilterField$Companion {
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/MembersFilterField;
+	public final fun getRole ()Lio/getstream/feeds/android/client/api/state/query/MembersFilterField;
+	public final fun getStatus ()Lio/getstream/feeds/android/client/api/state/query/MembersFilterField;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/client/api/state/query/MembersFilterField;
+	public final fun getUserId ()Lio/getstream/feeds/android/client/api/state/query/MembersFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/MembersQuery {
+	public fun <init> (Lio/getstream/feeds/android/client/api/model/FeedId;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/client/api/model/FeedId;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public final fun component2 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/feeds/android/client/api/model/FeedId;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/client/api/state/query/MembersQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/MembersQuery;Lio/getstream/feeds/android/client/api/model/FeedId;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/MembersQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFid ()Lio/getstream/feeds/android/client/api/model/FeedId;
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/MembersSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/MembersSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/MembersSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/MembersSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/MembersSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/MembersSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/MembersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/MembersSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/MembersSortField$UpdatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/MembersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/MembersSortField$UpdatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/MembersSortField$UserId : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/MembersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/MembersSortField$UserId;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/ModerationConfigSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField$Companion {
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField;
+	public final fun getKey ()Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField;
+	public final fun getTeam ()Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigsQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField$Key : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField$Key;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField$Team : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField$Team;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField$UpdatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/ModerationConfigsSortField$UpdatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesFilterField$Companion {
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+	public final fun getId ()Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+	public final fun getOptionId ()Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+	public final fun getPollId ()Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+	public final fun getUserId ()Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+	public final fun isAnswer ()Lio/getstream/feeds/android/client/api/state/query/PollVotesFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesQuery {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/client/api/state/query/PollVotesQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/PollVotesQuery;Ljava/lang/String;Ljava/lang/String;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/PollVotesQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPollId ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/PollVotesSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/PollVotesSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/PollVotesSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesSortField$AnswerText : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollVotesSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollVotesSortField$AnswerText;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollVotesSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollVotesSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesSortField$Id : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollVotesSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollVotesSortField$Id;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollVotesSortField$UpdatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollVotesSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollVotesSortField$UpdatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/PollsFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsFilterField$Companion {
+	public final fun getAllowAnswers ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun getAllowUserSuggestedOptions ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun getCreatedById ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun getId ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun getMaxVotesAllowed ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun getName ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun getVotingVisibility ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+	public final fun isClosed ()Lio/getstream/feeds/android/client/api/state/query/PollsFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/client/api/state/query/PollsQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/PollsQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/PollsQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrevious ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsSort : io/getstream/android/core/api/sort/Sort {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/PollsSort$Companion;
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/PollsSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsSort$Companion {
+	public final fun getDefault ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/PollsSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollsSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsSortField$Id : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollsSortField$Id;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsSortField$IsClosed : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollsSortField$IsClosed;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsSortField$Name : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollsSortField$Name;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsSortField$UpdatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollsSortField$UpdatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/PollsSortField$VoteCount : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/PollsSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/PollsSortField$VoteCount;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersFilterField : io/getstream/android/core/api/filter/FilterField {
+	public static final field Companion Lio/getstream/feeds/android/client/api/state/query/UsersFilterField$Companion;
+	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getLocalValue ()Lkotlin/jvm/functions/Function1;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersFilterField$Companion {
+	public final fun getBanned ()Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public final fun getId ()Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public final fun getLastActive ()Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public final fun getName ()Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public final fun getRole ()Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public final fun getTeams ()Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/client/api/state/query/UsersFilterField;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersQuery {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun copy (Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;)Lio/getstream/feeds/android/client/api/state/query/UsersQuery;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/client/api/state/query/UsersQuery;Lio/getstream/android/core/api/filter/Filter;Ljava/util/List;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/client/api/state/query/UsersQuery;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Lio/getstream/android/core/api/filter/Filter;
+	public final fun getIncludeDeactivatedUsers ()Ljava/lang/Boolean;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getOffset ()Ljava/lang/Integer;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersSort : io/getstream/android/core/api/sort/Sort {
+	public fun <init> (Lio/getstream/feeds/android/client/api/state/query/UsersSortField;Lio/getstream/android/core/api/sort/SortDirection;)V
+}
+
+public abstract interface class io/getstream/feeds/android/client/api/state/query/UsersSortField : io/getstream/android/core/api/sort/SortField {
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersSortField$CreatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/UsersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/UsersSortField$CreatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersSortField$Id : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/UsersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/UsersSortField$Id;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersSortField$LastActive : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/UsersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/UsersSortField$LastActive;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersSortField$Role : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/UsersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/UsersSortField$Role;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/client/api/state/query/UsersSortField$UpdatedAt : io/getstream/android/core/api/sort/SortField, io/getstream/feeds/android/client/api/state/query/UsersSortField {
+	public static final field INSTANCE Lio/getstream/feeds/android/client/api/state/query/UsersSortField$UpdatedAt;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getComparator ()Lio/getstream/android/core/api/sort/AnySortComparator;
+	public fun getRemote ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+

--- a/stream-feeds-android-client/api/stream-feeds-android-client.api
+++ b/stream-feeds-android-client/api/stream-feeds-android-client.api
@@ -16,12 +16,6 @@ public final class io/getstream/feeds/android/client/BuildConfig {
 	public fun <init> ()V
 }
 
-public final class io/getstream/feeds/android/client/GKt {
-	public static final field tag Ljava/lang/String;
-	public static final fun gol (Ljava/lang/Object;[Ljava/lang/Object;)V
-	public static final fun trace (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
-}
-
 public abstract interface class io/getstream/feeds/android/client/api/FeedsClient {
 	public abstract fun activity (Ljava/lang/String;Lio/getstream/feeds/android/client/api/model/FeedId;)Lio/getstream/feeds/android/client/api/state/Activity;
 	public abstract fun activityCommentList (Lio/getstream/feeds/android/client/api/state/query/ActivityCommentsQuery;)Lio/getstream/feeds/android/client/api/state/ActivityCommentList;

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/file/FeedUploadContext.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/file/FeedUploadContext.kt
@@ -30,9 +30,12 @@ public interface FeedUploadContext : UploadContext
  */
 public data object EmptyFeedUploadContext : FeedUploadContext
 
+/** An [UploadPayload] for feed uploads. */
 public typealias FeedUploadPayload = UploadPayload<FeedUploadContext>
 
+/** Builds a [FeedUploadPayload] with no extra context attached. */
 public fun FeedUploadPayload(file: File, type: FileType): FeedUploadPayload =
     FeedUploadPayload(file, type, EmptyFeedUploadContext)
 
+/** An [Uploader] for feed uploads. */
 public typealias FeedUploader = Uploader<FeedUploadContext>

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/file/UploadedFile.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/file/UploadedFile.kt
@@ -16,4 +16,11 @@
 
 package io.getstream.feeds.android.client.api.file
 
+/**
+ * Represents a file that has been uploaded to the CDN.
+ *
+ * @property fileUrl The remote URL of the uploaded file.
+ * @property thumbnailUrl The remote URL of the generated thumbnail, when available (typically for
+ *   image and video uploads).
+ */
 public data class UploadedFile(val fileUrl: String, val thumbnailUrl: String?)

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/FeedAddActivityRequest.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/FeedAddActivityRequest.kt
@@ -21,11 +21,42 @@ import io.getstream.feeds.android.network.models.AddActivityRequest
 import io.getstream.feeds.android.network.models.Attachment
 import io.getstream.feeds.android.network.models.Location
 
+/**
+ * Request payload for adding a new activity to one or more feeds.
+ *
+ * @property request The activity request sent to the server.
+ * @property attachmentUploads Local files to upload and attach to the activity.
+ */
 public data class FeedAddActivityRequest
 internal constructor(
     val request: AddActivityRequest,
     val attachmentUploads: List<FeedUploadPayload> = emptyList(),
 ) {
+    /**
+     * Builds a [FeedAddActivityRequest] from individual activity fields.
+     *
+     * @param type The activity type (for example `"post"`).
+     * @param feeds The IDs of the feeds the activity should be added to.
+     * @param attachments Already-uploaded attachments to attach to the activity.
+     * @param attachmentUploads Local files to upload and attach to the activity.
+     * @param collectionRefs References to collection entries associated with the activity.
+     * @param createNotificationActivity Whether the server should create a notification activity.
+     * @param custom Custom data to attach to the activity.
+     * @param expiresAt Optional expiration timestamp for the activity.
+     * @param filterTags Tags used for filtering the activity.
+     * @param id Optional client-provided activity ID.
+     * @param interestTags Tags used to drive interest-based ranking.
+     * @param location Optional geographic location associated with the activity.
+     * @param mentionedUserIds IDs of users mentioned in the activity.
+     * @param parentId The ID of the parent activity, when this is a reply.
+     * @param pollId The ID of an associated poll, when applicable.
+     * @param restrictReplies The reply-restriction policy for the activity.
+     * @param searchData Additional data indexed for search.
+     * @param skipEnrichUrl Whether to skip URL enrichment when processing the activity text.
+     * @param text The textual content of the activity.
+     * @param visibility The visibility policy for the activity.
+     * @param visibilityTag The visibility tag used when [visibility] is tag-based.
+     */
     public constructor(
         type: String,
         feeds: List<String> = emptyList(),

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/ModerationConfigData.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/model/ModerationConfigData.kt
@@ -26,6 +26,25 @@ import io.getstream.feeds.android.network.models.BlockListConfig
 import io.getstream.feeds.android.network.models.VelocityFilterConfig
 import java.util.Date
 
+/**
+ * A moderation configuration: the set of policies that apply to entities matched by [key] within a
+ * [team]. Each non-null sub-config enables a moderation feature.
+ *
+ * @property aiImageConfig Image moderation configuration.
+ * @property aiTextConfig Text moderation configuration.
+ * @property aiVideoConfig Video moderation configuration.
+ * @property async When `true`, moderation runs asynchronously and does not block the originating
+ *   call.
+ * @property automodPlatformCircumventionConfig Platform-circumvention automod configuration.
+ * @property automodSemanticFiltersConfig Semantic-filter automod configuration.
+ * @property automodToxicityConfig Toxicity automod configuration.
+ * @property blockListConfig Word-blocklist configuration.
+ * @property createdAt When this configuration was created.
+ * @property key Identifier for this configuration, unique within a team.
+ * @property team Team this configuration belongs to. Empty for the default, app-wide config.
+ * @property updatedAt When this configuration was last updated.
+ * @property velocityFilterConfig Velocity-filter (anti-spam) configuration.
+ */
 public data class ModerationConfigData(
     public val aiImageConfig: AIImageConfig?,
     public val aiTextConfig: AITextConfig?,
@@ -41,6 +60,7 @@ public data class ModerationConfigData(
     public val updatedAt: Date,
     public val velocityFilterConfig: VelocityFilterConfig?,
 ) {
+    /** Alias for [key]. */
     public val id: String
         get() = key
 }

--- a/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/PollVoteListState.kt
+++ b/stream-feeds-android-client/src/main/kotlin/io/getstream/feeds/android/client/api/state/PollVoteListState.kt
@@ -21,6 +21,7 @@ import io.getstream.feeds.android.client.api.model.PollVoteData
 import io.getstream.feeds.android.client.api.state.query.PollVotesQuery
 import kotlinx.coroutines.flow.StateFlow
 
+/** Observable state of the poll votes returned by a [PollVotesQuery]. */
 public interface PollVoteListState {
 
     /** The query used to fetch the poll votes. */

--- a/stream-feeds-android-network/api/stream-feeds-android-network.api
+++ b/stream-feeds-android-network/api/stream-feeds-android-network.api
@@ -1,0 +1,11947 @@
+public abstract interface class io/getstream/feeds/android/network/apis/FeedsApi {
+	public abstract fun acceptFeedMemberInvite (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AcceptFeedMemberInviteRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun acceptFeedMemberInvite (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun acceptFollow (Lio/getstream/feeds/android/network/models/AcceptFollowRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun activityFeedback (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityFeedbackRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun activityFeedback (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addActivity (Lio/getstream/feeds/android/network/models/AddActivityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addActivityReaction (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddReactionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addBookmark (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addBookmark (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addComment (Lio/getstream/feeds/android/network/models/AddCommentRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addComment (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addCommentBookmark (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddCommentBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addCommentBookmark (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addCommentReaction (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddCommentReactionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addCommentsBatch (Lio/getstream/feeds/android/network/models/AddCommentsBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun addUserGroupMembers (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddUserGroupMembersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun appeal (Lio/getstream/feeds/android/network/models/AppealRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun ban (Lio/getstream/feeds/android/network/models/BanRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun blockUsers (Lio/getstream/feeds/android/network/models/BlockUsersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun castPollVote (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CastPollVoteRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun castPollVote (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createBlockList (Lio/getstream/feeds/android/network/models/CreateBlockListRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createCollections (Lio/getstream/feeds/android/network/models/CreateCollectionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createDevice (Lio/getstream/feeds/android/network/models/CreateDeviceRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createFeedsBatch (Lio/getstream/feeds/android/network/models/CreateFeedsBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createGuest (Lio/getstream/feeds/android/network/models/CreateGuestRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createPoll (Lio/getstream/feeds/android/network/models/CreatePollRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createPollOption (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreatePollOptionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun createUserGroup (Lio/getstream/feeds/android/network/models/CreateUserGroupRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteActivities (Lio/getstream/feeds/android/network/models/DeleteActivitiesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteActivity (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteActivity$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteActivityReaction (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteActivityReaction$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteBlockList (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteBlockList$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteBookmark (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteBookmark$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteBookmarkFolder (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteCollections (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteComment (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteComment$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteCommentBookmark (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteCommentBookmark$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteCommentReaction (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteCommentReaction$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteConfig (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteConfig$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteDevice (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun deleteFeed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteFeed$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteFile (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteFile$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteImage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteImage$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deletePoll (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deletePoll$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deletePollOption (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deletePollOption$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deletePollVote (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deletePollVote$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun deleteUserGroup (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun deleteUserGroup$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun flag (Lio/getstream/feeds/android/network/models/FlagRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun follow (Lio/getstream/feeds/android/network/models/FollowRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun followBatch (Lio/getstream/feeds/android/network/models/FollowBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getActivity (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getApp (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getAppeal (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getBlockedUsers (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getComment (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getCommentReplies (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getCommentReplies$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getComments (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getComments$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getConfig (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getConfig$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getFollowSuggestions (Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getFollowSuggestions$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getOG (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getOrCreateFeed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/GetOrCreateFeedRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getOrCreateFeed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getOrCreateFeed$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/GetOrCreateFeedRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getOrCreateFeed$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getOrCreateFollows (Lio/getstream/feeds/android/network/models/FollowBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getOrCreateUnfollows (Lio/getstream/feeds/android/network/models/UnfollowBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getPoll (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPoll$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getPollOption (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getPollOption$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getUserGroup (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getUserGroup$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun getUserLiveLocations (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listBlockLists (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listBlockLists$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun listDevices (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun listUserGroups (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun listUserGroups$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun longPoll (Ljava/lang/String;Lio/getstream/feeds/android/network/models/WSAuthMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun longPoll$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lio/getstream/feeds/android/network/models/WSAuthMessage;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun markActivity (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/MarkActivityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun markActivity (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun mute (Lio/getstream/feeds/android/network/models/MuteRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun ownBatch (Ljava/lang/String;Lio/getstream/feeds/android/network/models/OwnBatchRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun ownBatch$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lio/getstream/feeds/android/network/models/OwnBatchRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun pinActivity (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PinActivityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun pinActivity (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryActivities (Lio/getstream/feeds/android/network/models/QueryActivitiesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryActivities (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryActivityReactions (Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryActivityReactionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryActivityReactions (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryAppeals (Lio/getstream/feeds/android/network/models/QueryAppealsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryAppeals (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryBookmarkFolders (Lio/getstream/feeds/android/network/models/QueryBookmarkFoldersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryBookmarkFolders (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryBookmarks (Lio/getstream/feeds/android/network/models/QueryBookmarksRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryBookmarks (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryCollections (Lio/getstream/feeds/android/network/models/QueryCollectionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryCollections (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryCommentReactions (Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryCommentReactionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryCommentReactions (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryComments (Lio/getstream/feeds/android/network/models/QueryCommentsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryFeedMembers (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryFeedMembersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryFeedMembers (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryFeeds (Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryFeedsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryFeeds (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryFeeds$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryFeedsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryFeeds$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun queryFollows (Lio/getstream/feeds/android/network/models/QueryFollowsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryFollows (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryModerationConfigs (Lio/getstream/feeds/android/network/models/QueryModerationConfigsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryModerationConfigs (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryPinnedActivities (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryPinnedActivitiesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryPinnedActivities (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryPollVotes (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryPollVotesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryPollVotes (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryPollVotes$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryPollVotesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryPollVotes$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun queryPolls (Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryPollsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryPolls (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryPolls$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryPollsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryPolls$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun queryReviewQueue (Lio/getstream/feeds/android/network/models/QueryReviewQueueRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryReviewQueue (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun queryUsers (Lio/getstream/feeds/android/network/models/QueryUsersPayload;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun queryUsers$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Lio/getstream/feeds/android/network/models/QueryUsersPayload;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun readCollections (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun readCollections$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun rejectFeedMemberInvite (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/RejectFeedMemberInviteRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun rejectFeedMemberInvite (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun rejectFollow (Lio/getstream/feeds/android/network/models/RejectFollowRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun removeUserGroupMembers (Ljava/lang/String;Lio/getstream/feeds/android/network/models/RemoveUserGroupMembersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun restoreActivity (Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/RestoreActivityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun restoreActivity (Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun restoreActivity$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/RestoreActivityRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun restoreActivity$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun restoreComment (Ljava/lang/String;Lio/getstream/feeds/android/network/models/RestoreCommentRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun restoreComment (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun searchUserGroups (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun searchUserGroups$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun stopWatchingFeed (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun stopWatchingFeed$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun submitAction (Lio/getstream/feeds/android/network/models/SubmitActionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun trackActivityMetrics (Lio/getstream/feeds/android/network/models/TrackActivityMetricsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun unblockUsers (Lio/getstream/feeds/android/network/models/UnblockUsersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun unfollow (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unfollow$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun unpinActivity (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unpinActivity$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public abstract fun updateActivity (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateActivity (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateActivityPartial (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityPartialRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateActivityPartial (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateBlockList (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateBlockListRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateBlockList (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateBookmark (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateBookmark (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateBookmarkFolder (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateBookmarkFolderRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateBookmarkFolder (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateCollections (Lio/getstream/feeds/android/network/models/UpdateCollectionsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateComment (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateCommentRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateComment (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateCommentBookmark (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateCommentBookmarkRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateCommentBookmark (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateCommentPartial (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateCommentPartialRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateCommentPartial (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateFeed (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateFeedRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateFeed (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateFeedMembers (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateFollow (Lio/getstream/feeds/android/network/models/UpdateFollowRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateLiveLocation (Lio/getstream/feeds/android/network/models/UpdateLiveLocationRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePoll (Lio/getstream/feeds/android/network/models/UpdatePollRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePollOption (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdatePollOptionRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePollPartial (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdatePollPartialRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePollPartial (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updatePushNotificationPreferences (Lio/getstream/feeds/android/network/models/UpsertPushPreferencesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateUserGroup (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateUserGroupRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateUserGroup (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateUsers (Lio/getstream/feeds/android/network/models/UpdateUsersRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun updateUsersPartial (Lio/getstream/feeds/android/network/models/UpdateUsersPartialRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun uploadFile (Lio/getstream/feeds/android/network/models/FileUploadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun uploadFile (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun uploadImage (Lio/getstream/feeds/android/network/models/ImageUploadRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun uploadImage (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun upsertActivities (Lio/getstream/feeds/android/network/models/UpsertActivitiesRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun upsertConfig (Lio/getstream/feeds/android/network/models/UpsertConfigRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/network/apis/FeedsApi$DefaultImpls {
+	public static synthetic fun deleteActivity$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteActivityReaction$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteBlockList$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteBookmark$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteComment$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteCommentBookmark$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteCommentReaction$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteConfig$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteFeed$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteFile$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteImage$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deletePoll$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deletePollOption$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deletePollVote$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun deleteUserGroup$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getCommentReplies$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getComments$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getConfig$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getFollowSuggestions$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getOrCreateFeed$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/GetOrCreateFeedRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getOrCreateFeed$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getPoll$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getPollOption$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun getUserGroup$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun listBlockLists$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun listUserGroups$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun longPoll$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lio/getstream/feeds/android/network/models/WSAuthMessage;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun ownBatch$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lio/getstream/feeds/android/network/models/OwnBatchRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryFeeds$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryFeedsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryFeeds$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryPollVotes$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryPollVotesRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryPollVotes$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryPolls$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryPollsRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryPolls$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun queryUsers$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Lio/getstream/feeds/android/network/models/QueryUsersPayload;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun readCollections$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/util/List;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun restoreActivity$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/RestoreActivityRequest;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun restoreActivity$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun searchUserGroups$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun stopWatchingFeed$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun unfollow$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun unpinActivity$default (Lio/getstream/feeds/android/network/apis/FeedsApi;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class io/getstream/feeds/android/network/infrastructure/BigDecimalAdapter {
+	public fun <init> ()V
+	public final fun fromJson (Ljava/lang/String;)Ljava/math/BigDecimal;
+	public final fun toJson (Ljava/math/BigDecimal;)Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/infrastructure/BigIntegerAdapter {
+	public fun <init> ()V
+	public final fun fromJson (Ljava/lang/String;)Ljava/math/BigInteger;
+	public final fun toJson (Ljava/math/BigInteger;)Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/infrastructure/ByteArrayAdapter {
+	public fun <init> ()V
+	public final fun fromJson (Ljava/lang/String;)[B
+	public final fun toJson ([B)Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/infrastructure/JavaUtilDateTimeAdapter {
+	public fun <init> ()V
+	public final fun fromJson (Ljava/lang/String;)Ljava/util/Date;
+	public final fun toJson (Ljava/util/Date;)Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/infrastructure/MoshiQueryConverterFactory : retrofit2/Converter$Factory {
+	public fun <init> (Lcom/squareup/moshi/Moshi;)V
+	public fun stringConverter (Ljava/lang/reflect/Type;[Ljava/lang/annotation/Annotation;Lretrofit2/Retrofit;)Lretrofit2/Converter;
+}
+
+public final class io/getstream/feeds/android/network/infrastructure/Serializer {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/infrastructure/Serializer;
+	public static final fun getMoshi ()Lcom/squareup/moshi/Moshi;
+	public static final fun getMoshiBuilder ()Lcom/squareup/moshi/Moshi$Builder;
+}
+
+public final class io/getstream/feeds/android/network/infrastructure/URIAdapter {
+	public fun <init> ()V
+	public final fun fromJson (Ljava/lang/String;)Ljava/net/URI;
+	public final fun toJson (Ljava/net/URI;)Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/infrastructure/UUIDAdapter {
+	public fun <init> ()V
+	public final fun fromJson (Ljava/lang/String;)Ljava/util/UUID;
+	public final fun toJson (Ljava/util/UUID;)Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AIImageConfig {
+	public fun <init> (ZLjava/util/List;Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (ZLjava/util/List;Ljava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AIImageConfig;ZLjava/util/List;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getEnabled ()Z
+	public final fun getOcrRules ()Ljava/util/List;
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AIImageLabelDefinition {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AIImageLabelDefinition;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AIImageLabelDefinition;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AIImageLabelDefinition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AITextConfig {
+	public fun <init> (ZLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun copy (ZLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AITextConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AITextConfig;ZLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AITextConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getEnabled ()Z
+	public final fun getProfile ()Ljava/lang/String;
+	public final fun getRules ()Ljava/util/List;
+	public final fun getSeverityRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AIVideoConfig {
+	public fun <init> (ZLjava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (ZLjava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AIVideoConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AIVideoConfig;ZLjava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AIVideoConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getEnabled ()Z
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;Ljava/lang/String;FLjava/util/Map;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;Ljava/lang/String;FLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()F
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;Ljava/lang/String;FLjava/util/Map;)Lio/getstream/feeds/android/network/models/AWSRekognitionRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AWSRekognitionRule;Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;Ljava/lang/String;FLjava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AWSRekognitionRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getMinConfidence ()F
+	public final fun getSubclassifications ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Bounce : io/getstream/feeds/android/network/models/AWSRekognitionRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Bounce;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$BounceFlag : io/getstream/feeds/android/network/models/AWSRekognitionRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$BounceFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$BounceRemove : io/getstream/feeds/android/network/models/AWSRekognitionRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$BounceRemove;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Flag : io/getstream/feeds/android/network/models/AWSRekognitionRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Remove : io/getstream/feeds/android/network/models/AWSRekognitionRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Shadow : io/getstream/feeds/android/network/models/AWSRekognitionRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Unknown : io/getstream/feeds/android/network/models/AWSRekognitionRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AWSRekognitionRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AcceptFeedMemberInviteRequest {
+	public fun <init> ()V
+}
+
+public final class io/getstream/feeds/android/network/models/AcceptFeedMemberInviteResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)Lio/getstream/feeds/android/network/models/AcceptFeedMemberInviteResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AcceptFeedMemberInviteResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AcceptFeedMemberInviteResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getMember ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AcceptFollowRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AcceptFollowRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AcceptFollowRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AcceptFollowRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFollowerRole ()Ljava/lang/String;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getTarget ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AcceptFollowResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;)Lio/getstream/feeds/android/network/models/AcceptFollowResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AcceptFollowResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AcceptFollowResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Action {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/Action;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/Action;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/Action;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStyle ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActionLogResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/ActionLogResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActionLogResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActionLogResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiProviders ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getReviewQueueItem ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun getTargetUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getTargetUserId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityAddedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityAddedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityAddedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityAddedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityDeletedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityFeedbackEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityFeedbackEvent;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityFeedbackEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityFeedback ()Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload {
+	public fun <init> (Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun copy (Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action;
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$Hide : io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$Hide;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$ShowLess : io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$ShowLess;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$ShowMore : io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$ShowMore;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$Unknown : io/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityFeedbackEventPayload$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/ActivityFeedbackRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityFeedbackRequest;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityFeedbackRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHide ()Ljava/lang/Boolean;
+	public final fun getShowLess ()Ljava/lang/Boolean;
+	public final fun getShowMore ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityFeedbackResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityFeedbackResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityFeedbackResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityFeedbackResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityMarkEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityMarkEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityMarkEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityMarkEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getMarkAllRead ()Ljava/lang/Boolean;
+	public final fun getMarkAllSeen ()Ljava/lang/Boolean;
+	public final fun getMarkRead ()Ljava/util/List;
+	public final fun getMarkSeen ()Ljava/util/List;
+	public final fun getMarkWatched ()Ljava/util/List;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityPinResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/ActivityPinResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityPinResponse;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityPinResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getFeed ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityPinnedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/PinActivityResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityPinnedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityPinnedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityPinnedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getPinnedActivity ()Lio/getstream/feeds/android/network/models/PinActivityResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityProcessorConfig {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ActivityProcessorConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityProcessorConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityProcessorConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfig ()Ljava/util/Map;
+	public final fun getOpenaiKey ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityReactionAddedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityReactionAddedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityReactionAddedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityReactionAddedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityReactionDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityReactionDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityReactionDeletedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityReactionDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityReactionUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityReactionUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityReactionUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityReactionUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRemovedFromFeedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityRemovedFromFeedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityRemovedFromFeedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityRemovedFromFeedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Ljava/util/Map;
+	public final fun component21 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component22 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ActivityRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityRequest;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getCollectionRefs ()Ljava/util/List;
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCreateNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getExpiresAt ()Ljava/lang/String;
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInterestTags ()Ljava/util/List;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMentionedUserIds ()Ljava/util/List;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getPollId ()Ljava/lang/String;
+	public final fun getRestrictReplies ()Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;
+	public final fun getSearchData ()Ljava/util/Map;
+	public final fun getSkipEnrichUrl ()Ljava/lang/Boolean;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getVisibility ()Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;
+	public final fun getVisibilityTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies {
+	public static final field Companion Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Everyone : io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Everyone;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Nobody : io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Nobody;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$PeopleIFollow : io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$PeopleIFollow;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$RestrictRepliesAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Unknown : io/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityRequest$RestrictReplies$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/ActivityRequest$Visibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$Visibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$Visibility$Private : io/getstream/feeds/android/network/models/ActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility$Private;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$Visibility$Public : io/getstream/feeds/android/network/models/ActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$Visibility$Tag : io/getstream/feeds/android/network/models/ActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility$Tag;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$Visibility$Unknown : io/getstream/feeds/android/network/models/ActivityRequest$Visibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRequest$Visibility$VisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/ActivityRequest$Visibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse {
+	public fun <init> (IILjava/util/Date;ZLjava/lang/String;IZILio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;FILjava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;Lio/getstream/feeds/android/network/models/NotificationContext;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/util/Map;)V
+	public synthetic fun <init> (IILjava/util/Date;ZLjava/lang/String;IZILio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;FILjava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;Lio/getstream/feeds/android/network/models/NotificationContext;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/util/Map;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()F
+	public final fun component11 ()I
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/util/Date;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Ljava/util/Map;
+	public final fun component25 ()Ljava/util/Map;
+	public final fun component26 ()Ljava/util/Map;
+	public final fun component27 ()Ljava/util/Map;
+	public final fun component28 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component29 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component30 ()Ljava/util/Date;
+	public final fun component31 ()Ljava/util/Date;
+	public final fun component32 ()Ljava/lang/Integer;
+	public final fun component33 ()Ljava/lang/Boolean;
+	public final fun component34 ()Ljava/lang/Boolean;
+	public final fun component35 ()Ljava/lang/Boolean;
+	public final fun component36 ()Ljava/lang/String;
+	public final fun component37 ()Ljava/lang/String;
+	public final fun component38 ()Ljava/lang/String;
+	public final fun component39 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component40 ()Ljava/util/List;
+	public final fun component41 ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun component42 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component43 ()Ljava/util/Map;
+	public final fun component44 ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun component45 ()Lio/getstream/feeds/android/network/models/NotificationContext;
+	public final fun component46 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component47 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun component48 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()I
+	public final fun component7 ()Z
+	public final fun component8 ()I
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;
+	public final fun copy (IILjava/util/Date;ZLjava/lang/String;IZILio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;FILjava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;Lio/getstream/feeds/android/network/models/NotificationContext;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityResponse;IILjava/util/Date;ZLjava/lang/String;IZILio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;FILjava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;Lio/getstream/feeds/android/network/models/NotificationContext;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/util/Map;IILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getBookmarkCount ()I
+	public final fun getCollections ()Ljava/util/Map;
+	public final fun getCommentCount ()I
+	public final fun getComments ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCurrentFeed ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getEditedAt ()Ljava/util/Date;
+	public final fun getExpiresAt ()Ljava/util/Date;
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getFriendReactionCount ()Ljava/lang/Integer;
+	public final fun getFriendReactions ()Ljava/util/List;
+	public final fun getHidden ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInterestTags ()Ljava/util/List;
+	public final fun getLatestReactions ()Ljava/util/List;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMentionedUsers ()Ljava/util/List;
+	public final fun getMetrics ()Ljava/util/Map;
+	public final fun getModeration ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun getModerationAction ()Ljava/lang/String;
+	public final fun getNotificationContext ()Lio/getstream/feeds/android/network/models/NotificationContext;
+	public final fun getOwnBookmarks ()Ljava/util/List;
+	public final fun getOwnReactions ()Ljava/util/List;
+	public final fun getParent ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun getPopularity ()I
+	public final fun getPreview ()Z
+	public final fun getReactionCount ()I
+	public final fun getReactionGroups ()Ljava/util/Map;
+	public final fun getRestrictReplies ()Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;
+	public final fun getScore ()F
+	public final fun getScoreVars ()Ljava/util/Map;
+	public final fun getSearchData ()Ljava/util/Map;
+	public final fun getSelectorSource ()Ljava/lang/String;
+	public final fun getShareCount ()I
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getVisibility ()Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;
+	public final fun getVisibilityTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isRead ()Ljava/lang/Boolean;
+	public final fun isSeen ()Ljava/lang/Boolean;
+	public final fun isWatched ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies {
+	public static final field Companion Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Everyone : io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Everyone;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Nobody : io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Nobody;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$PeopleIFollow : io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$PeopleIFollow;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$RestrictRepliesAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Unknown : io/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityResponse$RestrictReplies$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/ActivityResponse$Visibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$Visibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$Visibility$Private : io/getstream/feeds/android/network/models/ActivityResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility$Private;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$Visibility$Public : io/getstream/feeds/android/network/models/ActivityResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$Visibility$Tag : io/getstream/feeds/android/network/models/ActivityResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility$Tag;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$Visibility$Unknown : io/getstream/feeds/android/network/models/ActivityResponse$Visibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityResponse$Visibility$VisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/ActivityResponse$Visibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityRestoredEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityRestoredEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityRestoredEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityRestoredEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivitySelectorConfig {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ActivitySelectorConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivitySelectorConfig;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivitySelectorConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCutoffTime ()Ljava/util/Date;
+	public final fun getCutoffWindow ()Ljava/lang/String;
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getMinPopularity ()Ljava/lang/Integer;
+	public final fun getParams ()Ljava/util/Map;
+	public final fun getSort ()Ljava/util/List;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityUnpinnedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/PinActivityResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityUnpinnedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityUnpinnedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityUnpinnedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getPinnedActivity ()Lio/getstream/feeds/android/network/models/PinActivityResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ActivityUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/ActivityUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ActivityUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ActivityUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Ljava/util/Map;
+	public final fun component22 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component23 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/AddActivityRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddActivityRequest;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddActivityRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getCollectionRefs ()Ljava/util/List;
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCreateNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getExpiresAt ()Ljava/lang/String;
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInterestTags ()Ljava/util/List;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMentionedUserIds ()Ljava/util/List;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getPollId ()Ljava/lang/String;
+	public final fun getRestrictReplies ()Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;
+	public final fun getSearchData ()Ljava/util/Map;
+	public final fun getSkipEnrichUrl ()Ljava/lang/Boolean;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getVisibility ()Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;
+	public final fun getVisibilityTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies {
+	public static final field Companion Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Everyone : io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Everyone;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Nobody : io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Nobody;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$PeopleIFollow : io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$PeopleIFollow;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$RestrictRepliesAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Unknown : io/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddActivityRequest$RestrictReplies$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/AddActivityRequest$Visibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Private : io/getstream/feeds/android/network/models/AddActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Private;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Public : io/getstream/feeds/android/network/models/AddActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Tag : io/getstream/feeds/android/network/models/AddActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Tag;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Unknown : io/getstream/feeds/android/network/models/AddActivityRequest$Visibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityRequest$Visibility$VisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/AddActivityRequest$Visibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/AddActivityResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/lang/Integer;)Lio/getstream/feeds/android/network/models/AddActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddActivityResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getMentionNotificationsCreated ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddBookmarkRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;)Lio/getstream/feeds/android/network/models/AddBookmarkRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddBookmarkRequest;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddBookmarkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFolderId ()Ljava/lang/String;
+	public final fun getNewFolder ()Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddBookmarkResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)Lio/getstream/feeds/android/network/models/AddBookmarkResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddBookmarkResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddBookmarkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddCommentBookmarkRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;)Lio/getstream/feeds/android/network/models/AddCommentBookmarkRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddCommentBookmarkRequest;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddCommentBookmarkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFolderId ()Ljava/lang/String;
+	public final fun getNewFolder ()Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddCommentBookmarkResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)Lio/getstream/feeds/android/network/models/AddCommentBookmarkResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddCommentBookmarkResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddCommentBookmarkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddCommentReactionRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/AddCommentReactionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddCommentReactionRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddCommentReactionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCreateNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getEnforceUnique ()Ljava/lang/Boolean;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddCommentReactionResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AddCommentReactionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddCommentReactionResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddCommentReactionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNotificationCreated ()Ljava/lang/Boolean;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddCommentRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/AddCommentRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddCommentRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddCommentRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCreateNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMentionedUserIds ()Ljava/util/List;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getSkipEnrichUrl ()Ljava/lang/Boolean;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddCommentResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/lang/Integer;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/lang/Integer;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/lang/Integer;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AddCommentResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddCommentResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/lang/Integer;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddCommentResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getMentionNotificationsCreated ()Ljava/lang/Integer;
+	public final fun getNotificationCreated ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddCommentsBatchRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/getstream/feeds/android/network/models/AddCommentsBatchRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddCommentsBatchRequest;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddCommentsBatchRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComments ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddCommentsBatchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/AddCommentsBatchResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddCommentsBatchResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddCommentsBatchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComments ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddFolderRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddFolderRequest;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddReactionRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/AddReactionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddReactionRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddReactionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCreateNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getEnforceUnique ()Ljava/lang/Boolean;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddReactionResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AddReactionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddReactionResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddReactionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNotificationCreated ()Ljava/lang/Boolean;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddUserGroupMembersRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AddUserGroupMembersRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddUserGroupMembersRequest;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddUserGroupMembersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsAdmin ()Ljava/lang/Boolean;
+	public final fun getMemberIds ()Ljava/util/List;
+	public final fun getTeamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AddUserGroupMembersResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)Lio/getstream/feeds/android/network/models/AddUserGroupMembersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AddUserGroupMembersResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AddUserGroupMembersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUserGroup ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AggregatedActivityResponse {
+	public fun <init> (ILjava/util/Date;Ljava/lang/String;FLjava/util/Date;IZLjava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ILjava/util/Date;Ljava/lang/String;FLjava/util/Date;IZLjava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()F
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()I
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (ILjava/util/Date;Ljava/lang/String;FLjava/util/Date;IZLjava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AggregatedActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AggregatedActivityResponse;ILjava/util/Date;Ljava/lang/String;FLjava/util/Date;IZLjava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AggregatedActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivities ()Ljava/util/List;
+	public final fun getActivityCount ()I
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getGroup ()Ljava/lang/String;
+	public final fun getScore ()F
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserCount ()I
+	public final fun getUserCountTruncated ()Z
+	public fun hashCode ()I
+	public final fun isRead ()Ljava/lang/Boolean;
+	public final fun isSeen ()Ljava/lang/Boolean;
+	public final fun isWatched ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AggregationConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AggregationConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AggregationConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AggregationConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivitiesSort ()Ljava/lang/String;
+	public final fun getFormat ()Ljava/lang/String;
+	public final fun getGroupSize ()Ljava/lang/Integer;
+	public final fun getScoreStrategy ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AppEventResponse {
+	public fun <init> (ZLjava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FileUploadConfig;Lio/getstream/feeds/android/network/models/FileUploadConfig;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FileUploadConfig;Lio/getstream/feeds/android/network/models/FileUploadConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FileUploadConfig;Lio/getstream/feeds/android/network/models/FileUploadConfig;)Lio/getstream/feeds/android/network/models/AppEventResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AppEventResponse;ZLjava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FileUploadConfig;Lio/getstream/feeds/android/network/models/FileUploadConfig;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AppEventResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsyncUrlEnrichEnabled ()Ljava/lang/Boolean;
+	public final fun getAutoTranslationEnabled ()Z
+	public final fun getFileUploadConfig ()Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public final fun getImageUploadConfig ()Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AppResponseFields {
+	public fun <init> (ZZILjava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FileUploadConfig;Lio/getstream/feeds/android/network/models/FileUploadConfig;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public final fun copy (ZZILjava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FileUploadConfig;Lio/getstream/feeds/android/network/models/FileUploadConfig;)Lio/getstream/feeds/android/network/models/AppResponseFields;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AppResponseFields;ZZILjava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FileUploadConfig;Lio/getstream/feeds/android/network/models/FileUploadConfig;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AppResponseFields;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsyncUrlEnrichEnabled ()Z
+	public final fun getAutoTranslationEnabled ()Z
+	public final fun getFileUploadConfig ()Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public final fun getId ()I
+	public final fun getImageUploadConfig ()Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPlacement ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AppUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/AppEventResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/AppEventResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/AppEventResponse;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Lio/getstream/feeds/android/network/models/AppEventResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/AppUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AppUpdatedEvent;Ljava/util/Date;Lio/getstream/feeds/android/network/models/AppEventResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AppUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApp ()Lio/getstream/feeds/android/network/models/AppEventResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AppealItemResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/ModerationPayload;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/ModerationPayload;Lio/getstream/feeds/android/network/models/UserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/ModerationPayload;
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/ModerationPayload;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/AppealItemResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AppealItemResponse;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/ModerationPayload;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AppealItemResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppealReason ()Ljava/lang/String;
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getDecisionReason ()Ljava/lang/String;
+	public final fun getEntityContent ()Lio/getstream/feeds/android/network/models/ModerationPayload;
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AppealRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/AppealRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AppealRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AppealRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppealReason ()Ljava/lang/String;
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AppealResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AppealResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AppealResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AppealResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppealId ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Attachment {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/Images;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/Images;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/Integer;
+	public final fun component13 ()Ljava/lang/Integer;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Lio/getstream/feeds/android/network/models/Images;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/Images;)Lio/getstream/feeds/android/network/models/Attachment;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/Attachment;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/Images;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/Attachment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActions ()Ljava/util/List;
+	public final fun getAssetUrl ()Ljava/lang/String;
+	public final fun getAuthorIcon ()Ljava/lang/String;
+	public final fun getAuthorLink ()Ljava/lang/String;
+	public final fun getAuthorName ()Ljava/lang/String;
+	public final fun getColor ()Ljava/lang/String;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFallback ()Ljava/lang/String;
+	public final fun getFields ()Ljava/util/List;
+	public final fun getFooter ()Ljava/lang/String;
+	public final fun getFooterIcon ()Ljava/lang/String;
+	public final fun getGiphy ()Lio/getstream/feeds/android/network/models/Images;
+	public final fun getImageUrl ()Ljava/lang/String;
+	public final fun getOgScrapeUrl ()Ljava/lang/String;
+	public final fun getOriginalHeight ()Ljava/lang/Integer;
+	public final fun getOriginalWidth ()Ljava/lang/Integer;
+	public final fun getPretext ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getThumbUrl ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTitleLink ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig {
+	public fun <init> (ZLjava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (ZLjava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;ZLjava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getEnabled ()Z
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/AutomodRule$Action;Ljava/lang/String;F)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/AutomodRule$Action;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()F
+	public final fun copy (Lio/getstream/feeds/android/network/models/AutomodRule$Action;Ljava/lang/String;F)Lio/getstream/feeds/android/network/models/AutomodRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AutomodRule;Lio/getstream/feeds/android/network/models/AutomodRule$Action;Ljava/lang/String;FILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AutomodRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/AutomodRule$Action;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getThreshold ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/AutomodRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/AutomodRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/AutomodRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/AutomodRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$Bounce : io/getstream/feeds/android/network/models/AutomodRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodRule$Action$Bounce;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$BounceFlag : io/getstream/feeds/android/network/models/AutomodRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodRule$Action$BounceFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$BounceRemove : io/getstream/feeds/android/network/models/AutomodRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodRule$Action$BounceRemove;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AutomodRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$Flag : io/getstream/feeds/android/network/models/AutomodRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$Remove : io/getstream/feeds/android/network/models/AutomodRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$Shadow : io/getstream/feeds/android/network/models/AutomodRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodRule$Action$Unknown : io/getstream/feeds/android/network/models/AutomodRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AutomodRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AutomodRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AutomodRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig {
+	public fun <init> (ZLjava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (ZLjava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;ZLjava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getEnabled ()Z
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action;Ljava/lang/String;F)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()F
+	public final fun copy (Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action;Ljava/lang/String;F)Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action;Ljava/lang/String;FILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getThreshold ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Bounce : io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Bounce;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$BounceFlag : io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$BounceFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$BounceRemove : io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$BounceRemove;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Flag : io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Remove : io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Shadow : io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Unknown : io/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/AutomodToxicityConfig {
+	public fun <init> (ZLjava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (ZLjava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;ZLjava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getEnabled ()Z
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BanActionRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/feeds/android/network/models/BanActionRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BanActionRequestPayload;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BanActionRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBanFromFutureChannels ()Ljava/lang/Boolean;
+	public final fun getChannelBanOnly ()Ljava/lang/Boolean;
+	public final fun getChannelCid ()Ljava/lang/String;
+	public final fun getDeleteMessages ()Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;
+	public final fun getIpBan ()Ljava/lang/Boolean;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getShadow ()Ljava/lang/Boolean;
+	public final fun getTargetUserId ()Ljava/lang/String;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages {
+	public static final field Companion Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;
+}
+
+public final class io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$DeleteMessagesAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Hard : io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Hard;
+}
+
+public final class io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Pruning : io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Pruning;
+}
+
+public final class io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Soft : io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Soft;
+}
+
+public final class io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Unknown : io/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BanActionRequestPayload$DeleteMessages$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BanInfoResponse {
+	public fun <init> (Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun copy (Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/BanInfoResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BanInfoResponse;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BanInfoResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getExpires ()Ljava/util/Date;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getShadow ()Ljava/lang/Boolean;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BanOptions {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun copy (Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/BanOptions;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BanOptions;Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BanOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeleteMessages ()Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;
+	public final fun getDuration ()Ljava/lang/Integer;
+	public final fun getIpBan ()Ljava/lang/Boolean;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getShadowBan ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/BanOptions$DeleteMessages {
+	public static final field Companion Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;
+}
+
+public final class io/getstream/feeds/android/network/models/BanOptions$DeleteMessages$DeleteMessagesAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Hard : io/getstream/feeds/android/network/models/BanOptions$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Hard;
+}
+
+public final class io/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Pruning : io/getstream/feeds/android/network/models/BanOptions$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Pruning;
+}
+
+public final class io/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Soft : io/getstream/feeds/android/network/models/BanOptions$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Soft;
+}
+
+public final class io/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Unknown : io/getstream/feeds/android/network/models/BanOptions$DeleteMessages {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BanOptions$DeleteMessages$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BanRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UserRequest;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UserRequest;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserRequest;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UserRequest;)Lio/getstream/feeds/android/network/models/BanRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BanRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UserRequest;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BanRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBannedBy ()Lio/getstream/feeds/android/network/models/UserRequest;
+	public final fun getBannedById ()Ljava/lang/String;
+	public final fun getChannelCid ()Ljava/lang/String;
+	public final fun getDeleteMessages ()Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;
+	public final fun getIpBan ()Ljava/lang/Boolean;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getShadow ()Ljava/lang/Boolean;
+	public final fun getTargetUserId ()Ljava/lang/String;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/BanRequest$DeleteMessages {
+	public static final field Companion Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;
+}
+
+public final class io/getstream/feeds/android/network/models/BanRequest$DeleteMessages$DeleteMessagesAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Hard : io/getstream/feeds/android/network/models/BanRequest$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Hard;
+}
+
+public final class io/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Pruning : io/getstream/feeds/android/network/models/BanRequest$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Pruning;
+}
+
+public final class io/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Soft : io/getstream/feeds/android/network/models/BanRequest$DeleteMessages {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Soft;
+}
+
+public final class io/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Unknown : io/getstream/feeds/android/network/models/BanRequest$DeleteMessages {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BanRequest$DeleteMessages$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BanResponse {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BanResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BanResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BanResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockActionRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListConfig {
+	public fun <init> (ZLjava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (ZLjava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/BlockListConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockListConfig;ZLjava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockListConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getEnabled ()Z
+	public final fun getMatchSubstring ()Ljava/lang/Boolean;
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListOptions {
+	public fun <init> (Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior;Ljava/lang/String;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockListOptions;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockListOptions;Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockListOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBehavior ()Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior;
+	public final fun getBlocklist ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/BlockListOptions$Behavior {
+	public static final field Companion Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListOptions$Behavior$BehaviorAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListOptions$Behavior$Block : io/getstream/feeds/android/network/models/BlockListOptions$Behavior {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior$Block;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListOptions$Behavior$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListOptions$Behavior$Flag : io/getstream/feeds/android/network/models/BlockListOptions$Behavior {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListOptions$Behavior$ShadowBlock : io/getstream/feeds/android/network/models/BlockListOptions$Behavior {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior$ShadowBlock;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListOptions$Behavior$Unknown : io/getstream/feeds/android/network/models/BlockListOptions$Behavior {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockListOptions$Behavior$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListResponse {
+	public fun <init> (ZZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (ZZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (ZZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/BlockListResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockListResponse;ZZLjava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockListResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTeam ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getWords ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isLeetCheckEnabled ()Z
+	public final fun isPluralCheckEnabled ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/BlockListRule$Action;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/BlockListRule$Action;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/feeds/android/network/models/BlockListRule$Action;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockListRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockListRule;Lio/getstream/feeds/android/network/models/BlockListRule$Action;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockListRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/BlockListRule$Action;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTeam ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/BlockListRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/BlockListRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/BlockListRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$Bounce : io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListRule$Action$Bounce;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$BounceFlag : io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListRule$Action$BounceFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$BounceRemove : io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListRule$Action$BounceRemove;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockListRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$Flag : io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$MaskFlag : io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListRule$Action$MaskFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$Remove : io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$Shadow : io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BlockListRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockListRule$Action$Unknown : io/getstream/feeds/android/network/models/BlockListRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockListRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockListRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockListRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockUsersRequest {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockUsersRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockUsersRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockUsersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockedUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockUsersResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BlockUsersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockUsersResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockUsersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockedByUserId ()Ljava/lang/String;
+	public final fun getBlockedUserId ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BlockedUserResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/BlockedUserResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BlockedUserResponse;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BlockedUserResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockedUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getBlockedUserId ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/BodyguardRule$Action;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/BodyguardRule$Action;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/BodyguardRule$Action;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Lio/getstream/feeds/android/network/models/BodyguardRule$Action;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/BodyguardRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BodyguardRule;Lio/getstream/feeds/android/network/models/BodyguardRule$Action;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BodyguardRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/BodyguardRule$Action;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getSeverityRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/BodyguardRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/BodyguardRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/BodyguardRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/BodyguardRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$Bounce : io/getstream/feeds/android/network/models/BodyguardRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardRule$Action$Bounce;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$BounceFlag : io/getstream/feeds/android/network/models/BodyguardRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardRule$Action$BounceFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$BounceRemove : io/getstream/feeds/android/network/models/BodyguardRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardRule$Action$BounceRemove;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BodyguardRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$Flag : io/getstream/feeds/android/network/models/BodyguardRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$Remove : io/getstream/feeds/android/network/models/BodyguardRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$Shadow : io/getstream/feeds/android/network/models/BodyguardRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardRule$Action$Unknown : io/getstream/feeds/android/network/models/BodyguardRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BodyguardRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BodyguardRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BodyguardRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action;Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity;
+	public final fun copy (Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action;Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BodyguardSeverityRule;Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action;Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action;
+	public final fun getSeverity ()Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Bounce : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Bounce;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$BounceFlag : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$BounceFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$BounceRemove : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$BounceRemove;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Flag : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Remove : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Shadow : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Unknown : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity {
+	public static final field Companion Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Critical : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Critical;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$High : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$High;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Low : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Low;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Medium : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Medium;
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$SeverityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Unknown : io/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BodyguardSeverityRule$Severity$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BookmarkAddedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/BookmarkAddedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BookmarkAddedEvent;Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BookmarkAddedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BookmarkDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/BookmarkDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BookmarkDeletedEvent;Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BookmarkDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BookmarkFolderDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/BookmarkFolderDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BookmarkFolderDeletedEvent;Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BookmarkFolderDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmarkFolder ()Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BookmarkFolderResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BookmarkFolderUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/BookmarkFolderUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BookmarkFolderUpdatedEvent;Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BookmarkFolderUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmarkFolder ()Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BookmarkResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;)Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFolder ()Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BookmarkUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/BookmarkUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BookmarkUpdatedEvent;Ljava/util/Date;Lio/getstream/feeds/android/network/models/BookmarkResponse;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BookmarkUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/BypassActionRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/BypassActionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/BypassActionRequest;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/BypassActionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CastPollVoteRequest {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/feeds/android/network/models/VoteData;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/VoteData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/VoteData;
+	public final fun copy (Lio/getstream/feeds/android/network/models/VoteData;)Lio/getstream/feeds/android/network/models/CastPollVoteRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CastPollVoteRequest;Lio/getstream/feeds/android/network/models/VoteData;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CastPollVoteRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getVote ()Lio/getstream/feeds/android/network/models/VoteData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CollectionRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CollectionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CollectionRequest;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CollectionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CollectionResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/CollectionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CollectionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CollectionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentAddedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/CommentAddedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentAddedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentAddedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/CommentDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentDeletedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentReactionAddedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/CommentReactionAddedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentReactionAddedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentReactionAddedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentReactionDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/CommentReactionDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentReactionDeletedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentReactionDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentReactionUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/CommentReactionUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentReactionUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentReactionUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse {
+	public fun <init> (IFLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILio/getstream/feeds/android/network/models/CommentResponse$Status;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/util/Map;)V
+	public synthetic fun <init> (IFLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILio/getstream/feeds/android/network/models/CommentResponse$Status;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()I
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/CommentResponse$Status;
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()I
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component17 ()Ljava/lang/Float;
+	public final fun component18 ()Ljava/util/Date;
+	public final fun component19 ()Ljava/util/Date;
+	public final fun component2 ()F
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Ljava/util/Map;
+	public final fun component25 ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun component26 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (IFLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILio/getstream/feeds/android/network/models/CommentResponse$Status;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/CommentResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentResponse;IFLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILio/getstream/feeds/android/network/models/CommentResponse$Status;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getBookmarkCount ()I
+	public final fun getConfidenceScore ()F
+	public final fun getControversyScore ()Ljava/lang/Float;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDownvoteCount ()I
+	public final fun getEditedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLatestReactions ()Ljava/util/List;
+	public final fun getMentionedUsers ()Ljava/util/List;
+	public final fun getModeration ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getOwnReactions ()Ljava/util/List;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getReactionCount ()I
+	public final fun getReactionGroups ()Ljava/util/Map;
+	public final fun getReplyCount ()I
+	public final fun getScore ()I
+	public final fun getStatus ()Lio/getstream/feeds/android/network/models/CommentResponse$Status;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUpvoteCount ()I
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/CommentResponse$Status {
+	public static final field Companion Lio/getstream/feeds/android/network/models/CommentResponse$Status$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse$Status$Active : io/getstream/feeds/android/network/models/CommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CommentResponse$Status$Active;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse$Status$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CommentResponse$Status;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse$Status$Deleted : io/getstream/feeds/android/network/models/CommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CommentResponse$Status$Deleted;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse$Status$Hidden : io/getstream/feeds/android/network/models/CommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CommentResponse$Status$Hidden;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse$Status$Removed : io/getstream/feeds/android/network/models/CommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CommentResponse$Status$Removed;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse$Status$ShadowBlocked : io/getstream/feeds/android/network/models/CommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CommentResponse$Status$ShadowBlocked;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse$Status$StatusAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/CommentResponse$Status;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/CommentResponse$Status;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/CommentResponse$Status$Unknown : io/getstream/feeds/android/network/models/CommentResponse$Status {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CommentResponse$Status$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentResponse$Status$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentResponse$Status$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentRestoredEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/CommentRestoredEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentRestoredEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentRestoredEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CommentUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/CommentUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CommentUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CommentUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ConfigResponse {
+	public fun <init> (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/AIImageConfig;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Lio/getstream/feeds/android/network/models/LLMConfig;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;)V
+	public synthetic fun <init> (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/AIImageConfig;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Lio/getstream/feeds/android/network/models/LLMConfig;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/AITextConfig;
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/AIVideoConfig;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/BlockListConfig;
+	public final fun component16 ()Lio/getstream/feeds/android/network/models/LLMConfig;
+	public final fun component17 ()Lio/getstream/feeds/android/network/models/VelocityFilterConfig;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/AIImageConfig;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Lio/getstream/feeds/android/network/models/LLMConfig;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;)Lio/getstream/feeds/android/network/models/ConfigResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ConfigResponse;ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/AIImageConfig;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Lio/getstream/feeds/android/network/models/LLMConfig;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ConfigResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiImageConfig ()Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public final fun getAiImageLabelDefinitions ()Ljava/util/List;
+	public final fun getAiImageSubclassifications ()Ljava/util/Map;
+	public final fun getAiTextConfig ()Lio/getstream/feeds/android/network/models/AITextConfig;
+	public final fun getAiVideoConfig ()Lio/getstream/feeds/android/network/models/AIVideoConfig;
+	public final fun getAsync ()Z
+	public final fun getAutomodPlatformCircumventionConfig ()Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;
+	public final fun getAutomodSemanticFiltersConfig ()Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;
+	public final fun getAutomodToxicityConfig ()Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;
+	public final fun getBlockListConfig ()Lio/getstream/feeds/android/network/models/BlockListConfig;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getLlmConfig ()Lio/getstream/feeds/android/network/models/LLMConfig;
+	public final fun getSupportedVideoCallHarmTypes ()Ljava/util/List;
+	public final fun getTeam ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getVelocityFilterConfig ()Lio/getstream/feeds/android/network/models/VelocityFilterConfig;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ConnectUserDetailsRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getInvisible ()Ljava/lang/Boolean;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ContentCountRuleParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThreshold ()Ljava/lang/Integer;
+	public final fun getTimeWindow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;)Lio/getstream/feeds/android/network/models/CreateBlockListRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateBlockListRequest;Ljava/lang/String;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateBlockListRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTeam ()Ljava/lang/String;
+	public final fun getType ()Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;
+	public final fun getWords ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isLeetCheckEnabled ()Ljava/lang/Boolean;
+	public final fun isPluralCheckEnabled ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type {
+	public static final field Companion Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Domain : io/getstream/feeds/android/network/models/CreateBlockListRequest$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Domain;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$DomainAllowlist : io/getstream/feeds/android/network/models/CreateBlockListRequest$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$DomainAllowlist;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Email : io/getstream/feeds/android/network/models/CreateBlockListRequest$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Email;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$EmailAllowlist : io/getstream/feeds/android/network/models/CreateBlockListRequest$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$EmailAllowlist;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Regex : io/getstream/feeds/android/network/models/CreateBlockListRequest$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Regex;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$TypeAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Unknown : io/getstream/feeds/android/network/models/CreateBlockListRequest$Type {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Word : io/getstream/feeds/android/network/models/CreateBlockListRequest$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateBlockListRequest$Type$Word;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateBlockListResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BlockListResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BlockListResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BlockListResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BlockListResponse;)Lio/getstream/feeds/android/network/models/CreateBlockListResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateBlockListResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BlockListResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateBlockListResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocklist ()Lio/getstream/feeds/android/network/models/BlockListResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateCollectionsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/getstream/feeds/android/network/models/CreateCollectionsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateCollectionsRequest;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateCollectionsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollections ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateCollectionsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/CreateCollectionsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateCollectionsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateCollectionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollections ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateDeviceRequest {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;Ljava/lang/String;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/CreateDeviceRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateDeviceRequest;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateDeviceRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPushProvider ()Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;
+	public final fun getPushProviderName ()Ljava/lang/String;
+	public final fun getVoipToken ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider {
+	public static final field Companion Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Apn : io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Apn;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Firebase : io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Firebase;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Huawei : io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Huawei;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$PushProviderAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Unknown : io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Xiaomi : io/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreateDeviceRequest$PushProvider$Xiaomi;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateFeedsBatchRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/CreateFeedsBatchRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateFeedsBatchRequest;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateFeedsBatchRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFeeds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateFeedsBatchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/CreateFeedsBatchResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateFeedsBatchResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateFeedsBatchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFeeds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateGuestRequest {
+	public fun <init> (Lio/getstream/feeds/android/network/models/UserRequest;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/UserRequest;
+	public final fun copy (Lio/getstream/feeds/android/network/models/UserRequest;)Lio/getstream/feeds/android/network/models/CreateGuestRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateGuestRequest;Lio/getstream/feeds/android/network/models/UserRequest;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateGuestRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateGuestResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/CreateGuestResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateGuestResponse;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateGuestResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAccessToken ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreatePollOptionRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/CreatePollOptionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreatePollOptionRequest;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreatePollOptionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreatePollRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/CreatePollRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreatePollRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreatePollRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowAnswers ()Ljava/lang/Boolean;
+	public final fun getAllowUserSuggestedOptions ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEnforceUniqueVote ()Ljava/lang/Boolean;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMaxVotesAllowed ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getVotingVisibility ()Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;
+	public fun hashCode ()I
+	public final fun isClosed ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Anonymous : io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Anonymous;
+}
+
+public final class io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;
+}
+
+public final class io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Public : io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Unknown : io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility$VotingVisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/CreatePollRequest$VotingVisibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/CreateUserGroupRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/CreateUserGroupRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateUserGroupRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateUserGroupRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMemberIds ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTeamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CreateUserGroupResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)Lio/getstream/feeds/android/network/models/CreateUserGroupResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CreateUserGroupResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CreateUserGroupResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUserGroup ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/CustomActionRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Data {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/Data;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/Data;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/Data;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DecayFunctionConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DecayFunctionConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DecayFunctionConfig;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DecayFunctionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBase ()Ljava/lang/String;
+	public final fun getDecay ()Ljava/lang/String;
+	public final fun getDirection ()Ljava/lang/String;
+	public final fun getOffset ()Ljava/lang/String;
+	public final fun getOrigin ()Ljava/lang/String;
+	public final fun getScale ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteActivitiesRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/DeleteActivitiesRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteActivitiesRequest;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteActivitiesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeleteNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getHardDelete ()Ljava/lang/Boolean;
+	public final fun getIds ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteActivitiesResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/DeleteActivitiesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteActivitiesResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteActivitiesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeletedIds ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteActivityReactionResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;)Lio/getstream/feeds/android/network/models/DeleteActivityReactionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteActivityReactionResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteActivityReactionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteActivityRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getHardDelete ()Ljava/lang/Boolean;
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteActivityResponse {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteActivityResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteBookmarkFolderResponse {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteBookmarkFolderResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteBookmarkFolderResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteBookmarkFolderResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteBookmarkResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)Lio/getstream/feeds/android/network/models/DeleteBookmarkResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteBookmarkResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteBookmarkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteCollectionsResponse {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteCollectionsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteCollectionsResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteCollectionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteCommentBookmarkResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)Lio/getstream/feeds/android/network/models/DeleteCommentBookmarkResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteCommentBookmarkResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteCommentBookmarkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteCommentReactionResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;)Lio/getstream/feeds/android/network/models/DeleteCommentReactionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteCommentReactionResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;Lio/getstream/feeds/android/network/models/FeedsReactionResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteCommentReactionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteCommentRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getHardDelete ()Ljava/lang/Boolean;
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteCommentResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;)Lio/getstream/feeds/android/network/models/DeleteCommentResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteCommentResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteCommentResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteFeedResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteFeedResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteFeedResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteFeedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getTaskId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteModerationConfigResponse {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteModerationConfigResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteModerationConfigResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteModerationConfigResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteReactionRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getHardDelete ()Ljava/lang/Boolean;
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeleteUserRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeleteConversationChannels ()Ljava/lang/Boolean;
+	public final fun getDeleteFeedsContent ()Ljava/lang/Boolean;
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getHardDelete ()Ljava/lang/Boolean;
+	public final fun getMarkMessagesDeleted ()Ljava/lang/Boolean;
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/DeviceResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/DeviceResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/DeviceResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/DeviceResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getDisabled ()Ljava/lang/Boolean;
+	public final fun getDisabledReason ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getPushProvider ()Ljava/lang/String;
+	public final fun getPushProviderName ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public final fun getVoip ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedActivity {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/Data;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Data;Lio/getstream/feeds/android/network/models/Data;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Data;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/Data;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Data;Lio/getstream/feeds/android/network/models/Data;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Data;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component11 ()Ljava/util/Map;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Float;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/Data;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Data;Lio/getstream/feeds/android/network/models/Data;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Data;)Lio/getstream/feeds/android/network/models/EnrichedActivity;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EnrichedActivity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/Data;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Data;Lio/getstream/feeds/android/network/models/Data;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Data;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EnrichedActivity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActor ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun getForeignId ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLatestReactions ()Ljava/util/Map;
+	public final fun getObject ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun getOrigin ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun getOwnReactions ()Ljava/util/Map;
+	public final fun getReactionCounts ()Ljava/util/Map;
+	public final fun getScore ()Ljava/lang/Float;
+	public final fun getTarget ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun getTo ()Ljava/util/List;
+	public final fun getVerb ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedCollection {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/EnrichedCollection;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EnrichedCollection;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EnrichedCollection;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedCollectionResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getStatus ()Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status {
+	public static final field Companion Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Notfound : io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Notfound;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Ok : io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Ok;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$StatusAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Unknown : io/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EnrichedCollectionResponse$Status$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichedReaction {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Time;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Time;Lio/getstream/feeds/android/network/models/Data;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Time;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Time;Lio/getstream/feeds/android/network/models/Data;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component11 ()Ljava/util/Map;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/Time;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/Time;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Time;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Time;Lio/getstream/feeds/android/network/models/Data;)Lio/getstream/feeds/android/network/models/EnrichedReaction;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EnrichedReaction;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Time;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Time;Lio/getstream/feeds/android/network/models/Data;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EnrichedReaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getChildrenCounts ()Ljava/util/Map;
+	public final fun getCreatedAt ()Lio/getstream/feeds/android/network/models/Time;
+	public final fun getData ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLatestChildren ()Ljava/util/Map;
+	public final fun getOwnChildren ()Ljava/util/Map;
+	public final fun getParent ()Ljava/lang/String;
+	public final fun getTargetFeeds ()Ljava/util/List;
+	public final fun getUpdatedAt ()Lio/getstream/feeds/android/network/models/Time;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/Data;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EnrichmentOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/Boolean;
+	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/Boolean;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component16 ()Ljava/lang/Boolean;
+	public final fun component17 ()Ljava/lang/Boolean;
+	public final fun component18 ()Ljava/lang/Boolean;
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/EnrichmentOptions;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EnrichmentOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnrichOwnFollowings ()Ljava/lang/Boolean;
+	public final fun getIncludeScoreVars ()Ljava/lang/Boolean;
+	public final fun getSkipActivity ()Ljava/lang/Boolean;
+	public final fun getSkipActivityCollections ()Ljava/lang/Boolean;
+	public final fun getSkipActivityComments ()Ljava/lang/Boolean;
+	public final fun getSkipActivityCurrentFeed ()Ljava/lang/Boolean;
+	public final fun getSkipActivityMentionedUsers ()Ljava/lang/Boolean;
+	public final fun getSkipActivityOwnBookmarks ()Ljava/lang/Boolean;
+	public final fun getSkipActivityParents ()Ljava/lang/Boolean;
+	public final fun getSkipActivityPoll ()Ljava/lang/Boolean;
+	public final fun getSkipActivityReactions ()Ljava/lang/Boolean;
+	public final fun getSkipActivityRefreshImageUrls ()Ljava/lang/Boolean;
+	public final fun getSkipAll ()Ljava/lang/Boolean;
+	public final fun getSkipFeedMemberUser ()Ljava/lang/Boolean;
+	public final fun getSkipFollowers ()Ljava/lang/Boolean;
+	public final fun getSkipFollowing ()Ljava/lang/Boolean;
+	public final fun getSkipOwnCapabilities ()Ljava/lang/Boolean;
+	public final fun getSkipOwnFollows ()Ljava/lang/Boolean;
+	public final fun getSkipPins ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EntityCreatorResponse {
+	public fun <init> (IZLjava/util/Date;IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)V
+	public synthetic fun <init> (IZLjava/util/Date;IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/util/Map;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/util/Date;
+	public final fun component16 ()Ljava/util/Date;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/util/Date;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component20 ()Ljava/util/Date;
+	public final fun component21 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()I
+	public final fun component5 ()I
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Z
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (IZLjava/util/Date;IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/EntityCreatorResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EntityCreatorResponse;IZLjava/util/Date;IILjava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EntityCreatorResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvgResponseTime ()Ljava/lang/Integer;
+	public final fun getBanCount ()I
+	public final fun getBanned ()Z
+	public final fun getBlockedUserIds ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeactivatedAt ()Ljava/util/Date;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDeletedContentCount ()I
+	public final fun getFlaggedCount ()I
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLastActive ()Ljava/util/Date;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOnline ()Z
+	public final fun getRevokeTokensIssuedBefore ()Ljava/util/Date;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTeams ()Ljava/util/List;
+	public final fun getTeamsRole ()Ljava/util/Map;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EscalatePayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/EscalatePayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EscalatePayload;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EscalatePayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNotes ()Ljava/lang/String;
+	public final fun getPriority ()Ljava/lang/String;
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/EscalationMetadata {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/EscalationMetadata;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/EscalationMetadata;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/EscalationMetadata;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNotes ()Ljava/lang/String;
+	public final fun getPriority ()Ljava/lang/String;
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedCreatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/FeedCreatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedCreatedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedCreatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeed ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/FeedDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedDeletedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/network/models/FeedEvent {
+}
+
+public final class io/getstream/feeds/android/network/models/FeedGroup {
+	public fun <init> (IILjava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/network/models/AggregationConfig;Lio/getstream/feeds/android/network/models/NotificationConfig;Lio/getstream/feeds/android/network/models/PushNotificationConfig;Lio/getstream/feeds/android/network/models/RankingConfig;Lio/getstream/feeds/android/network/models/StoriesConfig;)V
+	public synthetic fun <init> (IILjava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/network/models/AggregationConfig;Lio/getstream/feeds/android/network/models/NotificationConfig;Lio/getstream/feeds/android/network/models/PushNotificationConfig;Lio/getstream/feeds/android/network/models/RankingConfig;Lio/getstream/feeds/android/network/models/StoriesConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component11 ()Ljava/util/Date;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/AggregationConfig;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/NotificationConfig;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/PushNotificationConfig;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/RankingConfig;
+	public final fun component16 ()Lio/getstream/feeds/android/network/models/StoriesConfig;
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (IILjava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/network/models/AggregationConfig;Lio/getstream/feeds/android/network/models/NotificationConfig;Lio/getstream/feeds/android/network/models/PushNotificationConfig;Lio/getstream/feeds/android/network/models/RankingConfig;Lio/getstream/feeds/android/network/models/StoriesConfig;)Lio/getstream/feeds/android/network/models/FeedGroup;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedGroup;IILjava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/network/models/AggregationConfig;Lio/getstream/feeds/android/network/models/NotificationConfig;Lio/getstream/feeds/android/network/models/PushNotificationConfig;Lio/getstream/feeds/android/network/models/RankingConfig;Lio/getstream/feeds/android/network/models/StoriesConfig;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedGroup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityProcessors ()Ljava/util/List;
+	public final fun getActivitySelectors ()Ljava/util/List;
+	public final fun getAggregation ()Lio/getstream/feeds/android/network/models/AggregationConfig;
+	public final fun getAggregationVersion ()I
+	public final fun getAppPk ()I
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDefaultVisibility ()Ljava/lang/String;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getGroupId ()Ljava/lang/String;
+	public final fun getLastFeedGetAt ()Ljava/util/Date;
+	public final fun getNotification ()Lio/getstream/feeds/android/network/models/NotificationConfig;
+	public final fun getPushNotification ()Lio/getstream/feeds/android/network/models/PushNotificationConfig;
+	public final fun getRanking ()Lio/getstream/feeds/android/network/models/RankingConfig;
+	public final fun getStories ()Lio/getstream/feeds/android/network/models/StoriesConfig;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedGroupChangedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedGroup;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedGroup;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/FeedGroup;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedGroup;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/FeedGroupChangedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedGroupChangedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedGroup;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedGroupChangedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedGroup ()Lio/getstream/feeds/android/network/models/FeedGroup;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedGroupDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/FeedGroupDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedGroupDeletedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedGroupDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getGroupId ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedGroupRestoredEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/FeedGroupRestoredEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedGroupRestoredEvent;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedGroupRestoredEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getGroupId ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedInput$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedInput$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FeedInput$Visibility;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedInput$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;)Lio/getstream/feeds/android/network/models/FeedInput;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedInput;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedInput$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVisibility ()Lio/getstream/feeds/android/network/models/FeedInput$Visibility;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedInput$Visibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput$Visibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedInput$Visibility;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput$Visibility$Followers : io/getstream/feeds/android/network/models/FeedInput$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Followers;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput$Visibility$Members : io/getstream/feeds/android/network/models/FeedInput$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Members;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput$Visibility$Private : io/getstream/feeds/android/network/models/FeedInput$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Private;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput$Visibility$Public : io/getstream/feeds/android/network/models/FeedInput$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput$Visibility$Unknown : io/getstream/feeds/android/network/models/FeedInput$Visibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput$Visibility$VisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedInput$Visibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedInput$Visibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedInput$Visibility$Visible : io/getstream/feeds/android/network/models/FeedInput$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedInput$Visibility$Visible;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberAddedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/FeedMemberAddedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedMemberAddedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedMemberAddedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getMember ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberRemovedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/FeedMemberRemovedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedMemberRemovedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedMemberRemovedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getMemberId ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/FeedMemberRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedMemberRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedMemberRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getInvite ()Ljava/lang/Boolean;
+	public final fun getMembershipLevel ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/MembershipLevelResponse;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/MembershipLevelResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/MembershipLevelResponse;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/MembershipLevelResponse;)Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/MembershipLevelResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getInviteAcceptedAt ()Ljava/util/Date;
+	public final fun getInviteRejectedAt ()Ljava/util/Date;
+	public final fun getMembershipLevel ()Lio/getstream/feeds/android/network/models/MembershipLevelResponse;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getStatus ()Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedMemberResponse$Status {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberResponse$Status$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberResponse$Status$Member : io/getstream/feeds/android/network/models/FeedMemberResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status$Member;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberResponse$Status$Pending : io/getstream/feeds/android/network/models/FeedMemberResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status$Pending;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberResponse$Status$Rejected : io/getstream/feeds/android/network/models/FeedMemberResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status$Rejected;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberResponse$Status$StatusAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberResponse$Status$Unknown : io/getstream/feeds/android/network/models/FeedMemberResponse$Status {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedMemberResponse$Status$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedMemberUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/FeedMemberUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedMemberUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedMemberResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedMemberUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getMember ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedOwnCapability$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$AddActivity : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$AddActivity;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$AddActivityBookmark : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$AddActivityBookmark;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$AddActivityReaction : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$AddActivityReaction;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$AddComment : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$AddComment;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$AddCommentReaction : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$AddCommentReaction;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedOwnCapability;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$CreateFeed : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$CreateFeed;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$DeleteAnyActivity : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$DeleteAnyActivity;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$DeleteAnyComment : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$DeleteAnyComment;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$DeleteFeed : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$DeleteFeed;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnActivity : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnActivity;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnActivityBookmark : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnActivityBookmark;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnActivityReaction : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnActivityReaction;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnComment : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnComment;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnCommentReaction : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$DeleteOwnCommentReaction;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$FeedOwnCapabilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedOwnCapability;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedOwnCapability;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$Follow : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$Follow;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$PinActivity : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$PinActivity;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$QueryFeedMembers : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$QueryFeedMembers;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$QueryFollows : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$QueryFollows;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$ReadActivities : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$ReadActivities;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$ReadFeed : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$ReadFeed;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$Unfollow : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$Unfollow;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$Unknown : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedOwnCapability$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedOwnCapability$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedOwnCapability$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$UpdateAnyActivity : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$UpdateAnyActivity;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$UpdateAnyComment : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$UpdateAnyComment;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$UpdateFeed : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$UpdateFeed;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$UpdateFeedFollowers : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$UpdateFeedFollowers;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$UpdateFeedMembers : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$UpdateFeedMembers;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$UpdateOwnActivity : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$UpdateOwnActivity;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$UpdateOwnActivityBookmark : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$UpdateOwnActivityBookmark;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnCapability$UpdateOwnComment : io/getstream/feeds/android/network/models/FeedOwnCapability {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedOwnCapability$UpdateOwnComment;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedOwnData {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedMemberResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)Lio/getstream/feeds/android/network/models/FeedOwnData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedOwnData;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedMemberResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedOwnData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOwnCapabilities ()Ljava/util/List;
+	public final fun getOwnFollowings ()Ljava/util/List;
+	public final fun getOwnFollows ()Ljava/util/List;
+	public final fun getOwnMembership ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;)Lio/getstream/feeds/android/network/models/FeedRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedById ()Ljava/lang/String;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getFeedGroupId ()Ljava/lang/String;
+	public final fun getFeedId ()Ljava/lang/String;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVisibility ()Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedRequest$Visibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest$Visibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest$Visibility$Followers : io/getstream/feeds/android/network/models/FeedRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Followers;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest$Visibility$Members : io/getstream/feeds/android/network/models/FeedRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Members;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest$Visibility$Private : io/getstream/feeds/android/network/models/FeedRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Private;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest$Visibility$Public : io/getstream/feeds/android/network/models/FeedRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest$Visibility$Unknown : io/getstream/feeds/android/network/models/FeedRequest$Visibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest$Visibility$VisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedRequest$Visibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedRequest$Visibility$Visible : io/getstream/feeds/android/network/models/FeedRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedRequest$Visibility$Visible;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse {
+	public fun <init> (ILjava/util/Date;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)V
+	public synthetic fun <init> (ILjava/util/Date;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Lio/getstream/feeds/android/network/models/FeedMemberResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()I
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component14 ()Ljava/util/Date;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component20 ()Ljava/util/Map;
+	public final fun component21 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component22 ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()I
+	public final fun copy (ILjava/util/Date;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)Lio/getstream/feeds/android/network/models/FeedResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedResponse;ILjava/util/Date;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Lio/getstream/feeds/android/network/models/FeedMemberResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityCount ()I
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getFeed ()Ljava/lang/String;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getFollowerCount ()I
+	public final fun getFollowingCount ()I
+	public final fun getGroupId ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMemberCount ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOwnCapabilities ()Ljava/util/List;
+	public final fun getOwnFollowings ()Ljava/util/List;
+	public final fun getOwnFollows ()Ljava/util/List;
+	public final fun getOwnMembership ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun getPinCount ()I
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getVisibility ()Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedResponse$Visibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse$Visibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse$Visibility$Followers : io/getstream/feeds/android/network/models/FeedResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Followers;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse$Visibility$Members : io/getstream/feeds/android/network/models/FeedResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Members;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse$Visibility$Private : io/getstream/feeds/android/network/models/FeedResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Private;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse$Visibility$Public : io/getstream/feeds/android/network/models/FeedResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse$Visibility$Unknown : io/getstream/feeds/android/network/models/FeedResponse$Visibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse$Visibility$VisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedResponse$Visibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedResponse$Visibility$Visible : io/getstream/feeds/android/network/models/FeedResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedResponse$Visibility$Visible;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse {
+	public fun <init> (ILjava/util/Date;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Float;Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)V
+	public synthetic fun <init> (ILjava/util/Date;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Float;Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Lio/getstream/feeds/android/network/models/FeedMemberResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()I
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component14 ()Ljava/util/Date;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/Float;
+	public final fun component17 ()Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Ljava/util/Map;
+	public final fun component23 ()Ljava/util/Map;
+	public final fun component24 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component25 ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()I
+	public final fun copy (ILjava/util/Date;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Float;Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)Lio/getstream/feeds/android/network/models/FeedSuggestionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedSuggestionResponse;ILjava/util/Date;Ljava/lang/String;Ljava/lang/String;IILjava/lang/String;Ljava/lang/String;ILjava/lang/String;ILjava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Float;Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Lio/getstream/feeds/android/network/models/FeedMemberResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedSuggestionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityCount ()I
+	public final fun getAlgorithmScores ()Ljava/util/Map;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getFeed ()Ljava/lang/String;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getFollowerCount ()I
+	public final fun getFollowingCount ()I
+	public final fun getGroupId ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMemberCount ()I
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOwnCapabilities ()Ljava/util/List;
+	public final fun getOwnFollowings ()Ljava/util/List;
+	public final fun getOwnFollows ()Ljava/util/List;
+	public final fun getOwnMembership ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun getPinCount ()I
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getRecommendationScore ()Ljava/lang/Float;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getVisibility ()Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Followers : io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Followers;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Members : io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Members;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Private : io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Private;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Public : io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Unknown : io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$VisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Visible : io/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedSuggestionResponse$Visibility$Visible;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/FeedUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeed ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;Ljava/util/Map;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/FeedsPreferences;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferences;Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferences;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;
+	public final fun getCommentMention ()Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;
+	public final fun getCommentReaction ()Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;
+	public final fun getCommentReply ()Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;
+	public final fun getCustomActivityTypes ()Ljava/util/Map;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;
+	public final fun getMention ()Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedsPreferences$Comment {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Comment$All : io/getstream/feeds/android/network/models/FeedsPreferences$Comment {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Comment$CommentAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Comment$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Comment$None : io/getstream/feeds/android/network/models/FeedsPreferences$Comment {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Comment$Unknown : io/getstream/feeds/android/network/models/FeedsPreferences$Comment {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Comment$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$All : io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$CommentMentionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$None : io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$Unknown : io/getstream/feeds/android/network/models/FeedsPreferences$CommentMention {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentMention$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$All : io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$CommentReactionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$None : io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$Unknown : io/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReaction$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$All : io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$CommentReplyAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$None : io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$Unknown : io/getstream/feeds/android/network/models/FeedsPreferences$CommentReply {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferences$CommentReply$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedsPreferences$Follow {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Follow$All : io/getstream/feeds/android/network/models/FeedsPreferences$Follow {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Follow$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Follow$FollowAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Follow$None : io/getstream/feeds/android/network/models/FeedsPreferences$Follow {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Follow$Unknown : io/getstream/feeds/android/network/models/FeedsPreferences$Follow {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Follow$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedsPreferences$Mention {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Mention$All : io/getstream/feeds/android/network/models/FeedsPreferences$Mention {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Mention$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Mention$MentionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Mention$None : io/getstream/feeds/android/network/models/FeedsPreferences$Mention {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Mention$Unknown : io/getstream/feeds/android/network/models/FeedsPreferences$Mention {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Mention$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FeedsPreferences$Reaction {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Reaction$All : io/getstream/feeds/android/network/models/FeedsPreferences$Reaction {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Reaction$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Reaction$None : io/getstream/feeds/android/network/models/FeedsPreferences$Reaction {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Reaction$ReactionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferences$Reaction$Unknown : io/getstream/feeds/android/network/models/FeedsPreferences$Reaction {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferences$Reaction$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsPreferencesResponse {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getCommentMention ()Ljava/lang/String;
+	public final fun getCommentReaction ()Ljava/lang/String;
+	public final fun getCommentReply ()Ljava/lang/String;
+	public final fun getCustomActivityTypes ()Ljava/util/Map;
+	public final fun getFollow ()Ljava/lang/String;
+	public final fun getMention ()Ljava/lang/String;
+	public final fun getReaction ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsReactionGroup {
+	public fun <init> (ILjava/util/Date;Ljava/util/Date;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun copy (ILjava/util/Date;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/FeedsReactionGroup;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsReactionGroup;ILjava/util/Date;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsReactionGroup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public final fun getFirstReactionAt ()Ljava/util/Date;
+	public final fun getLastReactionAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsReactionGroupResponse {
+	public fun <init> (ILjava/util/Date;Ljava/util/Date;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun copy (ILjava/util/Date;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/FeedsReactionGroupResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsReactionGroupResponse;ILjava/util/Date;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsReactionGroupResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCount ()I
+	public final fun getFirstReactionAt ()Ljava/util/Date;
+	public final fun getLastReactionAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsReactionResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsReactionResponse;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsReactionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getCommentId ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsV3ActivityResponse {
+	public fun <init> (IILjava/util/Date;ZLjava/lang/String;IZILjava/lang/String;FILjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;)V
+	public synthetic fun <init> (IILjava/util/Date;ZLjava/lang/String;IZILjava/lang/String;FILjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()F
+	public final fun component11 ()I
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/util/Date;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/List;
+	public final fun component19 ()Ljava/util/List;
+	public final fun component2 ()I
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Ljava/util/Map;
+	public final fun component25 ()Ljava/util/Map;
+	public final fun component26 ()Ljava/util/Map;
+	public final fun component27 ()Ljava/util/Map;
+	public final fun component28 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component29 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component30 ()Ljava/util/Date;
+	public final fun component31 ()Ljava/util/Date;
+	public final fun component32 ()Ljava/lang/String;
+	public final fun component33 ()Ljava/lang/String;
+	public final fun component34 ()Ljava/lang/String;
+	public final fun component35 ()Ljava/util/Map;
+	public final fun component36 ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()I
+	public final fun component7 ()Z
+	public final fun component8 ()I
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (IILjava/util/Date;ZLjava/lang/String;IZILjava/lang/String;FILjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;)Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;IILjava/util/Date;ZLjava/lang/String;IZILjava/lang/String;FILjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;IILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getBookmarkCount ()I
+	public final fun getCollections ()Ljava/util/Map;
+	public final fun getCommentCount ()I
+	public final fun getComments ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getEditedAt ()Ljava/util/Date;
+	public final fun getExpiresAt ()Ljava/util/Date;
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getHidden ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getInterestTags ()Ljava/util/List;
+	public final fun getLatestReactions ()Ljava/util/List;
+	public final fun getMentionedUsers ()Ljava/util/List;
+	public final fun getMetrics ()Ljava/util/Map;
+	public final fun getModeration ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun getModerationAction ()Ljava/lang/String;
+	public final fun getOwnBookmarks ()Ljava/util/List;
+	public final fun getOwnReactions ()Ljava/util/List;
+	public final fun getPopularity ()I
+	public final fun getPreview ()Z
+	public final fun getReactionCount ()I
+	public final fun getReactionGroups ()Ljava/util/Map;
+	public final fun getRestrictReplies ()Ljava/lang/String;
+	public final fun getScore ()F
+	public final fun getSearchData ()Ljava/util/Map;
+	public final fun getShareCount ()I
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getVisibility ()Ljava/lang/String;
+	public final fun getVisibilityTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FeedsV3CommentResponse {
+	public fun <init> (FLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/String;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;)V
+	public synthetic fun <init> (FLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/String;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()F
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/Date;
+	public final fun component12 ()I
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component16 ()Ljava/lang/Float;
+	public final fun component17 ()Ljava/util/Date;
+	public final fun component18 ()Ljava/util/Date;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Ljava/util/Map;
+	public final fun component23 ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()I
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (FLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/String;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;)Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;FLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/String;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationV2Response;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getConfidenceScore ()F
+	public final fun getControversyScore ()Ljava/lang/Float;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDownvoteCount ()I
+	public final fun getEditedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMentionedUsers ()Ljava/util/List;
+	public final fun getModeration ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getOwnReactions ()Ljava/util/List;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getReactionCount ()I
+	public final fun getReplyCount ()I
+	public final fun getScore ()I
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUpvoteCount ()I
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Field {
+	public fun <init> (ZLjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ZLjava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/Field;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/Field;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/Field;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getShort ()Z
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FileUploadConfig {
+	public fun <init> (ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FileUploadConfig;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FileUploadConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowedFileExtensions ()Ljava/util/List;
+	public final fun getAllowedMimeTypes ()Ljava/util/List;
+	public final fun getBlockedFileExtensions ()Ljava/util/List;
+	public final fun getBlockedMimeTypes ()Ljava/util/List;
+	public final fun getSizeLimit ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FileUploadRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/OnlyUserID;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/OnlyUserID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/OnlyUserID;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/OnlyUserID;)Lio/getstream/feeds/android/network/models/FileUploadRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FileUploadRequest;Ljava/lang/String;Lio/getstream/feeds/android/network/models/OnlyUserID;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FileUploadRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/OnlyUserID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FileUploadResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FileUploadResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FileUploadResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FileUploadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getThumbUrl ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FilterConfigResponse {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/network/models/FilterConfigResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FilterConfigResponse;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FilterConfigResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiTextLabels ()Ljava/util/List;
+	public final fun getConfigKeys ()Ljava/util/List;
+	public final fun getLlmLabels ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FlagCountRuleParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/Integer;)Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThreshold ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FlagRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationPayload;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationPayload;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/ModerationPayload;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationPayload;)Lio/getstream/feeds/android/network/models/FlagRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FlagRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationPayload;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FlagRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getEntityCreatorId ()Ljava/lang/String;
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getModerationPayload ()Lio/getstream/feeds/android/network/models/ModerationPayload;
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FlagResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FlagResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FlagResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FlagResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getItemId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FlagUserOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FlagUserOptions;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FlagUserOptions;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FlagUserOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowBatchRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/FollowBatchRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowBatchRequest;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowBatchRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFollows ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowBatchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/network/models/FollowBatchResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowBatchResponse;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowBatchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreated ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFollows ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowCreatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/FollowCreatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowCreatedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowCreatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowDeletedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/FollowDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowDeletedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowDeletedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;Ljava/lang/Boolean;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/FollowRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityCopyLimit ()Ljava/lang/Integer;
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCreateNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getPushPreference ()Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getTarget ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FollowRequest$PushPreference {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowRequest$PushPreference$All : io/getstream/feeds/android/network/models/FollowRequest$PushPreference {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowRequest$PushPreference$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowRequest$PushPreference$None : io/getstream/feeds/android/network/models/FollowRequest$PushPreference {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowRequest$PushPreference$PushPreferenceAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FollowRequest$PushPreference$Unknown : io/getstream/feeds/android/network/models/FollowRequest$PushPreference {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowRequest$PushPreference$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;Lio/getstream/feeds/android/network/models/FollowResponse$Status;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;Lio/getstream/feeds/android/network/models/FollowResponse$Status;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FollowResponse$Status;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;Lio/getstream/feeds/android/network/models/FollowResponse$Status;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/FollowResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;Lio/getstream/feeds/android/network/models/FollowResponse$Status;Ljava/util/Date;Lio/getstream/feeds/android/network/models/FeedResponse;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFollowerRole ()Ljava/lang/String;
+	public final fun getPushPreference ()Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;
+	public final fun getRequestAcceptedAt ()Ljava/util/Date;
+	public final fun getRequestRejectedAt ()Ljava/util/Date;
+	public final fun getSourceFeed ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun getStatus ()Lio/getstream/feeds/android/network/models/FollowResponse$Status;
+	public final fun getTargetFeed ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FollowResponse$PushPreference {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$PushPreference$All : io/getstream/feeds/android/network/models/FollowResponse$PushPreference {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference$All;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$PushPreference$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$PushPreference$None : io/getstream/feeds/android/network/models/FollowResponse$PushPreference {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference$None;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$PushPreference$PushPreferenceAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$PushPreference$Unknown : io/getstream/feeds/android/network/models/FollowResponse$PushPreference {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowResponse$PushPreference$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FollowResponse$Status {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FollowResponse$Status$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$Status$Accepted : io/getstream/feeds/android/network/models/FollowResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FollowResponse$Status$Accepted;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$Status$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FollowResponse$Status;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$Status$Pending : io/getstream/feeds/android/network/models/FollowResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FollowResponse$Status$Pending;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$Status$Rejected : io/getstream/feeds/android/network/models/FollowResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FollowResponse$Status$Rejected;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$Status$StatusAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FollowResponse$Status;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FollowResponse$Status;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FollowResponse$Status$Unknown : io/getstream/feeds/android/network/models/FollowResponse$Status {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FollowResponse$Status$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowResponse$Status$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowResponse$Status$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FollowUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/FollowUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FollowUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FollowUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FriendReactionsOptions {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;)Lio/getstream/feeds/android/network/models/FriendReactionsOptions;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FriendReactionsOptions;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FriendReactionsOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getType ()Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/FriendReactionsOptions$Type {
+	public static final field Companion Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;
+}
+
+public final class io/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Following : io/getstream/feeds/android/network/models/FriendReactionsOptions$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Following;
+}
+
+public final class io/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Mutual : io/getstream/feeds/android/network/models/FriendReactionsOptions$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Mutual;
+}
+
+public final class io/getstream/feeds/android/network/models/FriendReactionsOptions$Type$TypeAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Unknown : io/getstream/feeds/android/network/models/FriendReactionsOptions$Type {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FriendReactionsOptions$Type$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/FullUserResponse {
+	public fun <init> (ZLjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ZLjava/lang/String;ZIIIILjava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ZLjava/lang/String;ZIIIILjava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()I
+	public final fun component11 ()I
+	public final fun component12 ()I
+	public final fun component13 ()Ljava/util/Date;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component19 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component20 ()Ljava/util/Date;
+	public final fun component21 ()Ljava/util/Date;
+	public final fun component22 ()Ljava/util/Date;
+	public final fun component23 ()Ljava/lang/String;
+	public final fun component24 ()Ljava/util/Date;
+	public final fun component25 ()Ljava/lang/String;
+	public final fun component26 ()Ljava/util/Date;
+	public final fun component27 ()Ljava/util/List;
+	public final fun component28 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Z
+	public final fun component9 ()I
+	public final fun copy (ZLjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ZLjava/lang/String;ZIIIILjava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/FullUserResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/FullUserResponse;ZLjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ZLjava/lang/String;ZIIIILjava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/FullUserResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvgResponseTime ()Ljava/lang/Integer;
+	public final fun getBanExpires ()Ljava/util/Date;
+	public final fun getBanned ()Z
+	public final fun getBlockedUserIds ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeactivatedAt ()Ljava/util/Date;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDevices ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getInvisible ()Z
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLastActive ()Ljava/util/Date;
+	public final fun getLatestHiddenChannels ()Ljava/util/List;
+	public final fun getMutes ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOnline ()Z
+	public final fun getRevokeTokensIssuedBefore ()Ljava/util/Date;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getShadowBanned ()Z
+	public final fun getTeams ()Ljava/util/List;
+	public final fun getTeamsRole ()Ljava/util/Map;
+	public final fun getTotalUnreadCount ()I
+	public final fun getUnreadChannels ()I
+	public final fun getUnreadCount ()I
+	public final fun getUnreadThreads ()I
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetActivityResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)Lio/getstream/feeds/android/network/models/GetActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetActivityResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetAppealResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppealItemResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppealItemResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/AppealItemResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppealItemResponse;)Lio/getstream/feeds/android/network/models/GetAppealResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetAppealResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppealItemResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetAppealResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getItem ()Lio/getstream/feeds/android/network/models/AppealItemResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetApplicationResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppResponseFields;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/AppResponseFields;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppResponseFields;)Lio/getstream/feeds/android/network/models/GetApplicationResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetApplicationResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppResponseFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetApplicationResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getApp ()Lio/getstream/feeds/android/network/models/AppResponseFields;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetBlockedUsersResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/GetBlockedUsersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetBlockedUsersResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetBlockedUsersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocks ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetCommentRepliesResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/GetCommentRepliesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetCommentRepliesResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetCommentRepliesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComments ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetCommentResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;)Lio/getstream/feeds/android/network/models/GetCommentResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetCommentResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetCommentResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetCommentsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/GetCommentsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetCommentsResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetCommentsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComments ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetConfigResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConfigResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConfigResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ConfigResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConfigResponse;)Lio/getstream/feeds/android/network/models/GetConfigResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetConfigResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConfigResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetConfigResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfig ()Lio/getstream/feeds/android/network/models/ConfigResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetFollowSuggestionsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/GetFollowSuggestionsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetFollowSuggestionsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetFollowSuggestionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAlgorithmUsed ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getSuggestions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetOGResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/Images;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/Images;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/lang/Integer;
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/lang/String;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/util/List;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Lio/getstream/feeds/android/network/models/Images;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/Images;)Lio/getstream/feeds/android/network/models/GetOGResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetOGResponse;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/Images;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetOGResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActions ()Ljava/util/List;
+	public final fun getAssetUrl ()Ljava/lang/String;
+	public final fun getAuthorIcon ()Ljava/lang/String;
+	public final fun getAuthorLink ()Ljava/lang/String;
+	public final fun getAuthorName ()Ljava/lang/String;
+	public final fun getColor ()Ljava/lang/String;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFallback ()Ljava/lang/String;
+	public final fun getFields ()Ljava/util/List;
+	public final fun getFooter ()Ljava/lang/String;
+	public final fun getFooterIcon ()Ljava/lang/String;
+	public final fun getGiphy ()Lio/getstream/feeds/android/network/models/Images;
+	public final fun getImageUrl ()Ljava/lang/String;
+	public final fun getOgScrapeUrl ()Ljava/lang/String;
+	public final fun getOriginalHeight ()Ljava/lang/Integer;
+	public final fun getOriginalWidth ()Ljava/lang/Integer;
+	public final fun getPretext ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getThumbUrl ()Ljava/lang/String;
+	public final fun getTitle ()Ljava/lang/String;
+	public final fun getTitleLink ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetOrCreateFeedRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FeedInput;Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PagerRequest;Lio/getstream/feeds/android/network/models/PagerRequest;Lio/getstream/feeds/android/network/models/FriendReactionsOptions;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PagerRequest;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FeedInput;Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PagerRequest;Lio/getstream/feeds/android/network/models/PagerRequest;Lio/getstream/feeds/android/network/models/FriendReactionsOptions;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PagerRequest;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/PagerRequest;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/PagerRequest;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/FriendReactionsOptions;
+	public final fun component14 ()Ljava/util/Map;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/PagerRequest;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/FeedInput;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/EnrichmentOptions;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FeedInput;Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PagerRequest;Lio/getstream/feeds/android/network/models/PagerRequest;Lio/getstream/feeds/android/network/models/FriendReactionsOptions;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PagerRequest;)Lio/getstream/feeds/android/network/models/GetOrCreateFeedRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetOrCreateFeedRequest;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/FeedInput;Lio/getstream/feeds/android/network/models/EnrichmentOptions;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PagerRequest;Lio/getstream/feeds/android/network/models/PagerRequest;Lio/getstream/feeds/android/network/models/FriendReactionsOptions;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PagerRequest;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetOrCreateFeedRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Lio/getstream/feeds/android/network/models/FeedInput;
+	public final fun getEnrichmentOptions ()Lio/getstream/feeds/android/network/models/EnrichmentOptions;
+	public final fun getExternalRanking ()Ljava/util/Map;
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getFollowersPagination ()Lio/getstream/feeds/android/network/models/PagerRequest;
+	public final fun getFollowingPagination ()Lio/getstream/feeds/android/network/models/PagerRequest;
+	public final fun getFriendReactionsOptions ()Lio/getstream/feeds/android/network/models/FriendReactionsOptions;
+	public final fun getIdAround ()Ljava/lang/String;
+	public final fun getInterestWeights ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getMemberPagination ()Lio/getstream/feeds/android/network/models/PagerRequest;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getView ()Ljava/lang/String;
+	public final fun getWatch ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetOrCreateFeedResponse {
+	public fun <init> (ZLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/NotificationStatusResponse;)V
+	public synthetic fun <init> (ZLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/NotificationStatusResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/PagerResponse;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/PagerResponse;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/PagerResponse;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/NotificationStatusResponse;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun copy (ZLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/NotificationStatusResponse;)Lio/getstream/feeds/android/network/models/GetOrCreateFeedResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetOrCreateFeedResponse;ZLjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/FeedResponse;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/PagerResponse;Lio/getstream/feeds/android/network/models/NotificationStatusResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetOrCreateFeedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivities ()Ljava/util/List;
+	public final fun getAggregatedActivities ()Ljava/util/List;
+	public final fun getCreated ()Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFeed ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun getFollowers ()Ljava/util/List;
+	public final fun getFollowersPagination ()Lio/getstream/feeds/android/network/models/PagerResponse;
+	public final fun getFollowing ()Ljava/util/List;
+	public final fun getFollowingPagination ()Lio/getstream/feeds/android/network/models/PagerResponse;
+	public final fun getMemberPagination ()Lio/getstream/feeds/android/network/models/PagerResponse;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getNotificationStatus ()Lio/getstream/feeds/android/network/models/NotificationStatusResponse;
+	public final fun getPinnedActivities ()Ljava/util/List;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GetUserGroupResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)Lio/getstream/feeds/android/network/models/GetUserGroupResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GetUserGroupResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GetUserGroupResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUserGroup ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/GoogleVisionConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/GoogleVisionConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/GoogleVisionConfig;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/GoogleVisionConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnabled ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/HealthCheckEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/OwnUserResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/OwnUserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/OwnUserResponse;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/OwnUserResponse;)Lio/getstream/feeds/android/network/models/HealthCheckEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/HealthCheckEvent;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/OwnUserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/HealthCheckEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid ()Ljava/lang/String;
+	public final fun getConnectionId ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getMe ()Lio/getstream/feeds/android/network/models/OwnUserResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ImageContentParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Float;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Float;Ljava/util/List;)Lio/getstream/feeds/android/network/models/ImageContentParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ImageContentParameters;Ljava/lang/String;Ljava/lang/Float;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ImageContentParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHarmLabels ()Ljava/util/List;
+	public final fun getLabelOperator ()Ljava/lang/String;
+	public final fun getMinConfidence ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ImageData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ImageData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ImageData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ImageData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFrames ()Ljava/lang/String;
+	public final fun getHeight ()Ljava/lang/String;
+	public final fun getSize ()Ljava/lang/String;
+	public final fun getUrl ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ImageRuleParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Float;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/ImageRuleParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ImageRuleParameters;Ljava/lang/Float;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ImageRuleParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHarmLabels ()Ljava/util/List;
+	public final fun getMinConfidence ()Ljava/lang/Float;
+	public final fun getThreshold ()Ljava/lang/Integer;
+	public final fun getTimeWindow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ImageSize {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/feeds/android/network/models/ImageSize;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ImageSize;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ImageSize;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCrop ()Ljava/lang/String;
+	public final fun getHeight ()Ljava/lang/Integer;
+	public final fun getResize ()Ljava/lang/String;
+	public final fun getWidth ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ImageUploadRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/OnlyUserID;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/OnlyUserID;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/OnlyUserID;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/OnlyUserID;)Lio/getstream/feeds/android/network/models/ImageUploadRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ImageUploadRequest;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/OnlyUserID;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ImageUploadRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getUploadSizes ()Ljava/util/List;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/OnlyUserID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ImageUploadResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/ImageUploadResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ImageUploadResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ImageUploadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFile ()Ljava/lang/String;
+	public final fun getThumbUrl ()Ljava/lang/String;
+	public final fun getUploadSizes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Images {
+	public fun <init> (Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun copy (Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;)Lio/getstream/feeds/android/network/models/Images;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/Images;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;Lio/getstream/feeds/android/network/models/ImageData;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/Images;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFixedHeight ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun getFixedHeightDownsampled ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun getFixedHeightStill ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun getFixedWidth ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun getFixedWidthDownsampled ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun getFixedWidthStill ()Lio/getstream/feeds/android/network/models/ImageData;
+	public final fun getOriginal ()Lio/getstream/feeds/android/network/models/ImageData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMConfig {
+	public fun <init> (ZLjava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (ZLjava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/LLMConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/LLMConfig;ZLjava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/LLMConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppContext ()Ljava/lang/String;
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getEnabled ()Z
+	public final fun getRules ()Ljava/util/List;
+	public final fun getSeverityDescriptions ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/LLMRule$Action;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/LLMRule$Action;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/LLMRule$Action;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Lio/getstream/feeds/android/network/models/LLMRule$Action;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/LLMRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/LLMRule;Lio/getstream/feeds/android/network/models/LLMRule$Action;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/LLMRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/LLMRule$Action;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getLabel ()Ljava/lang/String;
+	public final fun getSeverityRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/LLMRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/LLMRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/LLMRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/LLMRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$Bounce : io/getstream/feeds/android/network/models/LLMRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/LLMRule$Action$Bounce;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$BounceFlag : io/getstream/feeds/android/network/models/LLMRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/LLMRule$Action$BounceFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$BounceRemove : io/getstream/feeds/android/network/models/LLMRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/LLMRule$Action$BounceRemove;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/LLMRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$Flag : io/getstream/feeds/android/network/models/LLMRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/LLMRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$Keep : io/getstream/feeds/android/network/models/LLMRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/LLMRule$Action$Keep;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$Remove : io/getstream/feeds/android/network/models/LLMRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/LLMRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$Shadow : io/getstream/feeds/android/network/models/LLMRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/LLMRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/LLMRule$Action$Unknown : io/getstream/feeds/android/network/models/LLMRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/LLMRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/LLMRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/LLMRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ListBlockListResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/ListBlockListResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ListBlockListResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ListBlockListResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocklists ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ListDevicesResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/ListDevicesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ListDevicesResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ListDevicesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDevices ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ListUserGroupsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/ListUserGroupsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ListUserGroupsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ListUserGroupsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUserGroups ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Location {
+	public fun <init> (FF)V
+	public final fun component1 ()F
+	public final fun component2 ()F
+	public final fun copy (FF)Lio/getstream/feeds/android/network/models/Location;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/Location;FFILjava/lang/Object;)Lio/getstream/feeds/android/network/models/Location;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLat ()F
+	public final fun getLng ()F
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/MarkActivityRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/network/models/MarkActivityRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/MarkActivityRequest;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/MarkActivityRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMarkAllRead ()Ljava/lang/Boolean;
+	public final fun getMarkAllSeen ()Ljava/lang/Boolean;
+	public final fun getMarkRead ()Ljava/util/List;
+	public final fun getMarkSeen ()Ljava/util/List;
+	public final fun getMarkWatched ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/MarkReviewedRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContentToMarkAsReviewedLimit ()Ljava/lang/Integer;
+	public final fun getDecisionReason ()Ljava/lang/String;
+	public final fun getDisableMarkingContentAsReviewed ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/MembershipLevelResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;ILjava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;ILjava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;ILjava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/MembershipLevelResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/MembershipLevelResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;ILjava/util/Date;Ljava/util/List;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/MembershipLevelResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getPriority ()I
+	public final fun getTags ()Ljava/util/List;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ModerationActionConfigResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()I
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ModerationActionConfigResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ModerationActionConfigResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ModerationActionConfigResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Ljava/lang/String;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getIcon ()Ljava/lang/String;
+	public final fun getOrder ()I
+	public final fun getQueueType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ModerationCustomActionEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ModerationCustomActionEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ModerationCustomActionEvent;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ModerationCustomActionEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActionId ()Ljava/lang/String;
+	public final fun getActionOptions ()Ljava/util/Map;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getReviewQueueItem ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ModerationFlagResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Ljava/util/List;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/ModerationFlagResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ModerationFlagResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ModerationFlagResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getEntityCreatorId ()Ljava/lang/String;
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getLabels ()Ljava/util/List;
+	public final fun getModerationPayload ()Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getResult ()Ljava/util/List;
+	public final fun getReviewQueueItem ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun getReviewQueueItemId ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ModerationFlaggedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/ModerationFlaggedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ModerationFlaggedEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ModerationFlaggedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContentType ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ModerationMarkReviewedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/ModerationMarkReviewedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ModerationMarkReviewedEvent;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ModerationMarkReviewedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getItem ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ModerationPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ModerationPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ModerationPayload;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ModerationPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getImages ()Ljava/util/List;
+	public final fun getTexts ()Ljava/util/List;
+	public final fun getVideos ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ModerationPayloadResponse {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getImages ()Ljava/util/List;
+	public final fun getTexts ()Ljava/util/List;
+	public final fun getVideos ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ModerationV2Response {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Ljava/lang/String;
+	public final fun getBlocklistMatched ()Ljava/lang/String;
+	public final fun getBlocklistsMatched ()Ljava/util/List;
+	public final fun getImageHarms ()Ljava/util/List;
+	public final fun getOriginalText ()Ljava/lang/String;
+	public final fun getPlatformCircumvented ()Ljava/lang/Boolean;
+	public final fun getSemanticFilterMatched ()Ljava/lang/String;
+	public final fun getTextHarms ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/MuteRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/util/List;Ljava/lang/Integer;)Lio/getstream/feeds/android/network/models/MuteRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/MuteRequest;Ljava/util/List;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/MuteRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTargetIds ()Ljava/util/List;
+	public final fun getTimeout ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/MuteResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/OwnUserResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/OwnUserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/OwnUserResponse;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/OwnUserResponse;)Lio/getstream/feeds/android/network/models/MuteResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/MuteResponse;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/OwnUserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/MuteResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getMutes ()Ljava/util/List;
+	public final fun getNonExistingUsers ()Ljava/util/List;
+	public final fun getOwnUser ()Lio/getstream/feeds/android/network/models/OwnUserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/NotificationComment {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/NotificationComment;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/NotificationComment;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/NotificationConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/NotificationConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/NotificationConfig;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/NotificationConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeduplicationWindow ()Ljava/lang/String;
+	public final fun getTrackRead ()Ljava/lang/Boolean;
+	public final fun getTrackSeen ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/NotificationContext {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/feeds/android/network/models/NotificationTarget;Lio/getstream/feeds/android/network/models/NotificationTrigger;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/NotificationTarget;Lio/getstream/feeds/android/network/models/NotificationTrigger;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/NotificationTarget;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/NotificationTrigger;
+	public final fun copy (Lio/getstream/feeds/android/network/models/NotificationTarget;Lio/getstream/feeds/android/network/models/NotificationTrigger;)Lio/getstream/feeds/android/network/models/NotificationContext;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/NotificationContext;Lio/getstream/feeds/android/network/models/NotificationTarget;Lio/getstream/feeds/android/network/models/NotificationTrigger;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/NotificationContext;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTarget ()Lio/getstream/feeds/android/network/models/NotificationTarget;
+	public final fun getTrigger ()Lio/getstream/feeds/android/network/models/NotificationTrigger;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/NotificationFeedUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Lio/getstream/feeds/android/network/models/NotificationStatusResponse;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Lio/getstream/feeds/android/network/models/NotificationStatusResponse;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/NotificationStatusResponse;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Lio/getstream/feeds/android/network/models/NotificationStatusResponse;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/NotificationFeedUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/NotificationFeedUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Lio/getstream/feeds/android/network/models/NotificationStatusResponse;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/NotificationFeedUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAggregatedActivities ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getNotificationStatus ()Lio/getstream/feeds/android/network/models/NotificationStatusResponse;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/NotificationParentActivity {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/NotificationParentActivity;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/NotificationParentActivity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/NotificationParentActivity;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/NotificationStatusResponse {
+	public fun <init> (IILjava/util/Date;Ljava/util/Date;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (IILjava/util/Date;Ljava/util/Date;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (IILjava/util/Date;Ljava/util/Date;Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/network/models/NotificationStatusResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/NotificationStatusResponse;IILjava/util/Date;Ljava/util/Date;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/NotificationStatusResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLastReadAt ()Ljava/util/Date;
+	public final fun getLastSeenAt ()Ljava/util/Date;
+	public final fun getReadActivities ()Ljava/util/List;
+	public final fun getSeenActivities ()Ljava/util/List;
+	public final fun getUnread ()I
+	public final fun getUnseen ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/NotificationTarget {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/util/Map;Lio/getstream/feeds/android/network/models/NotificationParentActivity;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/util/Map;Lio/getstream/feeds/android/network/models/NotificationParentActivity;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/NotificationComment;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/NotificationParentActivity;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/util/Map;Lio/getstream/feeds/android/network/models/NotificationParentActivity;)Lio/getstream/feeds/android/network/models/NotificationTarget;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/NotificationTarget;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/util/Map;Lio/getstream/feeds/android/network/models/NotificationParentActivity;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/NotificationTarget;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/NotificationComment;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getParentActivity ()Lio/getstream/feeds/android/network/models/NotificationParentActivity;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/NotificationTrigger {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/NotificationComment;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/NotificationTrigger;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/NotificationTrigger;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/NotificationComment;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/NotificationTrigger;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/NotificationComment;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/OCRRule$Action;Ljava/lang/String;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/OCRRule$Action;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Lio/getstream/feeds/android/network/models/OCRRule$Action;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/OCRRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/OCRRule;Lio/getstream/feeds/android/network/models/OCRRule$Action;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/OCRRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/OCRRule$Action;
+	public final fun getLabel ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/OCRRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/OCRRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/OCRRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/OCRRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$Bounce : io/getstream/feeds/android/network/models/OCRRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/OCRRule$Action$Bounce;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$BounceFlag : io/getstream/feeds/android/network/models/OCRRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/OCRRule$Action$BounceFlag;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$BounceRemove : io/getstream/feeds/android/network/models/OCRRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/OCRRule$Action$BounceRemove;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/OCRRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$Flag : io/getstream/feeds/android/network/models/OCRRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/OCRRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$Remove : io/getstream/feeds/android/network/models/OCRRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/OCRRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$Shadow : io/getstream/feeds/android/network/models/OCRRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/OCRRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/OCRRule$Action$Unknown : io/getstream/feeds/android/network/models/OCRRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/OCRRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/OCRRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/OCRRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/OnlyUserID {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/OnlyUserID;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/OnlyUserID;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/OnlyUserID;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/OwnBatchRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/network/models/OwnBatchRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/OwnBatchRequest;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/OwnBatchRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getFields ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/OwnBatchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/OwnBatchResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/OwnBatchResponse;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/OwnBatchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/util/Map;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/OwnUserResponse {
+	public fun <init> (ZLjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ZLjava/lang/String;IIIILjava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/PushPreferencesResponse;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ZLjava/lang/String;IIIILjava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/PushPreferencesResponse;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()I
+	public final fun component11 ()I
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/Map;
+	public final fun component17 ()Ljava/lang/Integer;
+	public final fun component18 ()Ljava/util/Date;
+	public final fun component19 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/util/Date;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Ljava/util/Date;
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Ljava/util/List;
+	public final fun component26 ()Lio/getstream/feeds/android/network/models/PushPreferencesResponse;
+	public final fun component27 ()Ljava/util/Map;
+	public final fun component28 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Z
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (ZLjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ZLjava/lang/String;IIIILjava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/PushPreferencesResponse;Ljava/util/Map;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/OwnUserResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/OwnUserResponse;ZLjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ZLjava/lang/String;IIIILjava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/PushPreferencesResponse;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/OwnUserResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvgResponseTime ()Ljava/lang/Integer;
+	public final fun getBanned ()Z
+	public final fun getBlockedUserIds ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeactivatedAt ()Ljava/util/Date;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDevices ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getInvisible ()Z
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLastActive ()Ljava/util/Date;
+	public final fun getLatestHiddenChannels ()Ljava/util/List;
+	public final fun getMutes ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOnline ()Z
+	public final fun getPushPreferences ()Lio/getstream/feeds/android/network/models/PushPreferencesResponse;
+	public final fun getRevokeTokensIssuedBefore ()Ljava/util/Date;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTeams ()Ljava/util/List;
+	public final fun getTeamsRole ()Ljava/util/Map;
+	public final fun getTotalUnreadCount ()I
+	public final fun getTotalUnreadCountByTeam ()Ljava/util/Map;
+	public final fun getUnreadChannels ()I
+	public final fun getUnreadCount ()I
+	public final fun getUnreadThreads ()I
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PagerRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PagerRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PagerRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PagerRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PagerResponse {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PagerResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PagerResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PagerResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PinActivityRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/PinActivityRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PinActivityRequest;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PinActivityRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PinActivityResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)Lio/getstream/feeds/android/network/models/PinActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PinActivityResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PinActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFeed ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollClosedFeedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/PollClosedFeedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollClosedFeedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollClosedFeedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollDeletedFeedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/PollDeletedFeedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollDeletedFeedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollDeletedFeedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollOptionInput {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/PollOptionInput;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollOptionInput;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollOptionInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollOptionRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/PollOptionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollOptionRequest;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollOptionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollOptionResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollOptionResponseData;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/PollOptionResponseData;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollOptionResponseData;)Lio/getstream/feeds/android/network/models/PollOptionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollOptionResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollOptionResponseData;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollOptionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getPollOption ()Lio/getstream/feeds/android/network/models/PollOptionResponseData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollOptionResponseData {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/PollOptionResponseData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollOptionResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollOptionResponseData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollResponseData;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollResponseData;)Lio/getstream/feeds/android/network/models/PollResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollResponseData;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollResponseData {
+	public fun <init> (ZZILjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public synthetic fun <init> (ZZILjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component11 ()I
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/Map;
+	public final fun component17 ()Ljava/util/Map;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component2 ()Z
+	public final fun component20 ()Ljava/lang/Integer;
+	public final fun component21 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Z
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (ZZILjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/PollResponseData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollResponseData;ZZILjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollResponseData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowAnswers ()Z
+	public final fun getAllowUserSuggestedOptions ()Z
+	public final fun getAnswersCount ()I
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getCreatedById ()Ljava/lang/String;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEnforceUniqueVote ()Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLatestAnswers ()Ljava/util/List;
+	public final fun getLatestVotesByOption ()Ljava/util/Map;
+	public final fun getMaxVotesAllowed ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getOwnVotes ()Ljava/util/List;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getVoteCount ()I
+	public final fun getVoteCountsByOption ()Ljava/util/Map;
+	public final fun getVotingVisibility ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isClosed ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollUpdatedFeedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/PollUpdatedFeedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollUpdatedFeedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollUpdatedFeedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollVoteCastedFeedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/PollVoteCastedFeedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollVoteCastedFeedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollVoteCastedFeedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun getPollVote ()Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollVoteChangedFeedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/PollVoteChangedFeedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollVoteChangedFeedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollVoteChangedFeedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun getPollVote ()Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollVoteRemovedFeedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/PollVoteRemovedFeedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollVoteRemovedFeedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollVoteRemovedFeedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun getPollVote ()Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollVoteResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;)Lio/getstream/feeds/android/network/models/PollVoteResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollVoteResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PollResponseData;Lio/getstream/feeds/android/network/models/PollVoteResponseData;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollVoteResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getPoll ()Lio/getstream/feeds/android/network/models/PollResponseData;
+	public final fun getVote ()Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollVoteResponseData {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollVoteResponseData;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollVoteResponseData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnswerText ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getOptionId ()Ljava/lang/String;
+	public final fun getPollId ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isAnswer ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PollVotesResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PollVotesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PollVotesResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PollVotesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getVotes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PushNotificationConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Boolean;Ljava/util/List;)Lio/getstream/feeds/android/network/models/PushNotificationConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PushNotificationConfig;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PushNotificationConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnablePush ()Ljava/lang/Boolean;
+	public final fun getPushTypes ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput {
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;Ljava/util/Date;Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedsPreferences;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;Ljava/util/Date;Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedsPreferences;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/FeedsPreferences;
+	public final fun copy (Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;Ljava/util/Date;Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedsPreferences;)Lio/getstream/feeds/android/network/models/PushPreferenceInput;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PushPreferenceInput;Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;Ljava/lang/String;Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;Ljava/util/Date;Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedsPreferences;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PushPreferenceInput;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCallLevel ()Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;
+	public final fun getChannelCid ()Ljava/lang/String;
+	public final fun getChatLevel ()Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;
+	public final fun getDisabledUntil ()Ljava/util/Date;
+	public final fun getFeedsLevel ()Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;
+	public final fun getFeedsPreferences ()Lio/getstream/feeds/android/network/models/FeedsPreferences;
+	public final fun getRemoveDisable ()Ljava/lang/Boolean;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel {
+	public static final field Companion Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$All : io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$All;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$CallLevelAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$Default : io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$Default;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$None : io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$None;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$Unknown : io/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$CallLevel$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel {
+	public static final field Companion Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$All : io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$All;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$AllMentions : io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$AllMentions;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$ChatLevelAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Default : io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Default;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$DirectMentions : io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$DirectMentions;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Mentions : io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Mentions;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$None : io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$None;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Unknown : io/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$ChatLevel$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel {
+	public static final field Companion Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$All : io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$All;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$Default : io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$Default;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$FeedsLevelAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$None : io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$None;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$Unknown : io/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PushPreferenceInput$FeedsLevel$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/PushPreferencesResponse {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;)Lio/getstream/feeds/android/network/models/PushPreferencesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/PushPreferencesResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/PushPreferencesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCallLevel ()Ljava/lang/String;
+	public final fun getChatLevel ()Ljava/lang/String;
+	public final fun getDisabledUntil ()Ljava/util/Date;
+	public final fun getFeedsLevel ()Ljava/lang/String;
+	public final fun getFeedsPreferences ()Lio/getstream/feeds/android/network/models/FeedsPreferencesResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryActivitiesRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryActivitiesRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryActivitiesRequest;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryActivitiesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getIncludeSoftDeletedActivities ()Ljava/lang/Boolean;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryActivitiesResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryActivitiesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryActivitiesResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryActivitiesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivities ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryActivityReactionsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryActivityReactionsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryActivityReactionsRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryActivityReactionsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryActivityReactionsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryActivityReactionsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryActivityReactionsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryActivityReactionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getReactions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryAppealsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryAppealsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryAppealsRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryAppealsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryAppealsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryAppealsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryAppealsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryAppealsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getItems ()Ljava/util/List;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryBookmarkFoldersRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryBookmarkFoldersRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryBookmarkFoldersRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryBookmarkFoldersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryBookmarkFoldersResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryBookmarkFoldersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryBookmarkFoldersResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryBookmarkFoldersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmarkFolders ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryBookmarksRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryBookmarksRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryBookmarksRequest;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryBookmarksRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryBookmarksResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryBookmarksResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryBookmarksResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryBookmarksResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmarks ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCollectionsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryCollectionsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryCollectionsRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryCollectionsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCollectionsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryCollectionsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryCollectionsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryCollectionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollections ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentReactionsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryCommentReactionsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryCommentReactionsRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryCommentReactionsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentReactionsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryCommentReactionsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryCommentReactionsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryCommentReactionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getReactions ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;
+	public final fun copy (Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;)Lio/getstream/feeds/android/network/models/QueryCommentsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryCommentsRequest;Ljava/util/Map;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryCommentsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getIdAround ()Ljava/lang/String;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort {
+	public static final field Companion Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Best : io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Best;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Controversial : io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Controversial;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$First : io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$First;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Last : io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Last;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$SortAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Top : io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Top;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Unknown : io/getstream/feeds/android/network/models/QueryCommentsRequest$Sort {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryCommentsRequest$Sort$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryCommentsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryCommentsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryCommentsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryCommentsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComments ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryFeedMembersRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryFeedMembersRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryFeedMembersRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryFeedMembersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryFeedMembersResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryFeedMembersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryFeedMembersResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryFeedMembersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryFeedsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryFeedsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryFeedsRequest;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryFeedsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public final fun getWatch ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryFeedsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryFeedsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryFeedsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryFeedsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryFollowsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryFollowsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryFollowsRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryFollowsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryFollowsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryFollowsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryFollowsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryFollowsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFollows ()Ljava/util/List;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryModerationConfigsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryModerationConfigsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryModerationConfigsRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryModerationConfigsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryModerationConfigsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryModerationConfigsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryModerationConfigsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryModerationConfigsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfigs ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryPinnedActivitiesRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryPinnedActivitiesRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryPinnedActivitiesRequest;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryPinnedActivitiesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryPinnedActivitiesResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryPinnedActivitiesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryPinnedActivitiesResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryPinnedActivitiesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPinnedActivities ()Ljava/util/List;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryPollVotesRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryPollVotesRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryPollVotesRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryPollVotesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryPollsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryPollsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryPollsRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryPollsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryPollsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/QueryPollsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryPollsResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryPollsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPolls ()Ljava/util/List;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryReviewQueueRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/QueryReviewQueueRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryReviewQueueRequest;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryReviewQueueRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilter ()Ljava/util/Map;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getLockCount ()Ljava/lang/Integer;
+	public final fun getLockDuration ()Ljava/lang/Integer;
+	public final fun getLockItems ()Ljava/lang/Boolean;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getSort ()Ljava/util/List;
+	public final fun getStatsOnly ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryReviewQueueResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FilterConfigResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FilterConfigResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/FilterConfigResponse;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FilterConfigResponse;)Lio/getstream/feeds/android/network/models/QueryReviewQueueResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryReviewQueueResponse;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FilterConfigResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryReviewQueueResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActionConfig ()Ljava/util/Map;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFilterConfig ()Lio/getstream/feeds/android/network/models/FilterConfigResponse;
+	public final fun getItems ()Ljava/util/List;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getPrev ()Ljava/lang/String;
+	public final fun getStats ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryUsersPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;)Lio/getstream/feeds/android/network/models/QueryUsersPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryUsersPayload;Ljava/util/Map;Ljava/lang/Boolean;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryUsersPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilterConditions ()Ljava/util/Map;
+	public final fun getIncludeDeactivatedUsers ()Ljava/lang/Boolean;
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getOffset ()Ljava/lang/Integer;
+	public final fun getPresence ()Ljava/lang/Boolean;
+	public final fun getSort ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/QueryUsersResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/QueryUsersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/QueryUsersResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/QueryUsersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUsers ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RankingConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/RankingConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RankingConfig;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RankingConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDefaults ()Ljava/util/Map;
+	public final fun getFunctions ()Ljava/util/Map;
+	public final fun getScore ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Reaction {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/User;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/User;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/Map;
+	public final fun component12 ()Ljava/util/Map;
+	public final fun component13 ()Ljava/util/Map;
+	public final fun component14 ()Ljava/util/Map;
+	public final fun component15 ()Ljava/util/Map;
+	public final fun component16 ()Ljava/util/Map;
+	public final fun component17 ()Lio/getstream/feeds/android/network/models/User;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/Float;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/User;)Lio/getstream/feeds/android/network/models/Reaction;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/Reaction;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Float;Ljava/util/List;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;Lio/getstream/feeds/android/network/models/User;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/Reaction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getChildrenCounts ()Ljava/util/Map;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getData ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getKind ()Ljava/lang/String;
+	public final fun getLatestChildren ()Ljava/util/Map;
+	public final fun getModeration ()Ljava/util/Map;
+	public final fun getOwnChildren ()Ljava/util/Map;
+	public final fun getParent ()Ljava/lang/String;
+	public final fun getScore ()Ljava/lang/Float;
+	public final fun getTargetFeeds ()Ljava/util/List;
+	public final fun getTargetFeedsExtraData ()Ljava/util/Map;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/User;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ReadCollectionsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/ReadCollectionsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ReadCollectionsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ReadCollectionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollections ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RejectAppealRequestPayload {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDecisionReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RejectFeedMemberInviteRequest {
+	public fun <init> ()V
+}
+
+public final class io/getstream/feeds/android/network/models/RejectFeedMemberInviteResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse;)Lio/getstream/feeds/android/network/models/RejectFeedMemberInviteResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RejectFeedMemberInviteResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedMemberResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RejectFeedMemberInviteResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getMember ()Lio/getstream/feeds/android/network/models/FeedMemberResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RejectFollowRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/RejectFollowRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RejectFollowRequest;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RejectFollowRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getTarget ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RejectFollowResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;)Lio/getstream/feeds/android/network/models/RejectFollowResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RejectFollowResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RejectFollowResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RemoveUserGroupMembersRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/List;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/RemoveUserGroupMembersRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RemoveUserGroupMembersRequest;Ljava/util/List;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RemoveUserGroupMembersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMemberIds ()Ljava/util/List;
+	public final fun getTeamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RemoveUserGroupMembersResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)Lio/getstream/feeds/android/network/models/RemoveUserGroupMembersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RemoveUserGroupMembersResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RemoveUserGroupMembersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUserGroup ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RepliesMeta {
+	public fun <init> (ZZILjava/lang/String;)V
+	public synthetic fun <init> (ZZILjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()I
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (ZZILjava/lang/String;)Lio/getstream/feeds/android/network/models/RepliesMeta;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RepliesMeta;ZZILjava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RepliesMeta;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDepthTruncated ()Z
+	public final fun getHasMore ()Z
+	public final fun getNextCursor ()Ljava/lang/String;
+	public final fun getRemaining ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Response {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/Response;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/Response;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/Response;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RestoreActionRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDecisionReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RestoreActivityRequest {
+	public fun <init> ()V
+}
+
+public final class io/getstream/feeds/android/network/models/RestoreActivityResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)Lio/getstream/feeds/android/network/models/RestoreActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RestoreActivityResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RestoreActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RestoreCommentRequest {
+	public fun <init> ()V
+}
+
+public final class io/getstream/feeds/android/network/models/RestoreCommentResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;)Lio/getstream/feeds/android/network/models/RestoreCommentResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RestoreCommentResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;Lio/getstream/feeds/android/network/models/CommentResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RestoreCommentResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ReviewQueueItemResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Lio/getstream/feeds/android/network/models/EnrichedActivity;Lio/getstream/feeds/android/network/models/AppealItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/EntityCreatorResponse;Lio/getstream/feeds/android/network/models/EscalationMetadata;Lio/getstream/feeds/android/network/models/EnrichedActivity;Lio/getstream/feeds/android/network/models/Reaction;Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Lio/getstream/feeds/android/network/models/Reaction;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Lio/getstream/feeds/android/network/models/EnrichedActivity;Lio/getstream/feeds/android/network/models/AppealItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/EntityCreatorResponse;Lio/getstream/feeds/android/network/models/EscalationMetadata;Lio/getstream/feeds/android/network/models/EnrichedActivity;Lio/getstream/feeds/android/network/models/Reaction;Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Lio/getstream/feeds/android/network/models/Reaction;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()I
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/util/Date;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/Date;
+	public final fun component19 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/util/Date;
+	public final fun component22 ()Ljava/lang/String;
+	public final fun component23 ()Ljava/util/Date;
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Lio/getstream/feeds/android/network/models/EnrichedActivity;
+	public final fun component26 ()Lio/getstream/feeds/android/network/models/AppealItemResponse;
+	public final fun component27 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component28 ()Lio/getstream/feeds/android/network/models/EntityCreatorResponse;
+	public final fun component29 ()Lio/getstream/feeds/android/network/models/EscalationMetadata;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component30 ()Lio/getstream/feeds/android/network/models/EnrichedActivity;
+	public final fun component31 ()Lio/getstream/feeds/android/network/models/Reaction;
+	public final fun component32 ()Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;
+	public final fun component33 ()Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;
+	public final fun component34 ()Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;
+	public final fun component35 ()Lio/getstream/feeds/android/network/models/Reaction;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()I
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Lio/getstream/feeds/android/network/models/EnrichedActivity;Lio/getstream/feeds/android/network/models/AppealItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/EntityCreatorResponse;Lio/getstream/feeds/android/network/models/EscalationMetadata;Lio/getstream/feeds/android/network/models/EnrichedActivity;Lio/getstream/feeds/android/network/models/Reaction;Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Lio/getstream/feeds/android/network/models/Reaction;)Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Lio/getstream/feeds/android/network/models/EnrichedActivity;Lio/getstream/feeds/android/network/models/AppealItemResponse;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/EntityCreatorResponse;Lio/getstream/feeds/android/network/models/EscalationMetadata;Lio/getstream/feeds/android/network/models/EnrichedActivity;Lio/getstream/feeds/android/network/models/Reaction;Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;Lio/getstream/feeds/android/network/models/Reaction;IILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActions ()Ljava/util/List;
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/EnrichedActivity;
+	public final fun getAiTextSeverity ()Ljava/lang/String;
+	public final fun getAppeal ()Lio/getstream/feeds/android/network/models/AppealItemResponse;
+	public final fun getAssignedTo ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getBans ()Ljava/util/List;
+	public final fun getCompletedAt ()Ljava/util/Date;
+	public final fun getConfigKey ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getEntityCreator ()Lio/getstream/feeds/android/network/models/EntityCreatorResponse;
+	public final fun getEntityCreatorId ()Ljava/lang/String;
+	public final fun getEntityId ()Ljava/lang/String;
+	public final fun getEntityType ()Ljava/lang/String;
+	public final fun getEscalated ()Z
+	public final fun getEscalatedAt ()Ljava/util/Date;
+	public final fun getEscalatedBy ()Ljava/lang/String;
+	public final fun getEscalationMetadata ()Lio/getstream/feeds/android/network/models/EscalationMetadata;
+	public final fun getFeedsV2Activity ()Lio/getstream/feeds/android/network/models/EnrichedActivity;
+	public final fun getFeedsV2Reaction ()Lio/getstream/feeds/android/network/models/Reaction;
+	public final fun getFeedsV3Activity ()Lio/getstream/feeds/android/network/models/FeedsV3ActivityResponse;
+	public final fun getFeedsV3Comment ()Lio/getstream/feeds/android/network/models/FeedsV3CommentResponse;
+	public final fun getFlags ()Ljava/util/List;
+	public final fun getFlagsCount ()I
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLanguages ()Ljava/util/List;
+	public final fun getLatestModeratorAction ()Ljava/lang/String;
+	public final fun getModerationPayload ()Lio/getstream/feeds/android/network/models/ModerationPayloadResponse;
+	public final fun getReaction ()Lio/getstream/feeds/android/network/models/Reaction;
+	public final fun getRecommendedAction ()Ljava/lang/String;
+	public final fun getReviewedAt ()Ljava/util/Date;
+	public final fun getReviewedBy ()Ljava/lang/String;
+	public final fun getSeverity ()I
+	public final fun getStatus ()Ljava/lang/String;
+	public final fun getTeams ()Ljava/util/List;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;Lio/getstream/feeds/android/network/models/BanOptions;Lio/getstream/feeds/android/network/models/FlagUserOptions;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;Lio/getstream/feeds/android/network/models/BanOptions;Lio/getstream/feeds/android/network/models/FlagUserOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/BanOptions;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FlagUserOptions;
+	public final fun copy (Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;Lio/getstream/feeds/android/network/models/BanOptions;Lio/getstream/feeds/android/network/models/FlagUserOptions;)Lio/getstream/feeds/android/network/models/RuleBuilderAction;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RuleBuilderAction;Ljava/lang/Boolean;Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;Lio/getstream/feeds/android/network/models/BanOptions;Lio/getstream/feeds/android/network/models/FlagUserOptions;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RuleBuilderAction;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBanOptions ()Lio/getstream/feeds/android/network/models/BanOptions;
+	public final fun getFlagUserOptions ()Lio/getstream/feeds/android/network/models/FlagUserOptions;
+	public final fun getSkipInbox ()Ljava/lang/Boolean;
+	public final fun getType ()Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field Companion Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$BanUser : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$BanUser;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$BlockContent : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$BlockContent;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$Blur : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$Blur;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$BounceContent : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$BounceContent;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$BounceFlagContent : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$BounceFlagContent;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$BounceRemoveContent : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$BounceRemoveContent;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$CallBlur : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$CallBlur;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$CallWarning : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$CallWarning;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$EndCall : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$EndCall;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$FlagContent : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$FlagContent;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$FlagUser : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$FlagUser;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$KickUser : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$KickUser;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$MuteAudio : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$MuteAudio;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$MuteVideo : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$MuteVideo;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$ShadowContent : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$ShadowContent;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$TypeAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$Unknown : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$Warning : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$Warning;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderAction$Type$WebhookOnly : io/getstream/feeds/android/network/models/RuleBuilderAction$Type {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/RuleBuilderAction$Type$WebhookOnly;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderCondition {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Float;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Lio/getstream/feeds/android/network/models/ImageContentParameters;Lio/getstream/feeds/android/network/models/ImageRuleParameters;Lio/getstream/feeds/android/network/models/TextContentParameters;Lio/getstream/feeds/android/network/models/TextRuleParameters;Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;Lio/getstream/feeds/android/network/models/UserRoleParameters;Lio/getstream/feeds/android/network/models/UserRuleParameters;Lio/getstream/feeds/android/network/models/VideoContentParameters;Lio/getstream/feeds/android/network/models/VideoRuleParameters;)V
+	public synthetic fun <init> (Ljava/lang/Float;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Lio/getstream/feeds/android/network/models/ImageContentParameters;Lio/getstream/feeds/android/network/models/ImageRuleParameters;Lio/getstream/feeds/android/network/models/TextContentParameters;Lio/getstream/feeds/android/network/models/TextRuleParameters;Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;Lio/getstream/feeds/android/network/models/UserRoleParameters;Lio/getstream/feeds/android/network/models/UserRuleParameters;Lio/getstream/feeds/android/network/models/VideoContentParameters;Lio/getstream/feeds/android/network/models/VideoRuleParameters;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Float;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/UserRoleParameters;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/UserRuleParameters;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/VideoContentParameters;
+	public final fun component16 ()Lio/getstream/feeds/android/network/models/VideoRuleParameters;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/ImageContentParameters;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/ImageRuleParameters;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/TextContentParameters;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/TextRuleParameters;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;
+	public final fun copy (Ljava/lang/Float;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Lio/getstream/feeds/android/network/models/ImageContentParameters;Lio/getstream/feeds/android/network/models/ImageRuleParameters;Lio/getstream/feeds/android/network/models/TextContentParameters;Lio/getstream/feeds/android/network/models/TextRuleParameters;Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;Lio/getstream/feeds/android/network/models/UserRoleParameters;Lio/getstream/feeds/android/network/models/UserRuleParameters;Lio/getstream/feeds/android/network/models/VideoContentParameters;Lio/getstream/feeds/android/network/models/VideoRuleParameters;)Lio/getstream/feeds/android/network/models/RuleBuilderCondition;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RuleBuilderCondition;Ljava/lang/Float;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Lio/getstream/feeds/android/network/models/ImageContentParameters;Lio/getstream/feeds/android/network/models/ImageRuleParameters;Lio/getstream/feeds/android/network/models/TextContentParameters;Lio/getstream/feeds/android/network/models/TextRuleParameters;Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;Lio/getstream/feeds/android/network/models/UserRoleParameters;Lio/getstream/feeds/android/network/models/UserRuleParameters;Lio/getstream/feeds/android/network/models/VideoContentParameters;Lio/getstream/feeds/android/network/models/VideoRuleParameters;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RuleBuilderCondition;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfidence ()Ljava/lang/Float;
+	public final fun getContentCountRuleParams ()Lio/getstream/feeds/android/network/models/ContentCountRuleParameters;
+	public final fun getContentFlagCountRuleParams ()Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;
+	public final fun getImageContentParams ()Lio/getstream/feeds/android/network/models/ImageContentParameters;
+	public final fun getImageRuleParams ()Lio/getstream/feeds/android/network/models/ImageRuleParameters;
+	public final fun getTextContentParams ()Lio/getstream/feeds/android/network/models/TextContentParameters;
+	public final fun getTextRuleParams ()Lio/getstream/feeds/android/network/models/TextRuleParameters;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUserCreatedWithinParams ()Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;
+	public final fun getUserCustomPropertyParams ()Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;
+	public final fun getUserFlagCountRuleParams ()Lio/getstream/feeds/android/network/models/FlagCountRuleParameters;
+	public final fun getUserIdenticalContentCountParams ()Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;
+	public final fun getUserRoleParams ()Lio/getstream/feeds/android/network/models/UserRoleParameters;
+	public final fun getUserRuleParams ()Lio/getstream/feeds/android/network/models/UserRuleParameters;
+	public final fun getVideoContentParams ()Lio/getstream/feeds/android/network/models/VideoContentParameters;
+	public final fun getVideoRuleParams ()Lio/getstream/feeds/android/network/models/VideoRuleParameters;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderConditionGroup {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/RuleBuilderConditionGroup;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RuleBuilderConditionGroup;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RuleBuilderConditionGroup;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConditions ()Ljava/util/List;
+	public final fun getLogic ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Boolean;Ljava/util/List;)Lio/getstream/feeds/android/network/models/RuleBuilderConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RuleBuilderConfig;Ljava/lang/Boolean;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RuleBuilderConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/RuleBuilderRule {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/RuleBuilderAction;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/RuleBuilderAction;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/RuleBuilderAction;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/RuleBuilderAction;)Lio/getstream/feeds/android/network/models/RuleBuilderRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/RuleBuilderRule;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/RuleBuilderAction;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/RuleBuilderRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/RuleBuilderAction;
+	public final fun getConditions ()Ljava/util/List;
+	public final fun getCooldownPeriod ()Ljava/lang/String;
+	public final fun getGroups ()Ljava/util/List;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLogic ()Ljava/lang/String;
+	public final fun getRuleType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SearchUserGroupsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/SearchUserGroupsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SearchUserGroupsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SearchUserGroupsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUserGroups ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SharedLocationResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;FFLjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;FFLjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()F
+	public final fun component6 ()F
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/Date;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;FFLjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/SharedLocationResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SharedLocationResponse;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;FFLjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SharedLocationResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelCid ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedByDeviceId ()Ljava/lang/String;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getEndAt ()Ljava/util/Date;
+	public final fun getLatitude ()F
+	public final fun getLongitude ()F
+	public final fun getMessageId ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SharedLocationResponseData {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;FFLjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;FFLjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()F
+	public final fun component5 ()F
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/util/Date;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;FFLjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/SharedLocationResponseData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SharedLocationResponseData;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;FFLjava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SharedLocationResponseData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelCid ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedByDeviceId ()Ljava/lang/String;
+	public final fun getEndAt ()Ljava/util/Date;
+	public final fun getLatitude ()F
+	public final fun getLongitude ()F
+	public final fun getMessageId ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SharedLocationsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/SharedLocationsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SharedLocationsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SharedLocationsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActiveLiveLocations ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SingleFollowResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/SingleFollowResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SingleFollowResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SingleFollowResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun getNotificationCreated ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SortParam {
+	public fun <init> (ILjava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (ILjava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/SortParam;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SortParam;ILjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SortParam;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDirection ()I
+	public final fun getField ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SortParamRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/SortParamRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SortParamRequest;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SortParamRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDirection ()Ljava/lang/Integer;
+	public final fun getField ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/StoriesConfig {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/StoriesConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/StoriesConfig;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/StoriesConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSkipWatched ()Ljava/lang/Boolean;
+	public final fun getTrackWatched ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/StoriesFeedUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Date;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/StoriesFeedUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/StoriesFeedUpdatedEvent;Ljava/util/Date;Ljava/lang/String;Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/StoriesFeedUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivities ()Ljava/util/List;
+	public final fun getAggregatedActivities ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFeedVisibility ()Ljava/lang/String;
+	public final fun getFid ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest {
+	public fun <init> (Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanActionRequestPayload;Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;Lio/getstream/feeds/android/network/models/BypassActionRequest;Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;Lio/getstream/feeds/android/network/models/EscalatePayload;Lio/getstream/feeds/android/network/models/FlagRequest;Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanActionRequestPayload;Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;Lio/getstream/feeds/android/network/models/BypassActionRequest;Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;Lio/getstream/feeds/android/network/models/EscalatePayload;Lio/getstream/feeds/android/network/models/FlagRequest;Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/EscalatePayload;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/FlagRequest;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;
+	public final fun component16 ()Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;
+	public final fun component17 ()Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;
+	public final fun component18 ()Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;
+	public final fun component19 ()Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/BanActionRequestPayload;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/BypassActionRequest;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;
+	public final fun copy (Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanActionRequestPayload;Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;Lio/getstream/feeds/android/network/models/BypassActionRequest;Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;Lio/getstream/feeds/android/network/models/EscalatePayload;Lio/getstream/feeds/android/network/models/FlagRequest;Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;)Lio/getstream/feeds/android/network/models/SubmitActionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SubmitActionRequest;Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BanActionRequestPayload;Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;Lio/getstream/feeds/android/network/models/BypassActionRequest;Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;Lio/getstream/feeds/android/network/models/EscalatePayload;Lio/getstream/feeds/android/network/models/FlagRequest;Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SubmitActionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActionType ()Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;
+	public final fun getAppealId ()Ljava/lang/String;
+	public final fun getBan ()Lio/getstream/feeds/android/network/models/BanActionRequestPayload;
+	public final fun getBlock ()Lio/getstream/feeds/android/network/models/BlockActionRequestPayload;
+	public final fun getBypass ()Lio/getstream/feeds/android/network/models/BypassActionRequest;
+	public final fun getCustom ()Lio/getstream/feeds/android/network/models/CustomActionRequestPayload;
+	public final fun getDeleteActivity ()Lio/getstream/feeds/android/network/models/DeleteActivityRequestPayload;
+	public final fun getDeleteComment ()Lio/getstream/feeds/android/network/models/DeleteCommentRequestPayload;
+	public final fun getDeleteReaction ()Lio/getstream/feeds/android/network/models/DeleteReactionRequestPayload;
+	public final fun getDeleteUser ()Lio/getstream/feeds/android/network/models/DeleteUserRequestPayload;
+	public final fun getEscalate ()Lio/getstream/feeds/android/network/models/EscalatePayload;
+	public final fun getFlag ()Lio/getstream/feeds/android/network/models/FlagRequest;
+	public final fun getItemId ()Ljava/lang/String;
+	public final fun getMarkReviewed ()Lio/getstream/feeds/android/network/models/MarkReviewedRequestPayload;
+	public final fun getRejectAppeal ()Lio/getstream/feeds/android/network/models/RejectAppealRequestPayload;
+	public final fun getRestore ()Lio/getstream/feeds/android/network/models/RestoreActionRequestPayload;
+	public final fun getShadowBlock ()Lio/getstream/feeds/android/network/models/ShadowBlockActionRequestPayload;
+	public final fun getUnban ()Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;
+	public final fun getUnblock ()Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field Companion Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$ActionTypeAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Ban : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Ban;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Block : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Block;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Bypass : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Bypass;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Custom : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Custom;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeEscalate : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeEscalate;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteActivity : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteActivity;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteComment : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteComment;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteMessage : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteMessage;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteReaction : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteReaction;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteUser : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$DeleteUser;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$EndCall : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$EndCall;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Escalate : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Escalate;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Flag : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$KickUser : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$KickUser;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$MarkReviewed : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$MarkReviewed;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$RejectAppeal : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$RejectAppeal;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Restore : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Restore;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$ShadowBlock : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$ShadowBlock;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unban : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unban;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unblock : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unblock;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unknown : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unmask : io/getstream/feeds/android/network/models/SubmitActionRequest$ActionType {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/SubmitActionRequest$ActionType$Unmask;
+}
+
+public final class io/getstream/feeds/android/network/models/SubmitActionResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppealItemResponse;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppealItemResponse;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/AppealItemResponse;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppealItemResponse;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;)Lio/getstream/feeds/android/network/models/SubmitActionResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/SubmitActionResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AppealItemResponse;Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/SubmitActionResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppealItem ()Lio/getstream/feeds/android/network/models/AppealItemResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getItem ()Lio/getstream/feeds/android/network/models/ReviewQueueItemResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/TextContentParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/TextContentParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/TextContentParameters;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/TextContentParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocklistMatch ()Ljava/util/List;
+	public final fun getContainsUrl ()Ljava/lang/Boolean;
+	public final fun getHarmLabels ()Ljava/util/List;
+	public final fun getLabelOperator ()Ljava/lang/String;
+	public final fun getLlmHarmLabels ()Ljava/util/Map;
+	public final fun getSeverity ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/TextRuleParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Float;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/Integer;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/TextRuleParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/TextRuleParameters;Ljava/lang/Boolean;Ljava/lang/Float;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/TextRuleParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocklistMatch ()Ljava/util/List;
+	public final fun getContainsUrl ()Ljava/lang/Boolean;
+	public final fun getHarmLabels ()Ljava/util/List;
+	public final fun getLlmHarmLabels ()Ljava/util/Map;
+	public final fun getSemanticFilterMinThreshold ()Ljava/lang/Float;
+	public final fun getSemanticFilterNames ()Ljava/util/List;
+	public final fun getSeverity ()Ljava/lang/String;
+	public final fun getThreshold ()Ljava/lang/Integer;
+	public final fun getTimeWindow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse {
+	public fun <init> (IFLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/RepliesMeta;Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/util/Map;)V
+	public synthetic fun <init> (IFLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/RepliesMeta;Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()I
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()I
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component17 ()Ljava/lang/Float;
+	public final fun component18 ()Ljava/util/Date;
+	public final fun component19 ()Ljava/util/Date;
+	public final fun component2 ()F
+	public final fun component20 ()Ljava/lang/String;
+	public final fun component21 ()Ljava/lang/String;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Ljava/util/List;
+	public final fun component24 ()Ljava/util/List;
+	public final fun component25 ()Ljava/util/Map;
+	public final fun component26 ()Lio/getstream/feeds/android/network/models/RepliesMeta;
+	public final fun component27 ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun component28 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()I
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (IFLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/RepliesMeta;Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/ThreadedCommentResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ThreadedCommentResponse;IFLjava/util/Date;ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Lio/getstream/feeds/android/network/models/UserResponse;Ljava/lang/Float;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/RepliesMeta;Lio/getstream/feeds/android/network/models/ModerationV2Response;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ThreadedCommentResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getBookmarkCount ()I
+	public final fun getConfidenceScore ()F
+	public final fun getControversyScore ()Ljava/lang/Float;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDownvoteCount ()I
+	public final fun getEditedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getLatestReactions ()Ljava/util/List;
+	public final fun getMentionedUsers ()Ljava/util/List;
+	public final fun getMeta ()Lio/getstream/feeds/android/network/models/RepliesMeta;
+	public final fun getModeration ()Lio/getstream/feeds/android/network/models/ModerationV2Response;
+	public final fun getObjectId ()Ljava/lang/String;
+	public final fun getObjectType ()Ljava/lang/String;
+	public final fun getOwnReactions ()Ljava/util/List;
+	public final fun getParentId ()Ljava/lang/String;
+	public final fun getReactionCount ()I
+	public final fun getReactionGroups ()Ljava/util/Map;
+	public final fun getReplies ()Ljava/util/List;
+	public final fun getReplyCount ()I
+	public final fun getScore ()I
+	public final fun getStatus ()Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUpvoteCount ()I
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status {
+	public static final field Companion Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Active : io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Active;
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Deleted : io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Deleted;
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Hidden : io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Hidden;
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Removed : io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Removed;
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$ShadowBlocked : io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$ShadowBlocked;
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$StatusAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Unknown : io/getstream/feeds/android/network/models/ThreadedCommentResponse$Status {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/ThreadedCommentResponse$Status$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/Time {
+	public fun <init> ()V
+}
+
+public final class io/getstream/feeds/android/network/models/TrackActivityMetricsEvent {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/feeds/android/network/models/TrackActivityMetricsEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/TrackActivityMetricsEvent;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/TrackActivityMetricsEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getDelta ()Ljava/lang/Integer;
+	public final fun getMetric ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/TrackActivityMetricsEventResult {
+	public fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/TrackActivityMetricsEventResult;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/TrackActivityMetricsEventResult;Ljava/lang/String;ZLjava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/TrackActivityMetricsEventResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityId ()Ljava/lang/String;
+	public final fun getAllowed ()Z
+	public final fun getError ()Ljava/lang/String;
+	public final fun getMetric ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/TrackActivityMetricsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/getstream/feeds/android/network/models/TrackActivityMetricsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/TrackActivityMetricsRequest;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/TrackActivityMetricsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEvents ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/TrackActivityMetricsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/TrackActivityMetricsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/TrackActivityMetricsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/TrackActivityMetricsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getResults ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnbanActionRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnbanActionRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelCid ()Ljava/lang/String;
+	public final fun getDecisionReason ()Ljava/lang/String;
+	public final fun getRemoveFutureChannelsBan ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnblockActionRequestPayload {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnblockActionRequestPayload;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDecisionReason ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnblockUsersRequest {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UnblockUsersRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnblockUsersRequest;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnblockUsersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlockedUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnblockUsersResponse {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UnblockUsersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnblockUsersResponse;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnblockUsersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnfollowBatchRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/UnfollowBatchRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnfollowBatchRequest;Ljava/util/List;Ljava/lang/Boolean;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnfollowBatchRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDeleteNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFollows ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnfollowBatchResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/UnfollowBatchResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnfollowBatchResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnfollowBatchResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFollows ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnfollowPair {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/UnfollowPair;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnfollowPair;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnfollowPair;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKeepHistory ()Ljava/lang/Boolean;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getTarget ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnfollowResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;)Lio/getstream/feeds/android/network/models/UnfollowResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnfollowResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnfollowResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnpinActivityResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)Lio/getstream/feeds/android/network/models/UnpinActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UnpinActivityResponse;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UnpinActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFeed ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnsupportedWSEvent : io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UnsupportedWSEventException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun getType ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityPartialRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateActivityPartialRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateActivityPartialRequest;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateActivityPartialRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getHandleMentionNotifications ()Ljava/lang/Boolean;
+	public final fun getRunActivityProcessors ()Ljava/lang/Boolean;
+	public final fun getSet ()Ljava/util/Map;
+	public final fun getUnset ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityPartialResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)Lio/getstream/feeds/android/network/models/UpdateActivityPartialResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateActivityPartialResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateActivityPartialResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/List;
+	public final fun component13 ()Ljava/util/List;
+	public final fun component14 ()Ljava/util/List;
+	public final fun component15 ()Ljava/util/List;
+	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Ljava/util/List;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component19 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component20 ()Ljava/util/Map;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Boolean;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateActivityRequest;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getCollectionRefs ()Ljava/util/List;
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getExpiresAt ()Ljava/util/Date;
+	public final fun getFeeds ()Ljava/util/List;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getHandleMentionNotifications ()Ljava/lang/Boolean;
+	public final fun getInterestTags ()Ljava/util/List;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getMentionedUserIds ()Ljava/util/List;
+	public final fun getPollId ()Ljava/lang/String;
+	public final fun getRestrictReplies ()Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;
+	public final fun getRunActivityProcessors ()Ljava/lang/Boolean;
+	public final fun getSearchData ()Ljava/util/Map;
+	public final fun getSkipEnrichUrl ()Ljava/lang/Boolean;
+	public final fun getText ()Ljava/lang/String;
+	public final fun getVisibility ()Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;
+	public final fun getVisibilityTag ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies {
+	public static final field Companion Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Everyone : io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Everyone;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Nobody : io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Nobody;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$PeopleIFollow : io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$PeopleIFollow;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$RestrictRepliesAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Unknown : io/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest$RestrictReplies$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Private : io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Private;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Public : io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Tag : io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Tag;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Unknown : io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility$VisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/UpdateActivityRequest$Visibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateActivityResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;)Lio/getstream/feeds/android/network/models/UpdateActivityResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateActivityResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ActivityResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateActivityResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivity ()Lio/getstream/feeds/android/network/models/ActivityResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateBlockListRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/UpdateBlockListRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateBlockListRequest;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateBlockListRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTeam ()Ljava/lang/String;
+	public final fun getWords ()Ljava/util/List;
+	public fun hashCode ()I
+	public final fun isLeetCheckEnabled ()Ljava/lang/Boolean;
+	public final fun isPluralCheckEnabled ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateBlockListResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BlockListResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BlockListResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BlockListResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BlockListResponse;)Lio/getstream/feeds/android/network/models/UpdateBlockListResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateBlockListResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BlockListResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateBlockListResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBlocklist ()Lio/getstream/feeds/android/network/models/BlockListResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateBookmarkFolderRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateBookmarkFolderRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateBookmarkFolderRequest;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateBookmarkFolderRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateBookmarkFolderResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;)Lio/getstream/feeds/android/network/models/UpdateBookmarkFolderResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateBookmarkFolderResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateBookmarkFolderResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmarkFolder ()Lio/getstream/feeds/android/network/models/BookmarkFolderResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateBookmarkRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;)Lio/getstream/feeds/android/network/models/UpdateBookmarkRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateBookmarkRequest;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateBookmarkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFolderId ()Ljava/lang/String;
+	public final fun getNewFolder ()Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public final fun getNewFolderId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateBookmarkResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)Lio/getstream/feeds/android/network/models/UpdateBookmarkResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateBookmarkResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateBookmarkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCollectionRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateCollectionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCollectionRequest;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCollectionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCollectionsRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/getstream/feeds/android/network/models/UpdateCollectionsRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCollectionsRequest;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCollectionsRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollections ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCollectionsResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/UpdateCollectionsResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCollectionsResponse;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCollectionsResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCollections ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCommentBookmarkRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;)Lio/getstream/feeds/android/network/models/UpdateCommentBookmarkRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCommentBookmarkRequest;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/AddFolderRequest;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCommentBookmarkRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getFolderId ()Ljava/lang/String;
+	public final fun getNewFolder ()Lio/getstream/feeds/android/network/models/AddFolderRequest;
+	public final fun getNewFolderId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCommentBookmarkResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;)Lio/getstream/feeds/android/network/models/UpdateCommentBookmarkResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCommentBookmarkResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/BookmarkResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCommentBookmarkResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBookmark ()Lio/getstream/feeds/android/network/models/BookmarkResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCommentPartialRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateCommentPartialRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCommentPartialRequest;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCommentPartialRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getHandleMentionNotifications ()Ljava/lang/Boolean;
+	public final fun getSet ()Ljava/util/Map;
+	public final fun getSkipEnrichUrl ()Ljava/lang/Boolean;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public final fun getUnset ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCommentPartialResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;)Lio/getstream/feeds/android/network/models/UpdateCommentPartialResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCommentPartialResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCommentPartialResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCommentRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/util/List;
+	public final fun component8 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateCommentRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCommentRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCommentRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getComment ()Ljava/lang/String;
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getHandleMentionNotifications ()Ljava/lang/Boolean;
+	public final fun getMentionedUserIds ()Ljava/util/List;
+	public final fun getSkipEnrichUrl ()Ljava/lang/Boolean;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateCommentResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;)Lio/getstream/feeds/android/network/models/UpdateCommentResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateCommentResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/CommentResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateCommentResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getComment ()Lio/getstream/feeds/android/network/models/CommentResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedMembersRequest {
+	public fun <init> (Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;
+	public final fun component2 ()Ljava/lang/Integer;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun copy (Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest;Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLimit ()Ljava/lang/Integer;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getNext ()Ljava/lang/String;
+	public final fun getOperation ()Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;
+	public final fun getPrev ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation {
+	public static final field Companion Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$OperationAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Remove : io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Set : io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Set;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Unknown : io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Upsert : io/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateFeedMembersRequest$Operation$Upsert;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedMembersResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/List;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lio/getstream/feeds/android/network/models/UpdateFeedMembersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateFeedMembersResponse;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateFeedMembersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdded ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getRemovedIds ()Ljava/util/List;
+	public final fun getUpdated ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;)V
+	public synthetic fun <init> (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Boolean;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/List;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun copy (Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;)Lio/getstream/feeds/android/network/models/UpdateFeedRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateFeedRequest;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/feeds/android/network/models/Location;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateFeedRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getClearLocation ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFilterTags ()Ljava/util/List;
+	public final fun getLocation ()Lio/getstream/feeds/android/network/models/Location;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFeedResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedResponse;)Lio/getstream/feeds/android/network/models/UpdateFeedResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateFeedResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FeedResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateFeedResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFeed ()Lio/getstream/feeds/android/network/models/FeedResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFollowRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;Ljava/lang/Boolean;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;Ljava/lang/Boolean;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;
+	public final fun component9 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;Ljava/lang/Boolean;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateFollowRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateFollowRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;Ljava/lang/Boolean;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateFollowRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivityCopyLimit ()Ljava/lang/Integer;
+	public final fun getCopyCustomToNotification ()Ljava/lang/Boolean;
+	public final fun getCreateNotificationActivity ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public final fun getFollowerRole ()Ljava/lang/String;
+	public final fun getPushPreference ()Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;
+	public final fun getSkipPush ()Ljava/lang/Boolean;
+	public final fun getSource ()Ljava/lang/String;
+	public final fun getTarget ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference {
+	public static final field Companion Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$All : io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$All;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$None : io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$None;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$PushPreferenceAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$Unknown : io/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateFollowRequest$PushPreference$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateFollowResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;)Lio/getstream/feeds/android/network/models/UpdateFollowResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateFollowResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/FollowResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateFollowResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getFollow ()Lio/getstream/feeds/android/network/models/FollowResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateLiveLocationRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/Float;Ljava/lang/Float;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/Float;Ljava/lang/Float;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/Float;
+	public final fun component4 ()Ljava/lang/Float;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/Float;Ljava/lang/Float;)Lio/getstream/feeds/android/network/models/UpdateLiveLocationRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateLiveLocationRequest;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Float;Ljava/lang/Float;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateLiveLocationRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEndAt ()Ljava/util/Date;
+	public final fun getLatitude ()Ljava/lang/Float;
+	public final fun getLongitude ()Ljava/lang/Float;
+	public final fun getMessageId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdatePollOptionRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdatePollOptionRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdatePollOptionRequest;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdatePollOptionRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdatePollPartialRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdatePollPartialRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdatePollPartialRequest;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdatePollPartialRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getSet ()Ljava/util/Map;
+	public final fun getUnset ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdatePollRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/util/List;
+	public final fun component11 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/Boolean;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Boolean;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun component8 ()Ljava/lang/Integer;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdatePollRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdatePollRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Integer;Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdatePollRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowAnswers ()Ljava/lang/Boolean;
+	public final fun getAllowUserSuggestedOptions ()Ljava/lang/Boolean;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getEnforceUniqueVote ()Ljava/lang/Boolean;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMaxVotesAllowed ()Ljava/lang/Integer;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Ljava/util/List;
+	public final fun getVotingVisibility ()Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;
+	public fun hashCode ()I
+	public final fun isClosed ()Ljava/lang/Boolean;
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility {
+	public static final field Companion Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Anonymous : io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Anonymous;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Public : io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Public;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Unknown : io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility$VotingVisibilityAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/UpdatePollRequest$VotingVisibility;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateUserGroupRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UpdateUserGroupRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateUserGroupRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateUserGroupRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTeamId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateUserGroupResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;)Lio/getstream/feeds/android/network/models/UpdateUserGroupResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateUserGroupResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/UserGroupResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateUserGroupResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUserGroup ()Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateUserPartialRequest {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateUserPartialRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateUserPartialRequest;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateUserPartialRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getId ()Ljava/lang/String;
+	public final fun getSet ()Ljava/util/Map;
+	public final fun getUnset ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateUsersPartialRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/getstream/feeds/android/network/models/UpdateUsersPartialRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateUsersPartialRequest;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateUsersPartialRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUsers ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateUsersRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Map;
+	public final fun copy (Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateUsersRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateUsersRequest;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateUsersRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUsers ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpdateUsersResponse {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpdateUsersResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpdateUsersResponse;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpdateUsersResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getMembershipDeletionTaskId ()Ljava/lang/String;
+	public final fun getUsers ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpsertActivitiesRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun copy (Ljava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/UpsertActivitiesRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpsertActivitiesRequest;Ljava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpsertActivitiesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivities ()Ljava/util/List;
+	public final fun getEnrichOwnFields ()Ljava/lang/Boolean;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpsertActivitiesResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()Ljava/lang/Integer;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;)Lio/getstream/feeds/android/network/models/UpsertActivitiesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpsertActivitiesResponse;Ljava/lang/String;Ljava/util/List;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpsertActivitiesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getActivities ()Ljava/util/List;
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getMentionNotificationsCreated ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpsertConfigRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/GoogleVisionConfig;Lio/getstream/feeds/android/network/models/LLMConfig;Lio/getstream/feeds/android/network/models/RuleBuilderConfig;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/GoogleVisionConfig;Lio/getstream/feeds/android/network/models/LLMConfig;Lio/getstream/feeds/android/network/models/RuleBuilderConfig;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public final fun component11 ()Lio/getstream/feeds/android/network/models/BlockListConfig;
+	public final fun component12 ()Lio/getstream/feeds/android/network/models/AITextConfig;
+	public final fun component13 ()Lio/getstream/feeds/android/network/models/GoogleVisionConfig;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/LLMConfig;
+	public final fun component15 ()Lio/getstream/feeds/android/network/models/RuleBuilderConfig;
+	public final fun component16 ()Lio/getstream/feeds/android/network/models/VelocityFilterConfig;
+	public final fun component2 ()Ljava/lang/Boolean;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/AITextConfig;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/AIVideoConfig;
+	public final fun component7 ()Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;
+	public final fun component8 ()Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;
+	public final fun component9 ()Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;
+	public final fun copy (Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/GoogleVisionConfig;Lio/getstream/feeds/android/network/models/LLMConfig;Lio/getstream/feeds/android/network/models/RuleBuilderConfig;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;)Lio/getstream/feeds/android/network/models/UpsertConfigRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpsertConfigRequest;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/AIVideoConfig;Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;Lio/getstream/feeds/android/network/models/AIImageConfig;Lio/getstream/feeds/android/network/models/BlockListConfig;Lio/getstream/feeds/android/network/models/AITextConfig;Lio/getstream/feeds/android/network/models/GoogleVisionConfig;Lio/getstream/feeds/android/network/models/LLMConfig;Lio/getstream/feeds/android/network/models/RuleBuilderConfig;Lio/getstream/feeds/android/network/models/VelocityFilterConfig;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpsertConfigRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAiImageConfig ()Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public final fun getAiTextConfig ()Lio/getstream/feeds/android/network/models/AITextConfig;
+	public final fun getAiVideoConfig ()Lio/getstream/feeds/android/network/models/AIVideoConfig;
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getAutomodPlatformCircumventionConfig ()Lio/getstream/feeds/android/network/models/AutomodPlatformCircumventionConfig;
+	public final fun getAutomodSemanticFiltersConfig ()Lio/getstream/feeds/android/network/models/AutomodSemanticFiltersConfig;
+	public final fun getAutomodToxicityConfig ()Lio/getstream/feeds/android/network/models/AutomodToxicityConfig;
+	public final fun getAwsRekognitionConfig ()Lio/getstream/feeds/android/network/models/AIImageConfig;
+	public final fun getBlockListConfig ()Lio/getstream/feeds/android/network/models/BlockListConfig;
+	public final fun getBodyguardConfig ()Lio/getstream/feeds/android/network/models/AITextConfig;
+	public final fun getGoogleVisionConfig ()Lio/getstream/feeds/android/network/models/GoogleVisionConfig;
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getLlmConfig ()Lio/getstream/feeds/android/network/models/LLMConfig;
+	public final fun getRuleBuilderConfig ()Lio/getstream/feeds/android/network/models/RuleBuilderConfig;
+	public final fun getTeam ()Ljava/lang/String;
+	public final fun getVelocityFilterConfig ()Lio/getstream/feeds/android/network/models/VelocityFilterConfig;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpsertConfigResponse {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConfigResponse;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConfigResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ConfigResponse;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConfigResponse;)Lio/getstream/feeds/android/network/models/UpsertConfigResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpsertConfigResponse;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConfigResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpsertConfigResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfig ()Lio/getstream/feeds/android/network/models/ConfigResponse;
+	public final fun getDuration ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpsertPushPreferencesRequest {
+	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lio/getstream/feeds/android/network/models/UpsertPushPreferencesRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpsertPushPreferencesRequest;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpsertPushPreferencesRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPreferences ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UpsertPushPreferencesResponse {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UpsertPushPreferencesResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UpsertPushPreferencesResponse;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UpsertPushPreferencesResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDuration ()Ljava/lang/String;
+	public final fun getUserPreferences ()Ljava/util/Map;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/User {
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/User;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/User;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/User;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getData ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserBannedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Ljava/lang/Boolean;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/Integer;
+	public final fun component16 ()Ljava/util/Map;
+	public final fun component17 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/UserBannedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserBannedEvent;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Integer;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserBannedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelCustom ()Ljava/util/Map;
+	public final fun getChannelId ()Ljava/lang/String;
+	public final fun getChannelMemberCount ()Ljava/lang/Integer;
+	public final fun getChannelMessageCount ()Ljava/lang/Integer;
+	public final fun getChannelType ()Ljava/lang/String;
+	public final fun getCid ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getExpiration ()Ljava/util/Date;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getShadow ()Ljava/lang/Boolean;
+	public final fun getTeam ()Ljava/lang/String;
+	public final fun getTotalBans ()Ljava/lang/Integer;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserCreatedWithinParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserCreatedWithinParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxAge ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserCustomPropertyParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserCustomPropertyParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOperator ()Ljava/lang/String;
+	public final fun getPropertyKey ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserDeactivatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/UserDeactivatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserDeactivatedEvent;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserDeactivatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserGroupMember {
+	public fun <init> (ILjava/util/Date;Ljava/lang/String;ZLjava/lang/String;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Z
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (ILjava/util/Date;Ljava/lang/String;ZLjava/lang/String;)Lio/getstream/feeds/android/network/models/UserGroupMember;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserGroupMember;ILjava/util/Date;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserGroupMember;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAppPk ()I
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getGroupId ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isAdmin ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserGroupResponse {
+	public fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()Ljava/util/List;
+	public final fun copy (Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserGroupResponse;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserGroupResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Ljava/lang/String;
+	public final fun getDescription ()Ljava/lang/String;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getMembers ()Ljava/util/List;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getTeamId ()Ljava/lang/String;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserIdenticalContentCountParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;Ljava/lang/Integer;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserIdenticalContentCountParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getThreshold ()Ljava/lang/Integer;
+	public final fun getTimeWindow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserMuteResponse {
+	public fun <init> (Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/util/Date;
+	public final fun component4 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun component5 ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun copy (Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;)Lio/getstream/feeds/android/network/models/UserMuteResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserMuteResponse;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponse;Lio/getstream/feeds/android/network/models/UserResponse;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserMuteResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getExpires ()Ljava/util/Date;
+	public final fun getTarget ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserReactivatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun component6 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/UserReactivatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserReactivatedEvent;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/util/Date;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserReactivatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserRequest {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Boolean;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UserRequest;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserRequest;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getInvisible ()Ljava/lang/Boolean;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserResponse {
+	public fun <init> (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Ljava/util/Date;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/Date;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/util/Date;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UserResponse;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserResponse;ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserResponse;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvgResponseTime ()Ljava/lang/Integer;
+	public final fun getBanned ()Z
+	public final fun getBlockedUserIds ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeactivatedAt ()Ljava/util/Date;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLastActive ()Ljava/util/Date;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOnline ()Z
+	public final fun getRevokeTokensIssuedBefore ()Ljava/util/Date;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTeams ()Ljava/util/List;
+	public final fun getTeamsRole ()Ljava/util/Map;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserResponseCommonFields {
+	public fun <init> (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Ljava/util/Date;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/util/Date;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/util/Date;
+	public final fun component18 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvgResponseTime ()Ljava/lang/Integer;
+	public final fun getBanned ()Z
+	public final fun getBlockedUserIds ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeactivatedAt ()Ljava/util/Date;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLastActive ()Ljava/util/Date;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOnline ()Z
+	public final fun getRevokeTokensIssuedBefore ()Ljava/util/Date;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTeams ()Ljava/util/List;
+	public final fun getTeamsRole ()Ljava/util/Map;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserResponsePrivacyFields {
+	public fun <init> (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)V
+	public synthetic fun <init> (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component10 ()Ljava/util/Map;
+	public final fun component11 ()Ljava/lang/Integer;
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Ljava/util/Date;
+	public final fun component14 ()Ljava/lang/String;
+	public final fun component15 ()Ljava/lang/Boolean;
+	public final fun component16 ()Ljava/util/Date;
+	public final fun component17 ()Ljava/lang/String;
+	public final fun component18 ()Ljava/util/Date;
+	public final fun component19 ()Ljava/util/Map;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/util/Date;
+	public final fun component8 ()Ljava/util/List;
+	public final fun component9 ()Ljava/util/List;
+	public final fun copy (ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;)Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;ZLjava/util/Date;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Ljava/util/Date;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/lang/Integer;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;Ljava/lang/String;Ljava/util/Date;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvgResponseTime ()Ljava/lang/Integer;
+	public final fun getBanned ()Z
+	public final fun getBlockedUserIds ()Ljava/util/List;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getDeactivatedAt ()Ljava/util/Date;
+	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getId ()Ljava/lang/String;
+	public final fun getImage ()Ljava/lang/String;
+	public final fun getInvisible ()Ljava/lang/Boolean;
+	public final fun getLanguage ()Ljava/lang/String;
+	public final fun getLastActive ()Ljava/util/Date;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getOnline ()Z
+	public final fun getRevokeTokensIssuedBefore ()Ljava/util/Date;
+	public final fun getRole ()Ljava/lang/String;
+	public final fun getTeams ()Ljava/util/List;
+	public final fun getTeamsRole ()Ljava/util/Map;
+	public final fun getUpdatedAt ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserRoleParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UserRoleParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserRoleParameters;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserRoleParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getOperator ()Ljava/lang/String;
+	public final fun getRole ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserRuleParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/UserRuleParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserRuleParameters;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserRuleParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxAge ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserUnbannedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component10 ()Ljava/util/Date;
+	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component12 ()Ljava/lang/String;
+	public final fun component13 ()Ljava/util/Map;
+	public final fun component14 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component8 ()Ljava/lang/String;
+	public final fun component9 ()Ljava/lang/String;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;)Lio/getstream/feeds/android/network/models/UserUnbannedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserUnbannedEvent;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/String;Ljava/lang/String;Ljava/util/Date;Ljava/lang/Boolean;Ljava/lang/String;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponseCommonFields;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserUnbannedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelCustom ()Ljava/util/Map;
+	public final fun getChannelId ()Ljava/lang/String;
+	public final fun getChannelMemberCount ()Ljava/lang/Integer;
+	public final fun getChannelMessageCount ()Ljava/lang/Integer;
+	public final fun getChannelType ()Ljava/lang/String;
+	public final fun getCid ()Ljava/lang/String;
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCreatedBy ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getShadow ()Ljava/lang/Boolean;
+	public final fun getTeam ()Ljava/lang/String;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponseCommonFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/UserUpdatedEvent : io/getstream/feeds/android/network/models/FeedEvent, io/getstream/feeds/android/network/models/WSClientEvent, io/getstream/feeds/android/network/models/WSEvent {
+	public fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;Ljava/lang/String;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;Ljava/lang/String;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;Ljava/lang/String;Ljava/util/Date;)Lio/getstream/feeds/android/network/models/UserUpdatedEvent;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/UserUpdatedEvent;Ljava/util/Date;Ljava/util/Map;Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;Ljava/lang/String;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/UserUpdatedEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getCustom ()Ljava/util/Map;
+	public final fun getReceivedAt ()Ljava/util/Date;
+	public final fun getType ()Ljava/lang/String;
+	public final fun getUser ()Lio/getstream/feeds/android/network/models/UserResponsePrivacyFields;
+	public fun getWSClientEventType ()Ljava/lang/String;
+	public fun getWSEventType ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfig {
+	public fun <init> (ZZIZZLjava/util/List;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (ZZIZZLjava/util/List;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()I
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()Ljava/util/List;
+	public final fun component7 ()Ljava/lang/Boolean;
+	public final fun copy (ZZIZZLjava/util/List;Ljava/lang/Boolean;)Lio/getstream/feeds/android/network/models/VelocityFilterConfig;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/VelocityFilterConfig;ZZIZZLjava/util/List;Ljava/lang/Boolean;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/VelocityFilterConfig;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAdvancedFilters ()Z
+	public final fun getAsync ()Ljava/lang/Boolean;
+	public final fun getCascadingActions ()Z
+	public final fun getCidsPerUser ()I
+	public final fun getEnabled ()Z
+	public final fun getFirstMessageOnly ()Z
+	public final fun getRules ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule {
+	public fun <init> (Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;ILio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;IZIIZIZIIZLjava/lang/Integer;)V
+	public synthetic fun <init> (Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;ILio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;IZIIZIZIIZLjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;
+	public final fun component10 ()Z
+	public final fun component11 ()I
+	public final fun component12 ()I
+	public final fun component13 ()Z
+	public final fun component14 ()Ljava/lang/Integer;
+	public final fun component2 ()I
+	public final fun component3 ()Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;
+	public final fun component4 ()I
+	public final fun component5 ()Z
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun component8 ()Z
+	public final fun component9 ()I
+	public final fun copy (Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;ILio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;IZIIZIZIIZLjava/lang/Integer;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule;Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;ILio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;IZIIZIZIIZLjava/lang/Integer;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAction ()Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;
+	public final fun getBanDuration ()I
+	public final fun getCascadingAction ()Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;
+	public final fun getCascadingThreshold ()I
+	public final fun getCheckMessageContext ()Z
+	public final fun getFastSpamThreshold ()I
+	public final fun getFastSpamTtl ()I
+	public final fun getIpBan ()Z
+	public final fun getProbationPeriod ()I
+	public final fun getShadowBan ()Z
+	public final fun getSlowSpamBanDuration ()Ljava/lang/Integer;
+	public final fun getSlowSpamThreshold ()I
+	public final fun getSlowSpamTtl ()I
+	public final fun getUrlOnly ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action {
+	public static final field Companion Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$ActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Ban : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Ban;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Flag : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Remove : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Shadow : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Unknown : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$Action$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction {
+	public static final field Companion Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getValue ()Ljava/lang/String;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Ban : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Ban;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$CascadingActionAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Companion {
+	public final fun fromString (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Flag : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Flag;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Remove : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Remove;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Shadow : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction {
+	public static final field INSTANCE Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Shadow;
+}
+
+public final class io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Unknown : io/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Unknown;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Unknown;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/VelocityFilterConfigRule$CascadingAction$Unknown;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUnknownValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/VideoContentParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/VideoContentParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/VideoContentParameters;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/VideoContentParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHarmLabels ()Ljava/util/List;
+	public final fun getLabelOperator ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/VideoRuleParameters {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;)Lio/getstream/feeds/android/network/models/VideoRuleParameters;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/VideoRuleParameters;Ljava/lang/Integer;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/VideoRuleParameters;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHarmLabels ()Ljava/util/List;
+	public final fun getThreshold ()Ljava/lang/Integer;
+	public final fun getTimeWindow ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/VoteData {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/feeds/android/network/models/VoteData;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/VoteData;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/VoteData;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnswerText ()Ljava/lang/String;
+	public final fun getOptionId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/WSAuthMessage {
+	public fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;Ljava/util/List;)Lio/getstream/feeds/android/network/models/WSAuthMessage;
+	public static synthetic fun copy$default (Lio/getstream/feeds/android/network/models/WSAuthMessage;Ljava/lang/String;Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/feeds/android/network/models/WSAuthMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getProducts ()Ljava/util/List;
+	public final fun getToken ()Ljava/lang/String;
+	public final fun getUserDetails ()Lio/getstream/feeds/android/network/models/ConnectUserDetailsRequest;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/network/models/WSClientEvent {
+	public abstract fun getWSClientEventType ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/feeds/android/network/models/WSEvent {
+	public abstract fun getWSEventType ()Ljava/lang/String;
+}
+
+public final class io/getstream/feeds/android/network/models/WSEventAdapter : com/squareup/moshi/JsonAdapter {
+	public fun <init> ()V
+	public fun fromJson (Lcom/squareup/moshi/JsonReader;)Lio/getstream/feeds/android/network/models/WSEvent;
+	public synthetic fun fromJson (Lcom/squareup/moshi/JsonReader;)Ljava/lang/Object;
+	public fun toJson (Lcom/squareup/moshi/JsonWriter;Lio/getstream/feeds/android/network/models/WSEvent;)V
+	public synthetic fun toJson (Lcom/squareup/moshi/JsonWriter;Ljava/lang/Object;)V
+}
+


### PR DESCRIPTION
### Goal

[AND-802](https://linear.app/stream/issue/AND-802/make-sure-all-public-code-has-kdoc)

Introduce the Kotlin binary-compatibility-validator. Also fill in the KDoc that was missing on the currently exposed public APIs.

### Implementation

- Apply the `org.jetbrains.kotlinx.binary-compatibility-validator` plugin.
- Drop the `api-check: false` override from `.github/workflows/android.yml` so the shared `android-ci` workflow runs the check.
- Add missing KDoc to public types and members under `client/api`.

### Testing

- `./gradlew apiCheck` passes locally.
- CI runs the api check via the shared workflow.

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced API documentation with detailed KDoc comments across file upload, activity request handling, moderation configuration settings, and poll voting functionality.

* **Chores**
  * Configured binary compatibility validation in the build system to ensure API stability and prevent unintended breaking changes in future releases.
  * Updated Android CI workflow configuration and build system settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-feeds-android/pull/202?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->