### PR TITLE
Unblock Dependabot bumps of the Stream conventions plugins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,6 @@ updates:
       - dependency-name: "io.getstream.android.test"
       - dependency-name: "io.getstream.java.library"
       - dependency-name: "io.getstream.java.platform"
-      - dependency-name: "io.getstream.publish"
     groups:
       stream-conventions:
         patterns:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -103,4 +103,3 @@ binary-compatibility-validator = { id = "org.jetbrains.kotlinx.binary-compatibil
 stream-project = { id = "io.getstream.project", version.ref = "streamConventions" }
 stream-android-library = { id = "io.getstream.android.library", version.ref = "streamConventions" }
 stream-android-application = { id = "io.getstream.android.application", version.ref = "streamConventions" }
-stream-publish = { id = "io.getstream.publish", version.ref = "streamConventions" }


### PR DESCRIPTION
<!-- label: pr:ci -->

### Goal

[AND-1362](https://linear.app/stream/issue/AND-1362/broaden-conventions-sonarcoverageexclusions-to-a-full-sonarexclusions)

Let Dependabot bump `streamConventions` on its own. There is no `io.getstream.publish` convention plugin, so its marker artifact 404s everywhere. All four `stream-*` plugins share the `streamConventions` version ref, and Dependabot only proposes a bump when every member of the group resolves the target version, so this one unused entry blocked the whole group. That is why every bump so far has been applied by hand.

### Implementation

- Drop the unused `stream-publish` entry from `gradle/libs.versions.toml`.
- Drop `io.getstream.publish` from the gradle `allow` list in `.github/dependabot.yml`.

### Testing

- Yaml validation via the PR-quality workflow.
- The next gradle Dependabot run should propose 0.14.0 as a grouped PR.

### Checklist
- [ ] Issue linked (if any)
- [ ] Tests/docs updated
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required for external contributors)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused publishing plugin from the project’s dependency and update configuration.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->