### PR TITLE
CI: add least-privilege permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,8 +21,6 @@ jobs:
       contents: read
       pull-requests: read
     uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
-      contents: read
-      pull-requests: read
     secrets:
       BUILD_CACHE_AWS_REGION: ${{ secrets.BUILD_CACHE_AWS_REGION }}
       BUILD_CACHE_AWS_BUCKET: ${{ secrets.BUILD_CACHE_AWS_BUCKET }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,6 +16,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   android-ci:
     uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.13.1

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
 jobs:
   android-ci:
     permissions:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,12 +15,15 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
-  pull-requests: read
-
 jobs:
   android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@v0.13.1
-    secrets: inherit
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
+    permissions:
+      contents: read
+      pull-requests: read
+    secrets:
+      BUILD_CACHE_AWS_REGION: ${{ secrets.BUILD_CACHE_AWS_REGION }}
+      BUILD_CACHE_AWS_BUCKET: ${{ secrets.BUILD_CACHE_AWS_BUCKET }}
+      BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+      BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -17,8 +17,10 @@ concurrency:
   cancel-in-progress: true
 jobs:
   android-ci:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
     permissions:
+      contents: read
+      pull-requests: read
+    uses: GetStream/stream-build-conventions-android/.github/workflows/android-ci.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
       contents: read
       pull-requests: read
     secrets:

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -16,15 +16,13 @@ on:
 concurrency:
   group: release
   cancel-in-progress: false
-
-permissions:
-  contents: read
-
 jobs:
   pre_release_check:
     name: Pre release check
     runs-on: ubuntu-24.04
     environment: 'publish'
+    permissions:
+      contents: read
     steps:
       - name: Check
         id: pre_release_check_step
@@ -33,7 +31,7 @@ jobs:
     permissions:
       contents: write
     needs: pre_release_check
-    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@v0.13.1
+    uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
     with:
       bump: ${{ inputs.bump }}
     secrets:

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -18,10 +18,11 @@ concurrency:
   cancel-in-progress: false
 jobs:
   pre_release_check:
+    permissions:
+      contents: read
     name: Pre release check
     runs-on: ubuntu-24.04
     environment: 'publish'
-    permissions:
       contents: read
     steps:
       - name: Check
@@ -29,6 +30,7 @@ jobs:
         run: echo "Pre release check"
   publish:
     permissions:
+      contents: read
       contents: write
     needs: pre_release_check
     uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -17,6 +17,9 @@ concurrency:
   group: release
   cancel-in-progress: false
 
+permissions:
+  contents: read
+
 jobs:
   pre_release_check:
     name: Pre release check

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -23,7 +23,6 @@ jobs:
     name: Pre release check
     runs-on: ubuntu-24.04
     environment: 'publish'
-      contents: read
     steps:
       - name: Check
         id: pre_release_check_step

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -29,7 +29,6 @@ jobs:
         run: echo "Pre release check"
   publish:
     permissions:
-      contents: read
       contents: write
     needs: pre_release_check
     uses: GetStream/stream-build-conventions-android/.github/workflows/release.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73

--- a/.github/workflows/publish-new-version.yml
+++ b/.github/workflows/publish-new-version.yml
@@ -16,6 +16,7 @@ on:
 concurrency:
   group: release
   cancel-in-progress: false
+
 jobs:
   pre_release_check:
     permissions:

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -10,6 +10,7 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
+
 jobs:
   update-sdk-sizes:
     permissions:

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   update-sdk-sizes:
     uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.13.1

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -15,7 +15,6 @@ jobs:
     permissions:
       contents: read
     uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
-      contents: read
     with:
       modules: "stream-feeds-android-client"
       metrics-project: "stream-feeds-android-metrics"

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -10,13 +10,11 @@ on:
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
-
-permissions:
-  contents: read
-
 jobs:
   update-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@v0.13.1
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
+    permissions:
+      contents: read
     with:
       modules: "stream-feeds-android-client"
       metrics-project: "stream-feeds-android-metrics"

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -12,8 +12,9 @@ concurrency:
   cancel-in-progress: true
 jobs:
   update-sdk-sizes:
-    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
     permissions:
+      contents: read
+    uses: GetStream/stream-build-conventions-android/.github/workflows/sdk-size-updates.yml@8c5fbade4ee9c06a0a979bcb0866e64669254f73
       contents: read
     with:
       modules: "stream-feeds-android-client"


### PR DESCRIPTION
### Goal
Add least-privilege `permissions` blocks to GitHub Actions workflows to resolve CodeQL `actions/missing-workflow-permissions` alerts (APPSEC-164).

### Implementation
- Add explicit workflow-level `permissions` blocks across GitHub Actions workflows.
- Default to read-only scopes (`contents: read`, `pull-requests: read`).
- Grant write scopes only where jobs need them (artifacts, Danger, release git push).

### Testing
- [ ] CI green on this PR
- [ ] Code scanning alerts close after merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android, release, and SDK size update automation to use pinned workflow versions for more reliable builds.
  * Added clearer job-level access permissions across CI and publishing steps, improving security and reducing unnecessary access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->